### PR TITLE
hotfix: SfProperty - missing data in slots examples

### DIFF
--- a/packages/vue/src/components/atoms/SfProperty/SfProperty.stories.js
+++ b/packages/vue/src/components/atoms/SfProperty/SfProperty.stories.js
@@ -78,7 +78,7 @@ export const WithNameSlot = (args, { argTypes }) => ({
     :class="classes"
     :name="name"
     :value="value">
-    <template #name="{name}">
+    <template #name="{props}">
       {{name}}:<br>
     </template>
   </SfProperty>`,
@@ -95,7 +95,7 @@ export const WithValueSlot = (args, { argTypes }) => ({
     :class="classes"
     :name="name"
     :value="value">
-    <template #value="{value}">
+    <template #value="{props}">
       <SfBadge>{{value}}</SfBadge>
     </template>
   </SfProperty>`,


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1628 

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->
![Screenshot from 2021-01-18 11-53-27](https://user-images.githubusercontent.com/46591755/104906836-83663200-5984-11eb-935d-c7d83f0641d6.png)
![Screenshot from 2021-01-18 11-53-32](https://user-images.githubusercontent.com/46591755/104906844-83fec880-5984-11eb-9ff4-a06d84112013.png)


# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
