### PR TITLE
chore: add storybook composition script to package json

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -98,5 +98,8 @@
     "*.vue",
     "*.scss",
     "*.css"
-  ]
+  ],
+  "storybook": {
+    "url": "https://docs.storefrontui.io/"
+  }
 }

--- a/packages/vue/src/stories/releases/v0.10.4/v0.10.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.4/v0.10.4.stories.mdx
@@ -1,0 +1,10 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.10.4 - Latest/Change log" />
+
+# v0.10.4
+
+## 🐛 Fixes
+
+
+- add script allowing for using Storybook composition  


### PR DESCRIPTION
# Related issue
Closes #1659 

# Scope of work
Add script for Storybook composition in package.json to make it easier for other storybooks to include our stories. 

# Screenshots of visual changes

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
