### PR TITLE
fix: img adjusted to mobile view

### DIFF
--- a/packages/shared/styles/components/organisms/SfProductCard.scss
+++ b/packages/shared/styles/components/organisms/SfProductCard.scss
@@ -64,6 +64,10 @@
       left: 0;
       opacity: var(--product-card-image-even-opacity, 0);
     }
+    .sf-image {
+      --image-width: 100%;
+      --image-height: auto;
+    }
   }
   &__badge {
     position: absolute;


### PR DESCRIPTION
# Related issue
Closes #1598 

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
after:
![Screenshot from 2021-01-11 10-14-26](https://user-images.githubusercontent.com/46591755/104163112-23a4df80-53f6-11eb-82b4-d5ed40d15e75.png)
before:
![Screenshot from 2021-01-11 10-15-47](https://user-images.githubusercontent.com/46591755/104163119-28699380-53f6-11eb-9209-a462960d0d23.png)



# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
