### PR TITLE
fix: SfStoreLocator storybook - change control options to object

### DIFF
--- a/packages/vue/src/components/organisms/SfStoreLocator/SfStoreLocator.stories.js
+++ b/packages/vue/src/components/organisms/SfStoreLocator/SfStoreLocator.stories.js
@@ -12,21 +12,11 @@ export default {
     tileServerUrl: {
       control: {
         type: "select",
-        options: [
-          {
-            name: "default",
-            value:
-              "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}",
-          },
-          {
-            name: "openstreetmap",
-            value: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-          },
-          {
-            name: "wikimedia",
-            value: "https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}{r}.png",
-          },
-        ],
+        options: {
+          default:
+            "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}",
+          openstreetmap: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        },
       },
       table: {
         category: "Props",


### PR DESCRIPTION
# Related issue
Closes #1631 

# Scope of work
Control options changed to object in SfStoreLocator tileServerUrl prop .

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/32042425/104928782-5b39fb80-59a3-11eb-8249-b8535ea496ad.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
