### PR TITLE
Fix/#1758 closing modal

### DIFF
--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.vue
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.vue
@@ -20,7 +20,7 @@
     @keyup.down="move(1)"
     @keyup.enter="enter($event)"
   >
-    <div style="position: relative;">
+    <div style="position: relative">
       <div
         ref="sfComponentSelect"
         v-focus

--- a/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.stories.js
+++ b/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.stories.js
@@ -62,7 +62,7 @@ const Template = (args, { argTypes }) => ({
   data() {
     return {
       searchValue: this.value,
-    }
+    };
   },
   computed: {
     iconCheck() {
@@ -122,7 +122,7 @@ export const UseIconSlot = (args, { argTypes }) => ({
   data() {
     return {
       searchValue: this.value,
-    }
+    };
   },
   props: Object.keys(argTypes),
   template: `

--- a/packages/vue/src/stories/releases/v0.10.5/v0.10.5.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.5/v0.10.5.stories.mdx
@@ -9,3 +9,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 - SfImage: images are dispalyed on SSR
+- v-click-outside: correctly handles mousedown event 

--- a/packages/vue/src/utilities/directives/click-outside/click-outside-directive.js
+++ b/packages/vue/src/utilities/directives/click-outside/click-outside-directive.js
@@ -8,11 +8,11 @@ export const clickOutside = {
         closeHandler();
       }
     };
-    document.addEventListener("mouseup", el._outsideClickHandler);
+    document.addEventListener("mousedown", el._outsideClickHandler);
     document.addEventListener("touchstart", el._outsideClickHandler);
   },
   unbind(el) {
-    document.removeEventListener("mouseup", el._outsideClickHandler);
+    document.removeEventListener("mousedown", el._outsideClickHandler);
     document.removeEventListener("touchstart", el._outsideClickHandler);
     el._outsideClickHandler = null;
   },


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1758 
Closes https://github.com/vuestorefront/vue-storefront/issues/5698

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
