### PR TITLE
Fix #1667/sffooter without js

### DIFF
--- a/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
+++ b/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
@@ -42,6 +42,11 @@ export default {
       default: () => [],
     },
   },
+  provide() {
+    return {
+      items: this.items,
+    }
+  },
   data() {
     return {
       isOpen: [],

--- a/packages/vue/src/components/organisms/SfFooter/_internal/SfFooterColumn.vue
+++ b/packages/vue/src/components/organisms/SfFooter/_internal/SfFooterColumn.vue
@@ -3,11 +3,11 @@
     <button v-focus class="sf-footer-column__title" @click="toggle(title)">
       {{ title }}
       <div class="sf-footer-column__chevron">
-        <SfChevron :class="{ 'sf-chevron--top': open }" />
+        <SfChevron :class="{ 'sf-chevron--top': isColumnOpen }" />
       </div>
     </button>
     <transition name="sf-fade">
-      <div v-if="open" class="sf-footer-column__content">
+      <div v-if="isColumnOpen" class="sf-footer-column__content">
         <slot />
       </div>
     </transition>
@@ -26,13 +26,21 @@ export default {
       default: "",
     },
   },
-  computed: {
-    open() {
-      return this.$parent.isOpen.includes(this.title);
+  inject: ["items"],
+  data() {
+    return {
+      isColumnOpen: true,
+    };
+  },
+  watch: {
+    "$parent.isOpen": {
+      handler(newVal) {
+        this.isColumnOpen = newVal.includes(this.title);
+      },
     },
   },
-  mounted() {
-    this.$parent.items.push(this.title);
+  created() {
+    this.items.push(this.title);
   },
   methods: {
     toggle(payload) {

--- a/packages/vue/src/stories/releases/v0.11.0/v0.11.0.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.0/v0.11.0.stories.mdx
@@ -7,3 +7,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 ## 🧹 Chores:
 
 - docs for transitions in `Utilites/Transitions/Docs`
+
+## 🐛 Fixes
+
+- SfFooter not working with js disabled


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1667 

# Scope of work
<!-- describe what you did -->

- Used `provide/inject`, watcher, and local data to make SfFooter work without JavaScript.
- Tested in `nuxt` branch and in Vue Storefront Next

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
