### PR TITLE
chore: add 0.10.1 release docs

### DIFF
--- a/packages/vue/src/stories/getting-started/pull-off-components.md
+++ b/packages/vue/src/stories/getting-started/pull-off-components.md
@@ -11,15 +11,9 @@ With just one command you can have all components and their styles, so that no n
 
 ## Required
 
-<<<<<<< HEAD:packages/vue/src/stories/getting-started/pull-off-components.md
-* Storefront UI added as a dependency to your project.
-
-* `fse` package added to your project with `npm install fse -D` or `yarn add fse -D` .
-=======
 - Storefront UI added as a dependency to your project.
 
 - `fse` package added to your project with `npm install fse -D` or `yarn add fse -D` .
->>>>>>> release/0.10.0:packages/vue/src/stories/getting-started/3. pulloff.stories.mdx
 
 ## How to copy components
 

--- a/packages/vue/src/stories/releases/v0.10.0/migration.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.0/migration.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Releases/v0.10.0 - Latest/Migration Guide" />
+<Meta title="Releases/v0.10.0/Migration Guide" />
 
 <style>{`
   .table {

--- a/packages/vue/src/stories/releases/v0.10.0/v0.10.0.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.0/v0.10.0.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Releases/v0.10.0 - Latest/Change log" />
+<Meta title="Releases/v0.10.0/Change log" />
 
 # v0.10.0
 

--- a/packages/vue/src/stories/releases/v0.10.1/v0.10.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.1/v0.10.1.stories.mdx
@@ -1,0 +1,30 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.10.1 - Latest/Change log" />
+
+# v0.10.1
+
+
+## 🐛 Fixes
+
+- SfHero: left arrow below image
+- SfHero: buttons not clickable fix
+- SfTextarea: change component from functional to standard to fix listeners bug 
+- SfCarousel: design broken 
+- SfArrow, AfCircleIcon: remove doubled listeners
+- SfImage: no image on Storybook
+- SfGallery: wrong prop type on storybook
+- SfStoreLocator: fix server select option prop on Storybook
+- SfProperty: missing data in slot examples on Storybook 
+- SfSelect: selectedValue not defined in Storybook
+- SfDivider: lack of story on Storybook
+- Category example: missing title
+
+
+## 🧹 Chores:
+
+- fix conflicts
+- fix changelog script
+- fix static assets for docs
+- fix logo build 
+- fix docs build

--- a/packages/vue/src/stories/releases/v0.10.1/v0.10.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.1/v0.10.1.stories.mdx
@@ -11,7 +11,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfHero: buttons not clickable fix
 - SfTextarea: change component from functional to standard to fix listeners bug 
 - SfCarousel: design broken 
-- SfArrow, AfCircleIcon: remove doubled listeners
+- SfArrow, SfCircleIcon: remove doubled listeners
 - SfImage: no image on Storybook
 - SfGallery: wrong prop type on storybook
 - SfStoreLocator: fix server select option prop on Storybook


### PR DESCRIPTION
# Related issue
no

# Scope of work
Add docs for 0.10.1 release.

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
