### PR TITLE
fix: SfProductCard - picture and title shouldn't be only links

### DIFF
--- a/packages/shared/styles/components/organisms/SfProductCard.scss
+++ b/packages/shared/styles/components/organisms/SfProductCard.scss
@@ -36,7 +36,7 @@
     line-height: 0;
     text-decoration: none;
     margin: var(--product-card-link-margin, 0);
-    text-align: left
+    text-align: left;
   }
   &__title {
     @include font(

--- a/packages/shared/styles/components/organisms/SfProductCard.scss
+++ b/packages/shared/styles/components/organisms/SfProductCard.scss
@@ -36,6 +36,7 @@
     line-height: 0;
     text-decoration: none;
     margin: var(--product-card-link-margin, 0);
+    text-align: left
   }
   &__title {
     @include font(

--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.stories.js
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.stories.js
@@ -121,6 +121,10 @@ export default {
       action: "Wishlist clicked",
       table: { category: "Events" },
     },
+    "handleClick": {
+      action: "Card clicked",
+      table: { category: "Events" },
+    },
   },
 };
 
@@ -150,6 +154,7 @@ const Template = (args, { argTypes }) => ({
     :is-added-to-cart="isAddedToCart"
     @click:add-to-cart="this['click:addToCart']"
     @click:wishlist="this['click:wishlist']"
+    @click="handleClick"
   />`,
 });
 
@@ -161,6 +166,12 @@ Common.args = {
   maxRating: 5,
   reviewsCount: 7,
   showAddToCartButton: true,
+};
+
+export const WithLink = Template.bind({});
+WithLink.args = {
+  ...Common.args,
+  link: "https://storefrontui.io",
 };
 
 export const WithBadge = Template.bind({});
@@ -229,6 +240,7 @@ export const UseImageSlot = (args, { argTypes }) => ({
     :is-added-to-cart="isAddedToCart"
     @click:add-to-cart="this['click:addToCart']"
     @click:wishlist="this['click:wishlist']"
+    @click="handleClick"
   >
     <template #image="{ image, title }">
       <div :style="{ height: '111px', display: 'flex', alignItems: 'center', justifyContent: 'center'}">CUSTOM IMAGE</div>
@@ -263,6 +275,7 @@ export const UseAddToCart = (args, { argTypes }) => ({
     :is-added-to-cart="isAddedToCart"
     @click:add-to-cart="this['click:addToCart']"
     @click:wishlist="this['click:wishlist']"
+    @click="handleClick"
   >
     <template #add-to-cart="{ isAddedToCart, showAddedToCartBadge, isAddingToCart }">
       CUSTOM ADD TO CART
@@ -297,6 +310,7 @@ export const UseTitleSlot = (args, { argTypes }) => ({
     :is-added-to-cart="isAddedToCart"
     @click:add-to-cart="this['click:addToCart']"
     @click:wishlist="this['click:wishlist']"
+    @click="handleClick"
   >
     <template #title">
       CUSTOM TITLE
@@ -331,6 +345,7 @@ export const UseWishlistIconSlot = (args, { argTypes }) => ({
     :is-added-to-cart="isAddedToCart"
     @click:add-to-cart="this['click:addToCart']"
     @click:wishlist="this['click:wishlist']"
+    @click="handleClick"
   >
     <template #wishlist-icon">
       CUSTOM WISHLIST ICON
@@ -365,6 +380,7 @@ export const UsePriceSlot = (args, { argTypes }) => ({
     :is-added-to-cart="isAddedToCart"
     @click:add-to-cart="this['click:addToCart']"
     @click:wishlist="this['click:wishlist']"
+    @click="handleClick"
   >
     <template #price">
       CUSTOM PRICE
@@ -399,6 +415,7 @@ export const UseReviewsSlot = (args, { argTypes }) => ({
     :is-added-to-cart="isAddedToCart"
     @click:add-to-cart="this['click:addToCart']"
     @click:wishlist="this['click:wishlist']"
+    @click="handleClick"
   >
     <template #reviews">
       CUSTOM REVIEWS

--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
@@ -5,7 +5,11 @@
         name="image"
         v-bind="{ image, title, link, imageHeight, imageWidth }"
       >
-        <SfLink :link="link" class="sf-product-card__link">
+        <SfButton
+          :link="link"
+          class="sf-button--pure sf-product-card__link"
+          v-on="$listeners"
+        >
           <template v-if="Array.isArray(image)">
             <SfImage
               v-for="(picture, key) in image.slice(0, 2)"
@@ -25,7 +29,7 @@
             :width="imageWidth"
             :height="imageHeight"
           />
-        </SfLink>
+        </SfButton>
       </slot>
       <slot name="badge" v-bind="{ badgeLabel, badgeColor }">
         <SfBadge
@@ -97,11 +101,15 @@
       </template>
     </div>
     <slot name="title" v-bind="{ title, link }">
-      <SfLink :link="link" class="sf-product-card__link">
+      <SfButton
+        :link="link"
+        class="sf-button--pure sf-product-card__link"
+        v-on="$listeners"
+      >
         <h3 class="sf-product-card__title">
           {{ title }}
         </h3>
-      </SfLink>
+      </SfButton>
     </slot>
     <slot name="price" v-bind="{ specialPrice, regularPrice }">
       <SfPrice
@@ -136,7 +144,6 @@
 <script>
 import { colorsValues as SF_COLORS } from "@storefront-ui/shared/variables/colors";
 import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
-import SfLink from "../../atoms/SfLink/SfLink.vue";
 import SfPrice from "../../atoms/SfPrice/SfPrice.vue";
 import SfRating from "../../atoms/SfRating/SfRating.vue";
 import SfImage from "../../atoms/SfImage/SfImage.vue";
@@ -150,7 +157,6 @@ export default {
     SfRating,
     SfIcon,
     SfImage,
-    SfLink,
     SfCircleIcon,
     SfBadge,
     SfButton,

--- a/packages/vue/src/stories/releases/v0.10.3/v0.10.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.3/v0.10.3.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Releases/v0.10.3 - Latest/Change log" />
+<Meta title="Releases/v0.10.3/Change log" />
 
 # v0.10.3
 

--- a/packages/vue/src/stories/releases/v0.10.4/v0.10.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.4/v0.10.4.stories.mdx
@@ -1,0 +1,10 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.10.4 - Latest/Change log" />
+
+# v0.10.4
+
+## 🐛 Fixes
+
+
+- SfProductCard: title and picture can also be buttons when link is not provided


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1706 

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
