### PR TITLE
fix: add missing glob dependency

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -34,6 +34,7 @@
     "body-scroll-lock": "^3.0.1",
     "cloudinary-build-url": "^0.1.1",
     "core-js": "^3.6.5",
+    "glob": "^7.1.4",
     "hammerjs": "^2.0.8",
     "leaflet": "^1.5.1",
     "nouislider": "^15.2.0",


### PR DESCRIPTION
# Scope of work
Added a missing dependency causing ```Error: @storefront-ui/vue tried to access glob, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.``` when using yarn2

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
