### PR TITLE
fix: SfGroupedProduct change mobile view for slider and adjust story

### DIFF
--- a/packages/shared/styles/components/organisms/SfGroupedProduct.scss
+++ b/packages/shared/styles/components/organisms/SfGroupedProduct.scss
@@ -16,8 +16,6 @@
     position: relative;
     display: flex;
     flex: var(--grouped-product-item-flex);
-    // flex: 0 0 8.75rem;
-    // line-height: 0;
   }
   &__image {
     background: var(--grouped-product-item-image-background, var(--c-light));

--- a/packages/shared/styles/components/organisms/SfGroupedProduct.scss
+++ b/packages/shared/styles/components/organisms/SfGroupedProduct.scss
@@ -1,7 +1,7 @@
 @import "../../helpers";
 .sf-grouped-product-item {
   position: relative;
-  display: var(--grouped-product-item-display);
+  display: var(--grouped-product-item-display, flex);
   box-sizing: border-box;
   padding: var(--grouped-product-item-padding, var(--spacer-xs));
   @include border(--grouped-product-item-border, 0, solid, var(--c-light));
@@ -13,9 +13,11 @@
     var(--font-family--primary)
   );
   &__aside {
-    position: var(--grouped-product-item-aside-position, relative);
-    flex: var(--grouped-product-item-flex);
+    position: relative;
     display: flex;
+    flex: var(--grouped-product-item-flex);
+    // flex: 0 0 8.75rem;
+    // line-height: 0;
   }
   &__image {
     background: var(--grouped-product-item-image-background, var(--c-light));
@@ -23,28 +25,31 @@
       mix-blend-mode: darken;
     }
   }
-  &__quantity-selector {
-    --quantity-selector-background: var(--c-light);
-    display: var(--grouped-product-item-quantity-selector-display, flex);
-    position: absolute;
-    bottom: var(
-      --grouped-product-item-quantity-selector-bottom,
-      var(--spacer-sm)
-    );
-    left: var(--grouped-product-item-quantity-selector-left, 50%);
-    right: var(--grouped-product-item-quantity-selector-right);
-    transform: var(
-      --grouped-product-item-quantity-selector-transfrom,
-      translate3d(-50%, 0, 0)
-    );
+  &__quantity-wrapper {
+    display: flex;
+    position: absolute;    
+    box-sizing: border-box;
+    padding: var(--spacer-sm);
+    left: 0;
+    bottom: 0;
     margin: var(--grouped-product-item-quantity-selector-margin);
     z-index: 1;
+  }
+  &__quantity-selector {
+    display: var(--grouped-product-item-quantity-selector-display, flex);
+    --quantity-selector-background: var(--c-light);
+    @include for-desktop {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      margin: 0 var(--spacer-xs) var(--spacer-xs) 0;
+    }
   }
   &__description {
     display: flex;
     flex-direction: column;
     width: 100%;
-    margin: var(--grouped-product-item-description-margin);
+    margin: var(--grouped-product-item-description-margin, 0 0 0 var(--spacer-sm));
   }
   &__info {
     display: flex;
@@ -69,14 +74,12 @@
   &__price {
     margin: var(--grouped-product-item-price-margin);
   }
-  @include for-desktop {
-    --grouped-product-item-display: flex;
+  @include for-desktop {    
     --grouped-product-item-aside-position: static;
     --grouped-product-item-quantity-selector-bottom: var(--spacer-xs);
     --grouped-product-item-quantity-selector-left: auto;
     --grouped-product-item-quantity-selector-right: var(--spacer-xs);
     --grouped-product-item-quantity-selector-transfrom: translate3d(0, 0, 0);
-    --grouped-product-item-border-width: 0 0 1px 0;
     --grouped-product-item-flex: 0 0 5.125rem;
     --grouped-product-item-description-margin: 0 0 0 var(--spacer-sm);
     --grouped-product-item-price-margin: 0 0 0 auto;
@@ -94,7 +97,6 @@
   @include for-desktop {
     .glide {
       &__slides {
-        display: block;
         width: auto;
         transform: unset;
       }
@@ -107,6 +109,7 @@
   }
   &.without-carousel {
     .glide {
+      --grouped-product-item-border-width: 0;
       &__slides {
         display: block;
         width: auto;

--- a/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.stories.js
+++ b/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.stories.js
@@ -16,6 +16,7 @@ export default {
         category: "Props",
       },
     },
+    input: { action: "Text area input typing", table: { category: "Events" } },
   },
 };
 
@@ -24,7 +25,40 @@ const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   data() {
     return {
-      productQty: 1,
+      products: [
+        {
+          productQty: 1,
+          title: "Leave white brooch",
+          priceRegular: "$10.99",
+          image: "/assets/storybook/SfGroupedProduct/product-white.png",
+          imageWidth: 146,
+          imageHeight: 200,
+        },
+        {
+          productQty: 1,
+          title: "Leave green brooch",
+          priceRegular: "$13.89",
+          image: "/assets/storybook/SfGroupedProduct/product-green.png",
+          imageWidth: 146,
+          imageHeight: 200,
+        },
+        {
+          productQty: 1,
+          title: "Leave black brooch",
+          priceRegular: "$9.99",
+          image: "/assets/storybook/SfGroupedProduct/product-black.png",
+          imageWidth: 146,
+          imageHeight: 200,
+        },
+        {
+          productQty: 1,
+          title: "Leave white brooch extra",
+          priceRegular: "$15.99",
+          image: "/assets/storybook/SfGroupedProduct/product-white.png",
+          imageWidth: 146,
+          imageHeight: 200,
+        },
+      ],
     };
   },
   template: `
@@ -34,78 +68,29 @@ const Template = (args, { argTypes }) => ({
     :style="{maxWidth: '1140px', margin: 'auto'}"
   >
     <SfGroupedProductItem
-      :qty="productQty"
-      @input="productQty = $event"
-      :image="image"
-      :image-width="imageWidth"
-      :image-height="imageHeight"
+      v-for="(item, i) in products"
+      :key="i"
+      v-model="item.productQty"
+      @input="input"
+      :image="item.image"
+      :image-width="item.imageWidth"
+      :image-height="item.imageHeight"
       :image-lazy="imageLazy"
-      :title="title"
-      :price-regular="priceRegular"
+      :title="item.title"
+      :price-regular="item.priceRegular"
     >
       <template #details>
         <div :style="{color: '#72757E', fontSize: 'var(--font-size--base'}">MSD23-345-324</div>
         <SfProperty name="Color" value="White" :style="{margin: 'auto 0 0 0', width: '110px'}" />
       </template>
-    </SfGroupedProductItem>
-    <SfGroupedProductItem
-      :qty="productQty"
-      @input="productQty = $event"
-      :image="image"
-      :image-width="imageWidth"
-      :image-height="imageHeight"
-      :image-lazy="imageLazy"
-      :title="title"
-      :price-regular="priceRegular"
-    >
-      <template #details>
-        <div :style="{color: '#72757E', fontSize: 'var(--font-size--base'}">MSD23-345-324</div>
-        <SfProperty name="Color" value="White" :style="{margin: 'auto 0 0 0', width: '110px'}" />
-      </template>
-    </SfGroupedProductItem>
-    <SfGroupedProductItem
-      :qty="productQty"
-      @input="productQty = $event"
-      :image="image"
-      :image-width="imageWidth"
-      :image-height="imageHeight"
-      :image-lazy="imageLazy"
-      :title="title"
-      :price-regular="priceRegular"
-    >
-      <template #details>
-        <div :style="{color: '#72757E', fontSize: 'var(--font-size--base'}">MSD23-345-324</div>
-        <SfProperty name="Color" value="White" :style="{margin: 'auto 0 0 0', width: '110px'}" />
-      </template>
-    </SfGroupedProductItem>
-    <SfGroupedProductItem
-      :qty="productQty"
-      @input="productQty = $event"
-      :image="image"
-      :image-width="imageWidth"
-      :image-height="imageHeight"
-      :image-lazy="imageLazy"
-      :title="title"
-      :price-regular="priceRegular"
-    >
-      <template #details>
-        <div :style="{color: '#72757E', fontSize: 'var(--font-size--base'}">MSD23-345-324</div>
-        <SfProperty name="Color" value="White" :style="{margin: 'auto 0 0 0', width: '110px'}" />
-      </template>
-    </SfGroupedProductItem>
+    </SfGroupedProductItem>    
   </SfGroupedProduct>`,
 });
 
 export const Common = Template.bind({});
 Common.args = {
   settings: { type: "slider" },
-  image: "/assets/storybook/SfGroupedProduct/product-white.png",
-  imageWidth: 146,
-  imageHeight: 200,
   imageLazy: true,
-  title: "Leave white brooch",
-  priceRegular: "$10.99",
-  hasCarousel: false,
 };
 
 export const UseConfigurationSlot = (args, { argTypes }) => ({

--- a/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.stories.js
+++ b/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.stories.js
@@ -31,7 +31,7 @@ const Template = (args, { argTypes }) => ({
   <SfGroupedProduct
     :settings="settings"
     :has-carousel="hasCarousel"
-    :style="{maxWidth: '500px'}"
+    :style="{maxWidth: '1140px', margin: 'auto'}"
   >
     <SfGroupedProductItem
       :qty="productQty"
@@ -45,7 +45,52 @@ const Template = (args, { argTypes }) => ({
     >
       <template #details>
         <div :style="{color: '#72757E', fontSize: 'var(--font-size--base'}">MSD23-345-324</div>
-        <SfProperty name="Color" value="White" :style="{margin: 'auto 0 0 0'}" />
+        <SfProperty name="Color" value="White" :style="{margin: 'auto 0 0 0', width: '110px'}" />
+      </template>
+    </SfGroupedProductItem>
+    <SfGroupedProductItem
+      :qty="productQty"
+      @input="productQty = $event"
+      :image="image"
+      :image-width="imageWidth"
+      :image-height="imageHeight"
+      :image-lazy="imageLazy"
+      :title="title"
+      :price-regular="priceRegular"
+    >
+      <template #details>
+        <div :style="{color: '#72757E', fontSize: 'var(--font-size--base'}">MSD23-345-324</div>
+        <SfProperty name="Color" value="White" :style="{margin: 'auto 0 0 0', width: '110px'}" />
+      </template>
+    </SfGroupedProductItem>
+    <SfGroupedProductItem
+      :qty="productQty"
+      @input="productQty = $event"
+      :image="image"
+      :image-width="imageWidth"
+      :image-height="imageHeight"
+      :image-lazy="imageLazy"
+      :title="title"
+      :price-regular="priceRegular"
+    >
+      <template #details>
+        <div :style="{color: '#72757E', fontSize: 'var(--font-size--base'}">MSD23-345-324</div>
+        <SfProperty name="Color" value="White" :style="{margin: 'auto 0 0 0', width: '110px'}" />
+      </template>
+    </SfGroupedProductItem>
+    <SfGroupedProductItem
+      :qty="productQty"
+      @input="productQty = $event"
+      :image="image"
+      :image-width="imageWidth"
+      :image-height="imageHeight"
+      :image-lazy="imageLazy"
+      :title="title"
+      :price-regular="priceRegular"
+    >
+      <template #details>
+        <div :style="{color: '#72757E', fontSize: 'var(--font-size--base'}">MSD23-345-324</div>
+        <SfProperty name="Color" value="White" :style="{margin: 'auto 0 0 0', width: '110px'}" />
       </template>
     </SfGroupedProductItem>
   </SfGroupedProduct>`,
@@ -55,11 +100,12 @@ export const Common = Template.bind({});
 Common.args = {
   settings: { type: "slider" },
   image: "/assets/storybook/SfGroupedProduct/product-white.png",
-  imageWidth: 82,
-  imageHeight: 112,
+  imageWidth: 146,
+  imageHeight: 200,
   imageLazy: true,
   title: "Leave white brooch",
   priceRegular: "$10.99",
+  hasCarousel: false,
 };
 
 export const UseConfigurationSlot = (args, { argTypes }) => ({

--- a/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.vue
+++ b/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.vue
@@ -44,6 +44,7 @@ export default {
         type: "slider",
         rewind: true,
         gap: 0,
+        perView: 2,
         slidePerPage: true,
         breakpoints: {
           1023: {

--- a/packages/vue/src/components/organisms/SfGroupedProduct/_internal/SfGroupedProductItem.vue
+++ b/packages/vue/src/components/organisms/SfGroupedProduct/_internal/SfGroupedProductItem.vue
@@ -21,6 +21,19 @@
           class="sf-grouped-product-item__image"
         />
       </slot>
+      <!-- @slot Custom input markup -->
+      <div class="smartphone-only">
+        <slot name="input" v-bind="{ qty }">
+          <div class="sf-grouped-product-item__quantity-wrapper">
+            <SfQuantitySelector
+              :qty="qty"
+              aria-label="Quantity"
+              class="sf-grouped-product-item__quantity-selector"
+              @input="$emit('input', $event)"
+            />
+          </div>
+        </slot>
+      </div>
     </div>
     <div class="sf-grouped-product-item__description">
       <!-- @slot Custom title markup -->
@@ -47,14 +60,16 @@
       </slot>
     </div>
     <!-- @slot Custom input markup -->
-    <slot name="input" v-bind="{ qty }">
-      <SfQuantitySelector
-        :qty="qty"
-        aria-label="Quantity"
-        class="sf-grouped-product-item__quantity-selector"
-        @input="$emit('input', $event)"
-      />
-    </slot>
+    <div class="desktop-only">
+      <slot name="input" v-bind="{ qty }">
+        <SfQuantitySelector
+          :qty="qty"
+          aria-label="Quantity"
+          class="sf-grouped-product-item__quantity-selector"
+          @input="$emit('input', $event)"
+        />
+      </slot>
+    </div>
   </li>
 </template>
 <script>


### PR DESCRIPTION
# Related issue
Closes #1636 

# Scope of work
Fix styling for mobile view with hasCarousel prop set to true. 
Set default number of sliders on desktop to 2.
Story fix - add more products.

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/32042425/105364768-d4cd2600-5bfd-11eb-922a-914860acd5a8.png)
 
![image](https://user-images.githubusercontent.com/32042425/105364810-df87bb00-5bfd-11eb-9c9e-5e259bb2753f.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
