### PR TITLE
fix: SfHero add condition to init glide when more than one item

### DIFF
--- a/packages/vue/src/components/organisms/SfHero/SfHero.vue
+++ b/packages/vue/src/components/organisms/SfHero/SfHero.vue
@@ -94,7 +94,7 @@ export default {
     },
   },
   mounted() {
-    if (this.numberOfPages) {
+    if (this.numberOfPages > 1) {
       this.$nextTick(() => {
         if (!this.$slots.default) return;
         const glide = new Glide(this.$refs.glide, this.mergedOptions);

--- a/packages/vue/src/stories/releases/v0.10.3/v0.10.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.3/v0.10.3.stories.mdx
@@ -1,0 +1,10 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.10.3 - Latest/Change log" />
+
+# v0.10.3
+
+## 🐛 Fixes
+
+
+- SfHero - add the condition to initialize glide.js when there is more than one item


### PR DESCRIPTION
# Related issue
Closes #1640 

# Scope of work
Fix the condition to init glide only when there is more than one item.

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
