### PR TITLE
hotfix: SfHero - left arrow below an image

### DIFF
--- a/packages/vue/src/components/organisms/SfHero/SfHero.vue
+++ b/packages/vue/src/components/organisms/SfHero/SfHero.vue
@@ -8,7 +8,7 @@
         </ul>
       </div>
     </div>
-    <div v-if="numberOfPages > 1 && client" class="sf-hero__controls">
+    <div v-if="numberOfPages > 1 && client" class="sf-hero__control--left">
       <!--@slot slot for icon moving to the previous item -->
       <slot name="prev" v-bind="{ go: () => go('prev') }">
         <SfButton class="sf-button--pure" @click.stop="go('prev')">


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1622 

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
![Screenshot from 2021-01-15 13-28-33](https://user-images.githubusercontent.com/46591755/104727678-0b0a3180-5736-11eb-94cf-b762cce1fdc2.png)


# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
