### PR TITLE
fix: textarea component changed back from functional to normal

### DIFF
--- a/packages/vue/src/components/atoms/SfTexarea/SfTextarea.vue
+++ b/packages/vue/src/components/atoms/SfTexarea/SfTextarea.vue
@@ -1,41 +1,36 @@
-<template functional>
+<template>
   <div
-    :class="[
-      data.class,
-      data.staticClass,
-      'sf-textarea',
-      {
-        'sf-textarea--has-text': !!props.value,
-        'sf-textarea--invalid': !props.valid,
-      },
-    ]"
+    class="sf-textarea"
+    :class="{
+      'sf-textarea--has-text': !!value,
+      'sf-textarea--invalid': !valid,
+    }"
   >
     <textarea
-      :id="props.name"
-      :value="props.value"
-      :name="props.name"
-      :placeholder="props.placeholder"
-      :cols="props.cols"
-      :rows="props.rows"
-      :wrap="props.wrap"
-      :disabled="props.disabled"
-      :required="props.required"
-      :maxlength="props.maxlength"
-      :minlength="props.minlength"
-      @input="listeners.input && listeners.input($event.target.value)"
+      :id="name"
+      v-focus
+      :value="value"
+      :name="name"
+      :placeholder="placeholder"
+      :cols="cols"
+      :rows="rows"
+      :wrap="wrap"
+      :disabled="disabled"
+      :required="required"
+      :maxlength="maxlength"
+      :minlength="minlength"
+      v-on="listeners"
     />
-    <label class="sf-textarea__label" :for="props.name">
+    <label class="sf-textarea__label" :for="name">
       <!-- @slot Custom input label -->
-      <slot name="label" v-bind="{ props }">{{ props.label }}</slot>
+      <slot name="label" v-bind="{ label }">{{ label }}</slot>
     </label>
-    <div v-if="!props.valid" class="sf-textarea__error-message">
+    <div class="sf-textarea__error-message">
       <transition name="sf-fade">
         <!-- @slot Custom error message -->
-        <slot name="error-message" v-bind="{ props }">
-          <div>
-            {{ props.errorMessage }}
-          </div>
-        </slot>
+        <slot v-if="!valid" name="error-message" v-bind="{ errorMessage }">
+          <div>{{ errorMessage }}</div></slot
+        >
       </transition>
     </div>
   </div>
@@ -153,6 +148,14 @@ export default {
       type: Boolean,
       default: false,
       description: "Native input disabled attribute",
+    },
+  },
+  computed: {
+    listeners() {
+      return {
+        ...this.$listeners,
+        input: (event) => this.$emit("input", event.target.value),
+      };
     },
   },
 };


### PR DESCRIPTION
# Related issue
Closes #1619 

# Scope of work
I removed changes from the previous version and SfTextarea is now normal component, not functional.

# Screenshots of visual changes

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
