### PR TITLE
fix: sfhero add client class to right control

### DIFF
--- a/packages/vue/src/components/organisms/SfHero/SfHero.vue
+++ b/packages/vue/src/components/organisms/SfHero/SfHero.vue
@@ -19,7 +19,7 @@
         </SfButton>
       </slot>
     </div>
-    <div v-if="numberOfPages > 1" class="sf-hero__control--right">
+    <div v-if="numberOfPages > 1 && client" class="sf-hero__control--right">
       <!-- @slot slot for icon moving to the next item  -->
       <slot name="next" v-bind="{ go: () => go('next') }">
         <SfButton class="sf-button--pure" @click.stop="go('next')">

--- a/packages/vue/src/stories/releases/v0.10.1/v0.10.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.1/v0.10.1.stories.mdx
@@ -8,6 +8,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 - SfHero: left arrow below image
 - SfHero: buttons not clickable fix
+- SfHero: add client class to right control arrow
 - SfTextarea: change component from functional to standard to fix listeners bug
 - SfCarousel: design broken
 - SfArrow, SfCircleIcon: remove doubled listeners


### PR DESCRIPTION
# Related issue
no

# Scope of work
Add client class to right control in order to avoid loading arrow on ssr.

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
