### PR TITLE
fix: sficon replace div with span element

### DIFF
--- a/packages/vue/src/components/atoms/SfIcon/SfIcon.vue
+++ b/packages/vue/src/components/atoms/SfIcon/SfIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <span
     ref="icon"
     :class="['sf-icon', iconColorClass, iconSizeClass]"
     :style="iconCustomStyle"
@@ -29,7 +29,7 @@
         />
       </svg>
     </slot>
-  </div>
+  </span>
 </template>
 <script>
 import icons from "@storefront-ui/shared/icons/icons";

--- a/packages/vue/src/stories/releases/v0.10.5/v0.10.5.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.5/v0.10.5.stories.mdx
@@ -9,3 +9,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
+- SfIcon - change div wrapping element to span to avoid html syntax error in SfMenuItem


### PR DESCRIPTION
# Related issue

Closes #1766 

# Scope of work
Change wrapping element of SfIcon to avoid ssr mismatch errors when it is put inside button (div inside button is not allowed html syntax). 

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [ ] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
