### PR TITLE
fix: SfSearchbar adding listeners 

### DIFF
--- a/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.stories.js
+++ b/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.stories.js
@@ -52,6 +52,8 @@ export default {
     input: { action: "Input changed", table: { category: "Events" } },
     enter: { action: "Enter pressed", table: { category: "Events" } },
     blur: { action: "Not focus anymore", table: { category: "Events" } },
+    focus: { action: "Focus", table: { category: "Events" } },
+    click: { action: "Button click", table: { category: "Events" } }
   },
 };
 
@@ -73,9 +75,11 @@ const Template = (args, { argTypes }) => ({
   :icon="iconCheck"
   :class="classes"
   :placeholder="placeholder"
+  @click="click"
   @enter="enter"
   @input="input"
   @blur="blur"
+  @focus="focus"
   aria-label="Search"
   v-model="value"/>`,
 });
@@ -117,10 +121,11 @@ export const UseIconSlot = (args, { argTypes }) => ({
   <SfSearchBar
     :class="customClass"
     :placeholder="placeholder"
-    @click="alert(value)"
+    @click="click"
     @enter="enter"
     @input="input"
     @blur="blur"
+    @focus="focus"
     aria-label="Search"
     v-model="value">
     <template #icon>👀</template>

--- a/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.stories.js
+++ b/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.stories.js
@@ -50,16 +50,20 @@ export default {
       description: "Define color of the search icon",
     },
     input: { action: "Input changed", table: { category: "Events" } },
-    enter: { action: "Enter pressed", table: { category: "Events" } },
     blur: { action: "Not focus anymore", table: { category: "Events" } },
     focus: { action: "Focus", table: { category: "Events" } },
-    click: { action: "Button click", table: { category: "Events" } }
+    click: { action: "Button click", table: { category: "Events" } },
   },
 };
 
 const Template = (args, { argTypes }) => ({
   components: { SfSearchBar },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      searchValue: this.value,
+    }
+  },
   computed: {
     iconCheck() {
       return this.iconSize || this.iconColor
@@ -76,12 +80,11 @@ const Template = (args, { argTypes }) => ({
   :class="classes"
   :placeholder="placeholder"
   @click="click"
-  @enter="enter"
-  @input="input"
   @blur="blur"
   @focus="focus"
+  @input="input"
   aria-label="Search"
-  v-model="value"/>`,
+  v-model="searchValue"/>`,
 });
 
 export const Common = Template.bind({});
@@ -116,18 +119,21 @@ Centered.args = {
 
 export const UseIconSlot = (args, { argTypes }) => ({
   components: { SfSearchBar },
+  data() {
+    return {
+      searchValue: this.value,
+    }
+  },
   props: Object.keys(argTypes),
   template: `
   <SfSearchBar
-    :class="customClass"
     :placeholder="placeholder"
     @click="click"
-    @enter="enter"
-    @input="input"
     @blur="blur"
     @focus="focus"
+    @input="input"
     aria-label="Search"
-    v-model="value">
+    v-model="searchValue">
     <template #icon>👀</template>
   </SfSearchBar>`,
 });

--- a/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.vue
+++ b/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.vue
@@ -7,10 +7,7 @@
       :value="value"
       v-bind="$attrs"
       :placeholder="placeholder"
-      @input="$emit('input', $event.target.value)"
-      @keyup.enter="$emit('enter', $event.target.value)"
-      @keyup.esc="$emit('input', '')"
-      @blur="$emit('blur')"
+      v-on="listeners"
     />
     <!-- @slot -->
     <slot name="icon">
@@ -57,6 +54,17 @@ export default {
     icon: {
       type: Object,
       default: () => ({}),
+    },
+  },
+  computed: {
+    listeners() {
+      return {
+        ...this.$listeners,
+        input: (event) => this.$emit("input", event.target.value),
+        ["keyup.enter"]: (event) => this.$emit("input", event.target.value),
+        ["keyup.esc"]: () => this.$emit("input", ""),
+        blur: () => this.$emit("blur"),
+      };
     },
   },
 };

--- a/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.vue
+++ b/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.vue
@@ -61,8 +61,8 @@ export default {
       return {
         ...this.$listeners,
         input: (event) => this.$emit("input", event.target.value),
-        ["keyup.enter"]: (event) => this.$emit("input", event.target.value),
-        ["keyup.esc"]: () => this.$emit("input", ""),
+        "keyup.enter": (event) => this.$emit("input", event.target.value),
+        "keyup.esc": () => this.$emit("input", ""),
         blur: () => this.$emit("blur"),
       };
     },

--- a/packages/vue/src/stories/releases/v0.10.3/v0.10.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.3/v0.10.3.stories.mdx
@@ -1,0 +1,10 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.10.3 - Latest/Change log" />
+
+# v0.10.3
+
+## 🐛 Fixes
+
+
+- SfSearchBar: add a possibility to pass listeners 


### PR DESCRIPTION
# Related issue
Closes #1692 

# Scope of work
Add listeners computed property which allows adding more listeners to the search input. 
Adjust stories to this change.

# Screenshots of visual changes

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
