### PR TITLE
fix: #1105 remove css vars for background-image

### DIFF
--- a/packages/vue/src/components/organisms/SfHero/_internal/SfHeroItem.vue
+++ b/packages/vue/src/components/organisms/SfHero/_internal/SfHeroItem.vue
@@ -75,11 +75,7 @@ export default {
       const image = this.image;
       const background = this.background;
       return {
-        "--_hero-item-background-image": image.mobile
-          ? `url(${image.mobile})`
-          : `url(${image})`,
-        "--_hero-item-background-desktop-image":
-          image.desktop && `url(${image.desktop})`,
+        "background-image": `url(${image})`,
         "--_hero-item-background-color": background,
       };
     },

--- a/packages/vue/src/stories/releases/v0.10.6/v0.10.6.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.6/v0.10.6.stories.mdx
@@ -1,0 +1,11 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.10.6 - Latest/Change log" />
+
+# v0.10.6
+
+## 🚀 Features
+
+
+## 🐛 Fixes
+- SfHero - fix infinite image request loop by removing css variables for background image


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1105 

# Scope of work
<!-- describe what you did -->

Removed CSS variables for background image that was causing the image request infinite loop. We lost the ability to pass different images for desktop and mobile as a prop, but we are sending requests for images only once.

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
