### PR TITLE
#1732 fix/sfgallery image not appearing on firefox

### DIFF
--- a/packages/shared/styles/components/molecules/SfGallery.scss
+++ b/packages/shared/styles/components/molecules/SfGallery.scss
@@ -40,7 +40,6 @@
   .glide {
     &__slide {
       flex: 1;
-      display: flex;
     }
     &__slides {
       margin: 0;

--- a/packages/vue/src/stories/releases/v0.10.5/v0.10.5.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.5/v0.10.5.stories.mdx
@@ -9,3 +9,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
+- SfGallery - main image not appearing on Firefox 


### PR DESCRIPTION
# Related issue
Closes #1732 

# Scope of work
Fix main image in SfGallery on Firefox.


# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/32042425/115058519-a5b90e80-9ee5-11eb-8d44-7625ea6709da.png)


# Checklist

- [x] No commented blocks of code left
- [ ] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
