### PR TITLE
feat: #1668 SfAccordion visual fix for hotfix 10.4

### DIFF
--- a/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.vue
@@ -58,7 +58,7 @@ export default {
   },
   data() {
     return {
-      isOpen: false,
+      isOpen: true,
     };
   },
   methods: {


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1668 (partly)

# Scope of work
<!-- describe what you did -->

This is the first step for SfAccordion fix. With that small change, SfAccordion is visible without JS. It does not work (this will be introduced later in v11), but it can be viewed (for hotfix 10.4).

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
