### PR TITLE
#1609 fix/unit tests warinings

### DIFF
--- a/packages/vue/src/components/atoms/SfCimage/SfCimage.spec.js
+++ b/packages/vue/src/components/atoms/SfCimage/SfCimage.spec.js
@@ -9,8 +9,9 @@ describe("SfCimage.vue", () => {
         cloud: {
           cloudName: "demo",
         },
+        alt: "example",
       },
     });
-    expect(component.contains(".sf-cimage")).toBe(true);
+    expect(component.classes("sf-cimage")).toBe(true);
   });
 });

--- a/packages/vue/src/components/molecules/SfAddressPicker/_internal/SfAddress.spec.js
+++ b/packages/vue/src/components/molecules/SfAddressPicker/_internal/SfAddress.spec.js
@@ -5,14 +5,10 @@ import SfAddressPicker from "../SfAddressPicker.vue";
 describe("SfAddress.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfAddress, {
-      parentComponent: SfAddressPicker,
-      inject: ["getSelectedValue", "setSelectedValue"],
-      provide() {
-        return {
-          getSelectedValue: this.getSelectedValue,
-          setSelectedValue: this.setSelectedValue,
-        };
-      },
+      provide: {
+        getSelectedValue: () => "example",
+        setSelectedValue: () => "example",
+      }
     });
     expect(component.classes("sf-address")).toBe(true);
   });

--- a/packages/vue/src/components/molecules/SfSteps/_internal/SfStep.spec.js
+++ b/packages/vue/src/components/molecules/SfSteps/_internal/SfStep.spec.js
@@ -4,25 +4,12 @@ import SfSteps from "../SfSteps.vue";
 describe("SfStep.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfStep, {
-      parentComponent: SfSteps,
-      inject: ["stepsData"],
-      provide() {
-        const stepsData = {};
-        Object.defineProperty(stepsData, "index", {
-          enumerable: false,
-          get: () => this.active,
-        });
-        Object.defineProperty(stepsData, "name", {
-          enumerable: false,
-          get: () => this.steps[this.active],
-        });
-        Object.defineProperty(stepsData, "updateSteps", {
-          enumerable: false,
-          value: this.updateSteps,
-        });
-        return {
-          stepsData,
-        };
+      provide: {
+        stepsData: {
+          index: 0,
+          name: "example",
+          updateSteps: () => [],
+        },
       },
     });
     expect(component.classes("sf-step")).toBe(true);

--- a/packages/vue/src/components/molecules/SfTile/SfTile.spec.js
+++ b/packages/vue/src/components/molecules/SfTile/SfTile.spec.js
@@ -4,6 +4,6 @@ import SfTile from "./SfTile.vue";
 describe("SfTile.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfTile);
-    expect(component.contains(".sf-tile")).toBe(true);
+    expect(component.classes("sf-tile")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfStoreLocator/_internal/SfStore.spec.js
+++ b/packages/vue/src/components/organisms/SfStoreLocator/_internal/SfStore.spec.js
@@ -3,28 +3,14 @@ import SfStore from "./SfStore.vue";
 describe("SfStore.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfStore, {
-      inject: [
-        "registerStore",
-        "removeStore",
-        "centerOn",
-        "locatorData",
-        "getGeoDistance",
-      ],
-      provide() {
-        const locatorData = {};
-        Object.defineProperty(locatorData, "userPosition", {
-          enumerable: true,
-          get: () => this.userPosition,
-        });
-        return {
-          registerStore: this.registerStore,
-          removeStore: this.removeStore,
-          centerOn: this.centerOn,
-          getGeoDistance: this.getGeoDistance,
-          locatorData,
-        };
-      },
-    });
+      provide: {
+        registerStore: () => {},
+        removeStore: () => {},
+        centerOn: () => {},
+        getGeoDistance: () => {},
+        locatorData: () => {},
+      }
+    }); 
     expect(component.classes("sf-store")).toBe(true);
   });
 });

--- a/packages/vue/src/components/organisms/SfTable/_internal/SfTableHeading.spec.js
+++ b/packages/vue/src/components/organisms/SfTable/_internal/SfTableHeading.spec.js
@@ -3,11 +3,8 @@ import SfTableHeading from "./SfTableHeading.vue";
 describe("SfTableHeading.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfTableHeading, {
-      inject: ["table"],
-      provide() {
-        return {
-          table: [],
-        };
+      provide: {
+        table: () => {},
       },
     });
     expect(component.exists()).toBe(true);

--- a/packages/vue/src/components/organisms/SfTable/_internal/SfTableRow.spec.js
+++ b/packages/vue/src/components/organisms/SfTable/_internal/SfTableRow.spec.js
@@ -3,11 +3,8 @@ import SfTableRow from "./SfTableRow.vue";
 describe("SfTableRow.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfTableRow, {
-      inject: ["table"],
-      provide() {
-        return {
-          table: [],
-        };
+      provide: {
+        table: () => {},
       },
     });
     expect(component.exists()).toBe(true);

--- a/packages/vue/src/components/organisms/SfTabs/_internal/SfTab.spec.js
+++ b/packages/vue/src/components/organisms/SfTabs/_internal/SfTab.spec.js
@@ -1,25 +1,16 @@
 import { shallowMount } from "@vue/test-utils";
 import SfTab from "./SfTab.vue";
-import SfTabs from "../SfTabs.vue";
-describe.skip("SfTab.vue", () => {
+describe("SfTab.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(SfTab, {
-      parentComponent: SfTabs,
-      inject: ["tabConfig"],
-      provide() {
-        const tabConfig = {};
-        Object.defineProperty(tabConfig, "tabMaxContentHeight", {
-          get: () => this.tabMaxContentHeight,
-        });
-        Object.defineProperty(tabConfig, "tabShowText", {
-          get: () => this.tabShowText,
-        });
-        Object.defineProperty(tabConfig, "tabHideText", {
-          get: () => this.tabHideText,
-        });
-        return this.tabConfig;
+      provide: {
+        tabConfig: {
+          tabMaxContentHeight: "",
+          tabShowText: "",
+          tabHideText: "",
+        },
       },
     });
-    expect(component.classes("sf-tabs__tab")).toBe(true);
+    expect(component.exists("sf-tabs__tab")).toBe(true);
   });
 });

--- a/packages/vue/src/stories/releases/v0.10.5/v0.10.5.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.5/v0.10.5.stories.mdx
@@ -1,16 +1,15 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Releases/v0.10.5 - Latest/Change log" />
+<Meta title="Releases/v0.10.5/Change log" />
 
 # v0.10.5
 
 ## 🚀 Features
 
-
 ## 🐛 Fixes
 
-- SfMegaMenu - additional class to hide bar on desktop 
+- SfMegaMenu - additional class to hide bar on desktop
 - SfIcon - change div wrapping element to span to avoid html syntax error in SfMenuItem
-- SfGallery - main image not appearing on Firefox 
+- SfGallery - main image not appearing on Firefox
 - SfImage: images are dispalyed on SSR
-- v-click-outside: correctly handles mousedown event 
+- v-click-outside: correctly handles mousedown event

--- a/packages/vue/src/stories/releases/v0.10.6/v0.10.6.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.6/v0.10.6.stories.mdx
@@ -1,0 +1,11 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.10.6 - Latest/Change log" />
+
+# v0.10.6
+
+## 🚀 Features
+
+## 🐛 Fixes
+
+- unit tests warnings fixed,


### PR DESCRIPTION
Closes #1609

Scope of work
Get rid of all warnings appearing during unit tests: remove depracated metohods and mock properties injected into internal properties.


![image](https://user-images.githubusercontent.com/32042425/116933758-49374c80-ac64-11eb-8f60-c3b421b0f5ab.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
