### PR TITLE
[WIP] feat: progressive lazy loading using lozad

### DIFF
--- a/packages/vue/src/components/atoms/SfImage/SfImage.stories.js
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.stories.js
@@ -6,7 +6,7 @@ import {
   number,
   object,
 } from "@storybook/addon-knobs";
-import { SfImage } from "@storefront-ui/vue";
+import { SfImage, SfArrow } from "@storefront-ui/vue";
 storiesOf("Atoms|Image", module)
   .addDecorator(withKnobs)
   .add("Common", () => ({
@@ -63,11 +63,77 @@ storiesOf("Atoms|Image", module)
     },
     template: `<SfImage
         :src="src"
+        :srcset="srcset"
         :alt="alt"
         :lazy="lazy"
         :rootMargin="rootMargin"
         :threshold="threshold"
       />`,
+  }))
+  .add("With progressive loading", () => ({
+    components: { SfImage, SfArrow },
+    props: {
+      srcset: {
+        default: object(
+          "srcset",
+          [
+            {
+              src: `/assets/storybook/SfImage/product-109x164.webp`,
+              media: `(max-width: 480px)`,
+              type: `image/webp`,
+            },
+            {
+              src: `/assets/storybook/SfImage/product-109x164.webp`,
+              media: `(min-width: 480px) and (max-width: 720px)`,
+              type: `image/webp`,
+            },
+            {
+              src: `/assets/storybook/SfImage/product-216x326.jpg`,
+              media: `(min-width: 1240px)`,
+              type: `image/jpg`,
+            },
+          ],
+          "Props"
+        ),
+      },
+      src: {
+        default: text(
+          "src",
+          "/assets/storybook/SfImage/placeholder.png",
+          "Props"
+        ),
+      },
+      alt: {
+        default: text("alt", "Vila stripe maxi shirt dress", "Props"),
+      },
+      width: {
+        default: number("width", 216, {}, "Props"),
+      },
+      height: {
+        default: number("height", 326, {}, "Props"),
+      },
+      lazy: {
+        default: boolean("lazy", true, "Props"),
+      },
+      rootMargin: {
+        default: text("rootMargin", "0px", "Props"),
+      },
+      threshold: {
+        default: number("threshold", 0.5, {}, "Props"),
+      },
+    },
+    template: `
+    <div>
+      <SfArrow class="sf-arrow--down" style="margin: 20vh auto 100vh auto"/>
+      <SfImage
+          :src="src"
+          :srcset="srcset"
+          :alt="alt"
+          :lazy="lazy"
+          :rootMargin="rootMargin"
+          :threshold="threshold"
+        />
+    </div>`,
   }))
   .add("Without width and height", () => ({
     components: { SfImage },

--- a/packages/vue/src/components/atoms/SfImage/SfImage.vue
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.vue
@@ -104,7 +104,7 @@ export default {
       if (this.isLazyAndNotLoaded) {
         return {
           srcset: [{ media: null, src: null, type: null }],
-          src: "",
+          src: this.src,
         };
       }
       // TODO: To be removed if src as an object will not be available anymore


### PR DESCRIPTION
# Related issue
Closes #1417 

# Scope of work
Fix in SfImage code to make possible progressive loading. Added story to show how can it be used. 

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/32042425/95392452-12c96700-08f9-11eb-8286-770df9258fa4.png)

![image](https://user-images.githubusercontent.com/32042425/95392458-16f58480-08f9-11eb-9ef7-9c5e4c3c319c.png)


# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
