### PR TITLE
fix: Possible to open SfSelect when it is disabled 

### DIFF
--- a/packages/shared/styles/components/molecules/SfSelect.scss
+++ b/packages/shared/styles/components/molecules/SfSelect.scss
@@ -94,10 +94,14 @@
   &.is-invalid {
     --select-dropdown-border-color: var(--c-danger);
   }
-  &.is-disabled {
+  &.is-disabled, select[disabled] {
     --select-dropdown-color: var(--c-text-disabled);
     --select-dropdown-border-color: var(--c-text-disabled);
     --select-label-color: var(--c-text-disabled);
+    color: var(--c-text-disabled);
+    .sf-select__dropdown:active {
+      --select-dropdown-border-color: var(--c-text-disabled);
+    }
   }
   &.is-required {
     --select-label-required: " *";

--- a/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
+++ b/packages/vue/src/components/molecules/SfSelect/SfSelect.vue
@@ -17,6 +17,7 @@
       :id="label"
       v-focus
       :value="value"
+      :disabled="disabled"
       class="sf-select__dropdown"
       @change="changeHandler"
     >

--- a/packages/vue/src/stories/releases/v0.10.3/v0.10.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.3/v0.10.3.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Releases/v0.10.3 - Latest/Change log" />
+<Meta title="Releases/v0.10.3/Change log" />
 
 # v0.10.3
 

--- a/packages/vue/src/stories/releases/v0.10.4/v0.10.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.4/v0.10.4.stories.mdx
@@ -1,0 +1,10 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.10.4 - Latest/Change log" />
+
+# v0.10.4
+
+## 🐛 Fixes
+
+
+- SfSelect: added `disabled` attribute


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1734

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
