### PR TITLE
fix: SfQuantitySelector let parent component handle '' and 0 input #1772

### DIFF
--- a/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.vue
+++ b/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.vue
@@ -49,13 +49,6 @@ export default {
       default: false,
     },
   },
-  watch: {
-    qty(val) {
-      if (val < 1 || isNaN(val)) {
-        this.$emit("input", 1);
-      }
-    },
-  },
 };
 </script>
 <style lang="scss">


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1772

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://boviewable.firebaseapp.com/reviews/vuestorefront/storefront-ui/1773)
<!-- Reviewable:end -->
