### PR TITLE
hotfix: SfSelect - selectedValue is not defined 

### DIFF
--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.stories.js
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.stories.js
@@ -106,6 +106,7 @@ const Template = (args, { argTypes }) => ({
   data() {
     return {
       options,
+      selectedValue: "",
     };
   },
   template: `
@@ -174,6 +175,7 @@ export const UseLabelSlot = (args, { argTypes }) => ({
   data() {
     return {
       options,
+      selectedValue: "",
     };
   },
   template: `


### PR DESCRIPTION
# Related issue
Closes #1613 

# Scope of work
selectedValue added to data

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
