### PR TITLE
#1688 Fix for jumping content in SfTabs

### DIFF
--- a/packages/vue/src/components/organisms/SfTabs/SfTabs.vue
+++ b/packages/vue/src/components/organisms/SfTabs/SfTabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-show="initialTabActivated" :class="{'sf-tabs': initialTabActivated}">
+  <div v-show="initialTabActivated" class="sf-tabs">
     <!--@slot Default. Here you should pass your tabs-->
     <slot />
   </div>

--- a/packages/vue/src/components/organisms/SfTabs/SfTabs.vue
+++ b/packages/vue/src/components/organisms/SfTabs/SfTabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sf-tabs">
+  <div v-show="initialTabActivated" :class="{'sf-tabs': initialTabActivated}">
     <!--@slot Default. Here you should pass your tabs-->
     <slot />
   </div>
@@ -11,6 +11,11 @@ Vue.component("SfTab", SfTab);
 
 export default {
   name: "SfTabs",
+  data() {
+    return {
+      initialTabActivated: false
+    }
+  },
   props: {
     /** Which tab should be open at the beginning  */
     openTab: {
@@ -48,6 +53,7 @@ export default {
     openChild() {
       if (this.openTab < this.$children.length + 1) {
         this.$children[this.openTab - 1].isActive = true;
+        this.initialTabActivated = true;
       }
     },
   },


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1688

# Scope of work
Now I'm showing `SfTabs` component right after child `SfTab` being activated, but not before this

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
