### PR TITLE
hotfix: SfPrice - lack of price in examples

### DIFF
--- a/packages/vue/src/components/atoms/SfPrice/SfPrice.stories.js
+++ b/packages/vue/src/components/atoms/SfPrice/SfPrice.stories.js
@@ -48,7 +48,7 @@ export const WithSpecialSlot = (args, { argTypes }) => ({
   <SfPrice
     :regular="regular"
     :special="special">
-    <template #special="{special}">
+    <template #special="{props}">
       <SfBadge class="color-warning">{{special}}</SfBadge>
     </template>  
   </SfPrice>`,
@@ -64,9 +64,9 @@ export const WithOldSlot = (args, { argTypes }) => ({
   <SfPrice
     :regular="regular"
     :special="special">
-    <template #special="{special}">
-      <SfBadge class="color-warning">{{special}}</SfBadge>
-    </template>  
+    <template #old="{props}">
+      <SfBadge class="color-warning">{{regular}}</SfBadge>
+    </template>
   </SfPrice>`,
 });
 WithOldSlot.args = {
@@ -80,7 +80,7 @@ export const WithRegularSlot = (args, { argTypes }) => ({
   <SfPrice
     :regular="regular"
     :special="special">
-    <template #regular="{regular, special}">
+    <template #regular="{props}">
       <SfBadge>{{regular}}</SfBadge>
     </template>
   </SfPrice>`,


### PR DESCRIPTION
# Related issue
Closes #1626 

# Scope of work

# Screenshots of visual changes
<!-- if visual changes applied -->

![Screenshot from 2021-01-18 11-28-07](https://user-images.githubusercontent.com/46591755/104904444-73008800-5981-11eb-891f-2de34dc20dec.png)
![Screenshot from 2021-01-18 11-28-12](https://user-images.githubusercontent.com/46591755/104904446-73991e80-5981-11eb-891a-43a34c78cd3a.png)
![Screenshot from 2021-01-18 11-28-18](https://user-images.githubusercontent.com/46591755/104904447-7431b500-5981-11eb-954e-6da8aa337cd1.png)


# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
