### PR TITLE
Center SfCarousel content to fix #1548

### DIFF
--- a/packages/shared/styles/components/organisms/SfCarousel.scss
+++ b/packages/shared/styles/components/organisms/SfCarousel.scss
@@ -28,6 +28,10 @@
     &__slide {
       overflow: unset;
     }
+    &__slide {
+      display: flex;
+      justify-content: center;
+    }
     &__slides {
       margin: 0;
     }


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1548

# Scope of work
<!-- describe what you did -->
Made SfCarouselItem a flex container with items centered along x-axis

# Screenshots of visual changes
<!-- if visual changes applied -->
Before: 
![before](https://user-images.githubusercontent.com/39009379/100422147-03a99e80-308a-11eb-8a11-5185ae5d93f9.jpg)

After:
![after](https://user-images.githubusercontent.com/39009379/100422159-0906e900-308a-11eb-99af-dcbd8ab02718.jpg)

It also does not break the behavior when more than 4 items:
![sure](https://user-images.githubusercontent.com/39009379/100422718-1d97b100-308b-11eb-94ae-7210dfba15fb.jpg)

# Checklist

- [x] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
