### PR TITLE
[WIP] Feat #1668/accordion without js

### DIFF
--- a/packages/shared/styles/components/organisms/SfAccordion.scss
+++ b/packages/shared/styles/components/organisms/SfAccordion.scss
@@ -5,6 +5,8 @@
   backface-visibility: hidden;
   &__header {
     display: flex;
+    cursor: pointer;
+    user-select: none;
     justify-content: var(--accordion-item-header-justify, space-between);
     padding: var(--accordion-item-header-padding, var(--spacer-sm));
     color: var(--accordion-item-header-color);
@@ -30,10 +32,6 @@
     }
   }
   &__content {
-    padding: var(
-      --accordion-item-content-padding,
-      var(--spacer-base) var(--spacer-sm)
-    );
     color: var(--accordion-item-content-color, var(--c-text));
     @include border(
       --accordion-item-content-border,
@@ -65,5 +63,46 @@
 .sf-accordion {
   &.has-chevron {
     --accordion-item-chevron-display: flex;
+  }
+}
+
+.accordion__single { 
+  &__hidden {
+    display: none;
+    & ~ .accordion__single__question .sf-accordion-item__chevron {
+      transition: transform 300ms cubic-bezier(0.25, 1.7, 0.35, 0.8);
+      right: calc(var(--chevron-size, 1.25rem) / 10);
+      transform: rotate(calc(var(--chevron-rotate, 90deg) * -1));
+    }
+    &:checked {
+      & ~ .accordion__single__answer {
+        max-height: 400px;
+        opacity: 1;
+        transform: translate(0, 0);
+        margin-top: 14px;
+      }
+      & ~ .accordion__single__question {
+        color: var(--c-primary)
+      }
+      & ~ .sf-accordion-item__content {
+        padding: var(
+          --accordion-item-content-padding,
+          var(--spacer-base) var(--spacer-sm)
+        );
+      }
+      & ~ .accordion__single__question .sf-accordion-item__chevron {
+        --chevron-color: var(--c-primary);
+        right: calc(var(--chevron-size, 1.25rem) / 10);
+        transform: rotate(calc(var(--chevron-rotate, 0deg) * -1));
+      }
+    }
+  }
+  &__answer {
+    margin-top: 0;
+    max-height: 0;
+    opacity: 0;
+    transform: translate(0, 50%);
+    transition: all .4s ease;
+    position: relative;
   }
 }

--- a/packages/shared/styles/components/organisms/SfAccordion.scss
+++ b/packages/shared/styles/components/organisms/SfAccordion.scss
@@ -33,6 +33,11 @@
   }
   &__content {
     color: var(--accordion-item-content-color, var(--c-text));
+    max-height: 0;
+    opacity: 0;
+    transform: translate(0, 50%);
+    transition: all .4s ease;
+    position: relative;
     @include border(
       --accordion-item-content-border,
       1px 0,
@@ -59,29 +64,15 @@
     --accordion-item-content-border-width: 0;
     --accordion-item-content-padding: var(--spacer-base) 0;
   }
-}
-.sf-accordion {
-  &.has-chevron {
-    --accordion-item-chevron-display: flex;
-  }
-}
-
-.accordion__single { 
   &__hidden {
     display: none;
-    & ~ .accordion__single__question .sf-accordion-item__chevron {
+    & ~ .sf-accordion-item__header .sf-accordion-item__chevron {
       transition: transform 300ms cubic-bezier(0.25, 1.7, 0.35, 0.8);
       right: calc(var(--chevron-size, 1.25rem) / 10);
       transform: rotate(calc(var(--chevron-rotate, 90deg) * -1));
     }
     &:checked {
-      & ~ .accordion__single__answer {
-        max-height: 400px;
-        opacity: 1;
-        transform: translate(0, 0);
-        margin-top: 14px;
-      }
-      & ~ .accordion__single__question {
+      & ~ .sf-accordion-item__header {
         color: var(--c-primary)
       }
       & ~ .sf-accordion-item__content {
@@ -89,20 +80,19 @@
           --accordion-item-content-padding,
           var(--spacer-base) var(--spacer-sm)
         );
+        max-height: 400px;
+        opacity: 1;
+        transform: translate(0, 0);
       }
-      & ~ .accordion__single__question .sf-accordion-item__chevron {
+      & ~ .sf-accordion-item__header .sf-accordion-item__chevron {
         --chevron-color: var(--c-primary);
-        right: calc(var(--chevron-size, 1.25rem) / 10);
         transform: rotate(calc(var(--chevron-rotate, 0deg) * -1));
       }
     }
   }
-  &__answer {
-    margin-top: 0;
-    max-height: 0;
-    opacity: 0;
-    transform: translate(0, 50%);
-    transition: all .4s ease;
-    position: relative;
+}
+.sf-accordion {
+  &.has-chevron {
+    --accordion-item-chevron-display: flex;
   }
 }

--- a/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.vue
@@ -1,7 +1,32 @@
 <template>
   <div class="sf-accordion-item">
+    <div class="accordion__single">
+      <input
+        :id="header"
+        class="accordion__single__hidden"
+        type="checkbox"
+        autocomplete="off"
+        checked
+      />
+      <label
+        class="accordion__single__question sf-accordion-item__header"
+        :for="header"
+        :aria-pressed="isOpen.toString()"
+        :aria-expanded="isOpen.toString()"
+        @click="accordionClick"
+      >
+        <span>{{ header }}</span>
+        <!-- @slot here you can add additional information about this item -->
+        <slot name="additional-info" />
+        <SfChevron tabindex="0" class="sf-accordion-item__chevron" />
+      </label>
+      <div class="accordion__single__answer sf-accordion-item__content">
+        <!-- @slot -->
+        <slot />
+      </div>
+    </div>
     <!-- @slot -->
-    <slot
+    <!-- <slot
       name="header"
       v-bind="{
         header,
@@ -16,39 +41,35 @@
         :class="{ 'is-open': isOpen }"
         class="sf-button--pure sf-accordion-item__header"
         @click="accordionClick"
-      >
-        {{ header }}
-        <!-- @slot here you can add additional information about this item -->
-        <slot name="additional-info" />
+      > -->
+    <!-- {{ header }} -->
+    <!-- @slot here you can add additional information about this item -->
+    <!-- <slot name="additional-info" />
         <SfChevron
           tabindex="0"
           class="sf-accordion-item__chevron"
           :class="{ 'sf-chevron--right': !isOpen }"
         />
-      </SfButton>
-    </slot>
-    <SfExpand :transition="$parent.transition">
-      <div v-if="isOpen">
-        <div class="sf-accordion-item__content">
-          <!-- @slot -->
-          <slot />
+      </SfButton> -->
+    <!-- </slot> -->
+    <!-- <SfExpand :transition="$parent.transition"> -->
+    <!-- <div v-if="isOpen">
+        <div class="sf-accordion-item__content"> -->
+    <!-- @slot -->
+    <!-- <slot />
         </div>
-      </div>
-    </SfExpand>
+      </div> -->
+    <!-- </SfExpand> -->
   </div>
 </template>
 <script>
 import { focus } from "../../../../utilities/directives";
-import SfExpand from "../../../../utilities/transitions/component/SfExpand";
 import SfChevron from "../../../atoms/SfChevron/SfChevron.vue";
-import SfButton from "../../../atoms/SfButton/SfButton.vue";
 export default {
   name: "SfAccordionItem",
   directives: { focus },
   components: {
     SfChevron,
-    SfButton,
-    SfExpand,
   },
   props: {
     header: {

--- a/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.vue
@@ -1,73 +1,34 @@
 <template>
   <div class="sf-accordion-item">
-    <div class="accordion__single">
-      <input
-        :id="header"
-        class="accordion__single__hidden"
-        type="checkbox"
-        autocomplete="off"
-        checked
-      />
-      <label
-        class="accordion__single__question sf-accordion-item__header"
-        :for="header"
-        :aria-pressed="isOpen.toString()"
-        :aria-expanded="isOpen.toString()"
-        @click="accordionClick"
-      >
-        <span>{{ header }}</span>
-        <!-- @slot here you can add additional information about this item -->
-        <slot name="additional-info" />
-        <SfChevron tabindex="0" class="sf-accordion-item__chevron" />
-      </label>
-      <div class="accordion__single__answer sf-accordion-item__content">
-        <!-- @slot -->
-        <slot />
-      </div>
-    </div>
-    <!-- @slot -->
-    <!-- <slot
-      name="header"
-      v-bind="{
-        header,
-        isOpen,
-        accordionClick,
-        showChevron: $parent.showChevron,
-      }"
+    <input
+      :id="header"
+      class="sf-accordion-item__hidden"
+      type="checkbox"
+      autocomplete="off"
+      checked
+    />
+    <label
+      class="sf-accordion-item__header"
+      :for="header"
+      :aria-pressed="isOpen.toString()"
+      :aria-expanded="isOpen.toString()"
+      @click="accordionClick"
     >
-      <SfButton
-        :aria-pressed="isOpen.toString()"
-        :aria-expanded="isOpen.toString()"
-        :class="{ 'is-open': isOpen }"
-        class="sf-button--pure sf-accordion-item__header"
-        @click="accordionClick"
-      > -->
-    <!-- {{ header }} -->
-    <!-- @slot here you can add additional information about this item -->
-    <!-- <slot name="additional-info" />
-        <SfChevron
-          tabindex="0"
-          class="sf-accordion-item__chevron"
-          :class="{ 'sf-chevron--right': !isOpen }"
-        />
-      </SfButton> -->
-    <!-- </slot> -->
-    <!-- <SfExpand :transition="$parent.transition"> -->
-    <!-- <div v-if="isOpen">
-        <div class="sf-accordion-item__content"> -->
-    <!-- @slot -->
-    <!-- <slot />
-        </div>
-      </div> -->
-    <!-- </SfExpand> -->
+      <span>{{ header }}</span>
+      <!-- @slot here you can add additional information about this item -->
+      <slot name="additional-info" />
+      <SfChevron tabindex="0" class="sf-accordion-item__chevron" />
+    </label>
+    <div class="sf-accordion-item__content">
+      <!-- @slot -->
+      <slot />
+    </div>
   </div>
 </template>
 <script>
-import { focus } from "../../../../utilities/directives";
 import SfChevron from "../../../atoms/SfChevron/SfChevron.vue";
 export default {
   name: "SfAccordionItem",
-  directives: { focus },
   components: {
     SfChevron,
   },


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1668 

# Scope of work
<!-- describe what you did -->

Refactor SfAccordionItem to be visible and work (!) without JS. Instead of a button, there is a hidden checkbox that allow SfAccordion to work the same way with and without JS.

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
