### PR TITLE
fix: SfMegaMenu bar shows on desktop

### DIFF
--- a/packages/shared/styles/components/organisms/SfMegaMenu.scss
+++ b/packages/shared/styles/components/organisms/SfMegaMenu.scss
@@ -62,7 +62,7 @@
   @include for-desktop {
     --mega-menu-height: auto;
   }
-  &__bar {
+  &__bar.sf-bar {
     display: var(--mega-menu-bar-display, flex);
     @include for-desktop {
       display: var(--mega-menu-bar-display, none);

--- a/packages/vue/src/stories/releases/v0.10.5/v0.10.5.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.5/v0.10.5.stories.mdx
@@ -9,3 +9,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
+- SfMegaMenu - additional class to hide bar on desktop 


### PR DESCRIPTION
# Related issue
Closes #1751

# Scope of work
Add class to sf-mega-menu__bar to upgrade specifity (avoid bar to show on desktop when in production mode).

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [ ] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
