### PR TITLE
fix: listeners in functional components 

### DIFF
--- a/packages/vue/src/components/atoms/SfArrow/SfArrow.vue
+++ b/packages/vue/src/components/atoms/SfArrow/SfArrow.vue
@@ -16,7 +16,6 @@
         aria-hidden="true"
         v-bind="data.attrs"
         :class="[data.class, data.staticClass, 'sf-arrow__icon']"
-        v-on="listeners"
       />
     </slot>
   </component>

--- a/packages/vue/src/components/atoms/SfCircleIcon/SfCircleIcon.vue
+++ b/packages/vue/src/components/atoms/SfCircleIcon/SfCircleIcon.vue
@@ -18,7 +18,6 @@
         :size="props.iconSize"
         :badge-label="props.badgeLabel"
         :has-badge="props.hasBadge"
-        v-on="listeners"
       />
     </slot>
   </component>

--- a/packages/vue/src/components/atoms/SfOverlay/SfOverlay.vue
+++ b/packages/vue/src/components/atoms/SfOverlay/SfOverlay.vue
@@ -4,7 +4,7 @@
       v-if="props.visible"
       ref="overlay"
       :class="[data.class, data.staticClass, 'sf-overlay']"
-      @click="listeners.click || (() => {})"
+      @click="listeners.click"
     ></div>
   </transition>
 </template>

--- a/packages/vue/src/components/atoms/SfOverlay/SfOverlay.vue
+++ b/packages/vue/src/components/atoms/SfOverlay/SfOverlay.vue
@@ -4,7 +4,7 @@
       v-if="props.visible"
       ref="overlay"
       :class="[data.class, data.staticClass, 'sf-overlay']"
-      @click="listeners.click"
+      @click="listeners.click || (() => {})"
     ></div>
   </transition>
 </template>


### PR DESCRIPTION
# Related issue
Closes #1647 

# Scope of work
Additional listeners removed from SfCircleIcon and SfArrow.
Fix listener in SfOverlay to properly emit click event.


# Screenshots of visual changes

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
