### PR TITLE
fix: add change event to the SfRadio component

### DIFF
--- a/packages/vue/src/components/molecules/SfRadio/SfRadio.stories.js
+++ b/packages/vue/src/components/molecules/SfRadio/SfRadio.stories.js
@@ -81,7 +81,14 @@ export default {
         },
       },
     },
-    input: { action: "Toggle selection", table: { category: "Events" } },
+    change: {
+      action: "Toggle selection: change event",
+      table: { category: "Events" },
+    },
+    input: {
+      action: "Toggle selection: input event",
+      table: { category: "Events" },
+    },
   },
 };
 
@@ -90,16 +97,17 @@ const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   template: `
   <SfRadio 
-  :class="classes"
-  :label="label"
-  :details="details"
-  :description="description"
-  :name="name"
-  :value="value"
-  :disabled="disabled"
-  :required="required"
-  v-model="selected"
-  @input="input"
+    :class="classes"
+    :label="label"
+    :details="details"
+    :description="description"
+    :name="name"
+    :value="value"
+    :disabled="disabled"
+    :required="required"
+    v-model="selected"
+    @change="change"
+    @input="input"
   />`,
 });
 
@@ -136,15 +144,16 @@ export const UseCheckmarkSlot = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   template: `
   <SfRadio 
-  :class="classes"
-  :label="label"
-  :details="details"
-  :description="description"
-  :name="name"
-  :value="value"
-  :disabled="disabled"
-  :required="required"
-  @input="input"
+    :class="classes"
+    :label="label"
+    :details="details"
+    :description="description"
+    :name="name"
+    :value="value"
+    :disabled="disabled"
+    :required="required"
+    @change="change"
+    @input="input"
   >
     <template #checkmark="{isChecked, disabled}">
       <div v-if="isChecked">😀</div>
@@ -159,15 +168,16 @@ export const UseLabelSlot = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   template: `
   <SfRadio 
-  :class="classes"
-  :label="label"
-  :details="details"
-  :description="description"
-  :name="name"
-  :value="value"
-  :disabled="disabled"
-  :required="required"
-  @input="input"
+    :class="classes"
+    :label="label"
+    :details="details"
+    :description="description"
+    :name="name"
+    :value="value"
+    :disabled="disabled"
+    :required="required"
+    @change="change"
+    @input="input"
   >
     <template #label="{label, isChecked, disabled}">
       CUSTOM LABEL
@@ -181,15 +191,16 @@ export const UseDetailsSlot = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   template: `
   <SfRadio 
-  :class="classes"
-  :label="label"
-  :details="details"
-  :description="description"
-  :name="name"
-  :value="value"
-  :disabled="disabled"
-  :required="required"
-  @input="input"
+    :class="classes"
+    :label="label"
+    :details="details"
+    :description="description"
+    :name="name"
+    :value="value"
+    :disabled="disabled"
+    :required="required"
+    @change="change"
+    @input="input"
   >
     <template #details="{details}">
       CUSTOM DETAILS
@@ -203,15 +214,16 @@ export const UseDescriptionSlot = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   template: `
   <SfRadio 
-  :class="classes"
-  :label="label"
-  :details="details"
-  :description="description"
-  :name="name"
-  :value="value"
-  :disabled="disabled"
-  :required="required"
-  @input="input"
+    :class="classes"
+    :label="label"
+    :details="details"
+    :description="description"
+    :name="name"
+    :value="value"
+    :disabled="disabled"
+    :required="required"
+    @change="change"
+    @input="input"
   >
     <template #description="{description}">
       CUSTOM DESCRIPTION

--- a/packages/vue/src/components/molecules/SfRadio/SfRadio.vue
+++ b/packages/vue/src/components/molecules/SfRadio/SfRadio.vue
@@ -14,6 +14,7 @@
         :value="value"
         :checked="isChecked"
         :disabled="disabled"
+        @change="changeHandler"
         @input="inputHandler"
       />
       <!-- @slot Custom checkmark markup (bind 'isChecked' boolean, 'disabled' boolean -->
@@ -91,6 +92,9 @@ export default {
     },
   },
   methods: {
+    changeHandler() {
+      this.$emit("change", this.value);
+    },
     inputHandler() {
       this.$emit("input", this.value);
     },

--- a/packages/vue/src/stories/releases/v0.10.3/v0.10.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.3/v0.10.3.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Releases/v0.10.3 - Latest/Change log" />
+<Meta title="Releases/v0.10.3/Change log" />
 
 # v0.10.3
 

--- a/packages/vue/src/stories/releases/v0.10.4/v0.10.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.4/v0.10.4.stories.mdx
@@ -1,0 +1,10 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.10.4 - Latest/Change log" />
+
+# v0.10.4
+
+## 🐛 Fixes
+
+
+- SfRadio: add change event for older browsers 


### PR DESCRIPTION
# Related issue
Closes #1604 

# Scope of work
Add change event to the SfRadio to enable using by older browsers.

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
