### PR TITLE
hotfix: SfFilter - wrong example in "use count slot"

### DIFF
--- a/packages/vue/src/components/molecules/SfFilter/SfFilter.stories.js
+++ b/packages/vue/src/components/molecules/SfFilter/SfFilter.stories.js
@@ -95,7 +95,7 @@ export const UseCountSlot = (args, { argTypes }) => ({
     @change="selected = !selected"
     style="max-width: 22.875rem"
   >
-  <template #label="{label}">CUSTOM LABEL</template>
+  <template #count="{count}">CUSTOM COUNT</template>
   </SfFilter>`,
 });
 UseCountSlot.args = { ...Common.args };


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1632 

# Scope of work
Story for count slot in SfFilter 


# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
