### PR TITLE
fix: sfheader mobile navigation

### DIFF
--- a/packages/shared/styles/components/organisms/SfHeader.scss
+++ b/packages/shared/styles/components/organisms/SfHeader.scss
@@ -90,7 +90,8 @@
   }
   
 }
-.sf-header-navigation {
+.sf-header__navigation {
+  display: none;
   &__menu {
     display: var(--header-navigation-menu-display, none);
     @include for-desktop {
@@ -151,18 +152,21 @@
     }
   }
   &__navigation {
-    order: 1;
-    display: var(--header-navigation-display, none);
+    order: 1;    
     flex: 0 0 calc(100% + var(--spacer-sm) * 2);
     margin: var(--header-navigation-margin, 0 calc(var(--spacer-sm) * -1));
     @include for-desktop {
-      --header-navigation-display: flex;
+      display: var(--header-navigation-display, flex);
       --header-navigation-margin: 0 auto 0 var(--spacer-xl);
       order: 0;
       flex: 0 0 auto;
     }
     &.is-visible {
-      --header-navigation-display: flex;
+      display: flex;
+      --link-text-decoration: none;
+      @include for-mobile {
+        flex-direction: column;      
+      }
     }
   }
   &__search {
@@ -221,7 +225,10 @@
     }
   }
   &--has-mobile-navigation {
-    --header-navigation-display: flex;
+    .sf-header__navigation {
+      display: flex;  
+      flex-direction: column;
+    }       
   }
   &--multiline {
     @include for-desktop{

--- a/packages/shared/styles/components/organisms/SfHeader.scss
+++ b/packages/shared/styles/components/organisms/SfHeader.scss
@@ -156,7 +156,7 @@
     flex: 0 0 calc(100% + var(--spacer-sm) * 2);
     margin: var(--header-navigation-margin, 0 calc(var(--spacer-sm) * -1));
     @include for-desktop {
-      display: var(--header-navigation-display, flex);
+      display: flex;
       --header-navigation-margin: 0 auto 0 var(--spacer-xl);
       order: 0;
       flex: 0 0 auto;
@@ -225,10 +225,12 @@
     }
   }
   &--has-mobile-navigation {
-    .sf-header__navigation {
-      display: flex;  
-      flex-direction: column;
-    }       
+    @include for-mobile{
+      .sf-header__navigation {
+        display: flex;  
+        flex-direction: column;
+      }   
+    }    
   }
   &--multiline {
     @include for-desktop{

--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.vue
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.vue
@@ -20,7 +20,7 @@
     @keyup.down="move(1)"
     @keyup.enter="enter($event)"
   >
-    <div style="position: relative;">
+    <div style="position: relative">
       <div
         ref="sfComponentSelect"
         v-focus

--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.vue
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.vue
@@ -20,7 +20,7 @@
     @keyup.down="move(1)"
     @keyup.enter="enter($event)"
   >
-    <div style="position: relative">
+    <div style="position: relative;">
       <div
         ref="sfComponentSelect"
         v-focus

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
@@ -134,9 +134,7 @@ const Template = (args, { argTypes }) => ({
     :cart-items-qty="cartItemsQty"
     :wishlist-items-qty="wishlistItemsQty"
     @click:cart="this['click:cart']"
-    @click:wishlist="this[
-      
-      </SfHeaderNavigationItem>'click:wishlist']"
+    @click:wishlist="this['click:wishlist']"
     @click:account="this['click:account']"
     @change:search="searchValues = $event"
 >

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
@@ -1,4 +1,4 @@
-import { SfHeader, SfLink } from "@storefront-ui/vue";
+import { SfHeader, SfLink, SfMenuItem } from "@storefront-ui/vue";
 
 export default {
   title: "Components/Organisms/Header",
@@ -110,7 +110,7 @@ export default {
 };
 
 const Template = (args, { argTypes }) => ({
-  components: { SfHeader, SfLink },
+  components: { SfHeader, SfLink, SfMenuItem },
   props: Object.keys(argTypes),
   data() {
     return {
@@ -129,6 +129,7 @@ const Template = (args, { argTypes }) => ({
     :cart-icon="cartIcon"
     :wishlist-icon="wishlistIcon"
     :is-sticky="isSticky"
+    :is-nav-visible="isNavVisible"
     :account-icon="accountIcon"
     :cart-items-qty="cartItemsQty"
     :wishlist-items-qty="wishlistItemsQty"
@@ -143,6 +144,10 @@ const Template = (args, { argTypes }) => ({
       :key="item">
       <template slot="desktop-navigation-item">
         <SfLink href="#">{{item}}</SfLink>
+      </template>
+      <template slot="mobile-navigation-item">
+        <SfMenuItem :label="item" class="sf-header-navigation-item__menu-item">
+        </SfMenuItem>
       </template>
     </SfHeaderNavigationItem>
   </template>

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
@@ -1,4 +1,4 @@
-import { SfHeader, SfLink, SfMenuItem } from "@storefront-ui/vue";
+import { SfHeader, SfLink } from "@storefront-ui/vue";
 
 export default {
   title: "Components/Organisms/Header",
@@ -110,7 +110,7 @@ export default {
 };
 
 const Template = (args, { argTypes }) => ({
-  components: { SfHeader, SfLink, SfMenuItem },
+  components: { SfHeader, SfLink },
   props: Object.keys(argTypes),
   data() {
     return {
@@ -146,8 +146,9 @@ const Template = (args, { argTypes }) => ({
         <SfLink href="#">{{item}}</SfLink>
       </template>
       <template slot="mobile-navigation-item">
-        <SfMenuItem :label="item" class="sf-header-navigation-item__menu-item">
-        </SfMenuItem>
+        <SfLink href="#" class="sf-header-navigation-item__menu-item">
+          {{item}}
+        </SfLink>
       </template>
     </SfHeaderNavigationItem>
   </template>

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.stories.js
@@ -134,23 +134,18 @@ const Template = (args, { argTypes }) => ({
     :cart-items-qty="cartItemsQty"
     :wishlist-items-qty="wishlistItemsQty"
     @click:cart="this['click:cart']"
-    @click:wishlist="this['click:wishlist']"
+    @click:wishlist="this[
+      
+      </SfHeaderNavigationItem>'click:wishlist']"
     @click:account="this['click:account']"
     @change:search="searchValues = $event"
 >
   <template #navigation>
     <SfHeaderNavigationItem
       v-for="item in navigationItems"
-      :key="item">
-      <template slot="desktop-navigation-item">
-        <SfLink href="#">{{item}}</SfLink>
-      </template>
-      <template slot="mobile-navigation-item">
-        <SfLink href="#" class="sf-header-navigation-item__menu-item">
-          {{item}}
-        </SfLink>
-      </template>
-    </SfHeaderNavigationItem>
+      :key="item"
+      :label="item"
+    />
   </template>
 </SfHeader>`,
 });

--- a/packages/vue/src/stories/releases/v0.10.1/v0.10.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.1/v0.10.1.stories.mdx
@@ -12,6 +12,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfTextarea: change component from functional to standard to fix listeners bug 
 - SfCarousel: design broken 
 - SfArrow, SfCircleIcon: remove doubled listeners
+- SfHeader: mobile navigation broken view
 - SfImage: no image on Storybook
 - SfGallery: wrong prop type on storybook
 - SfStoreLocator: fix server select option prop on Storybook

--- a/packages/vue/src/stories/releases/v0.10.1/v0.10.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.1/v0.10.1.stories.mdx
@@ -11,18 +11,9 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfTextarea: change component from functional to standard to fix listeners bug
 - SfCarousel: design broken
 - SfArrow, SfCircleIcon: remove doubled listeners
-<<<<<<< HEAD
-- SfHeader: mobile navigation broken view
-- SfImage: no image on Storybook
-- SfGallery: wrong prop type on storybook
-- SfStoreLocator: fix server select option prop on Storybook
-- SfProperty: missing data in slot examples on Storybook 
-- SfSelect: selectedValue not defined in Storybook
-- SfDivider: lack of story on Storybook
-=======
->>>>>>> d7e27203d9a17d639d10b2e3d22430fc6b90b095
 - Category example: missing title
 - SfImage: accept empty alt text for decorative-only images
+- SfHeader: mobile navigation broken view
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
Closes #1635

# Scope of work
Fix style for mobile navigation modifier and isNavVisable prop. 
Add menuItem for mobile to story. 

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/32042425/105252311-752f3600-5b7d-11eb-8380-5757904592cf.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
