### PR TITLE
fix: add number prop type to badgeLabel in sficon, update docs

### DIFF
--- a/packages/vue/docs/releases/v0.9.3.md
+++ b/packages/vue/docs/releases/v0.9.3.md
@@ -1,0 +1,9 @@
+# Latest version - v0.9.2 🎉
+
+## What is new?
+
+:point_right:
+
+## Fixes
+
+- SfIcon: add number type as acceptable to badgeLabel prop,

--- a/packages/vue/src/components/atoms/SfIcon/SfIcon.vue
+++ b/packages/vue/src/components/atoms/SfIcon/SfIcon.vue
@@ -99,7 +99,7 @@ export default {
       default: false,
     },
     badgeLabel: {
-      type: String,
+      type: [String, Number],
       default: "",
     },
     /**


### PR DESCRIPTION
# Related issue
Closes #1520 

# Scope of work
Add number type to badgeLabel prop in sfIcon to avoid bugs when passing number to the icon in SfHeader.
Add docs for the 0.9.3 version with this change described. 

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
