### PR TITLE
fix: SfSidebar revert last changes 

### DIFF
--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.vue
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.vue
@@ -4,7 +4,7 @@
     <transition :name="transitionName">
       <aside
         v-if="visible"
-        ref="sidebarAside"
+        ref="asideContent"
         v-focus-trap
         v-click-outside="checkPersistence"
         class="sf-sidebar__aside"
@@ -43,16 +43,10 @@
           <!--@slot Use this slot to add sticky top content.-->
           <slot name="content-top" />
         </div>
-        <SfScrollable
-          show-text=""
-          hide-text=""
-          :max-content-height="setMaxHeight"
-        >
-          <div ref="content" class="sf-sidebar__content">
-            <!--@slot Use this slot to add SfSidebar content.-->
-            <slot />
-          </div>
-        </SfScrollable>
+        <div class="sf-sidebar__content">
+          <!--@slot Use this slot to add SfSidebar content.-->
+          <slot />
+        </div>
         <!--@slot Use this slot to place content to sticky bottom.-->
         <div v-if="hasBottom" class="sf-sidebar__bottom">
           <slot name="content-bottom" />
@@ -70,7 +64,6 @@ import SfBar from "../../molecules/SfBar/SfBar.vue";
 import SfCircleIcon from "../../atoms/SfCircleIcon/SfCircleIcon.vue";
 import SfOverlay from "../../atoms/SfOverlay/SfOverlay.vue";
 import SfHeading from "../../atoms/SfHeading/SfHeading.vue";
-import SfScrollable from "../../molecules/SfScrollable/SfScrollable.vue";
 export default {
   name: "SfSidebar",
   directives: { focusTrap, clickOutside },
@@ -79,7 +72,6 @@ export default {
     SfCircleIcon,
     SfOverlay,
     SfHeading,
-    SfScrollable,
   },
   props: {
     /**
@@ -137,7 +129,6 @@ export default {
       position: "left",
       staticClass: null,
       className: null,
-      setMaxHeight: "",
     };
   },
   computed: {
@@ -160,10 +151,7 @@ export default {
         if (!isClient) return;
         if (value) {
           this.$nextTick(() => {
-            disableBodyScroll(this.$refs.content);
-            if (this.$slots.default) {
-              this.setMaxHeight = `${this.$refs.sidebarAside.offsetHeight.toString()}px`;
-            }
+            disableBodyScroll(this.$refs.asideContent);
           });
           document.addEventListener("keydown", this.keydownHandler);
         } else {
@@ -173,6 +161,12 @@ export default {
       },
       immediate: true,
     },
+  },
+  mounted() {
+    this.classHandler();
+  },
+  updated() {
+    this.classHandler();
   },
   methods: {
     close() {

--- a/packages/vue/src/stories/releases/v0.10.1/v0.10.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.1/v0.10.1.stories.mdx
@@ -13,6 +13,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfArrow, SfCircleIcon: remove doubled listeners
 - Category example: missing title
 - SfImage: accept empty alt text for decorative-only images
+- SfSidebar: SfScrollable removed and body scroll lock added to sidebar component
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue

Closes #1665 

# Scope of work
Revert changes implemented in 0.10.0 version to avoid bugs.
Add body scroll lock to whole sidebar component, not to content to avoid scrolling body.

Adding scrollbar should be made in new patch version because when using SfScrollabe it needs more changes in elements and style.

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/contributing/coding-guidelines.html#component-rules) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
