### PR TITLE
fix: SfSidebar change rendering of docs to iframe on storybook

### DIFF
--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.stories.js
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.stories.js
@@ -58,6 +58,11 @@ export default {
     },
     close: { action: "Close sidebar clicked", table: { category: "Events" } },
   },
+  parameters: {
+    docs: {
+      inlineStories: false,
+    },
+  },
 };
 
 const Template = (args, { argTypes }) => ({


### PR DESCRIPTION
# Related issue
Closes #1634 

# Scope of work
Change the way of rendering docs to iframe instead of inline. Need to be styled, because iframe is too small to see whole component and shows only mobile mode. 


# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/32042425/105009146-70159e00-5a3a-11eb-8465-fe3d9aa901f8.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
