### PR TITLE
hotfix: SfGallery - invalid prop type

### DIFF
--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.stories.js
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.stories.js
@@ -42,6 +42,12 @@ export default {
     },
     sliderOptions: {
       control: "object",
+      defaultValue: {
+        type: "slider",
+        autoplay: false,
+        rewind: false,
+        gap: 0,
+      },
       table: {
         category: "Props",
       },


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1637 

# Scope of work
Default value for slider options.

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
