### PR TITLE
fix: SfRadio add listeners

### DIFF
--- a/packages/vue/src/components/molecules/SfRadio/SfRadio.vue
+++ b/packages/vue/src/components/molecules/SfRadio/SfRadio.vue
@@ -14,8 +14,7 @@
         :value="value"
         :checked="isChecked"
         :disabled="disabled"
-        @change="changeHandler"
-        @input="inputHandler"
+        v-on="listeners"
       />
       <!-- @slot Custom checkmark markup (bind 'isChecked' boolean, 'disabled' boolean -->
       <slot name="checkmark" v-bind="{ isChecked, disabled }">
@@ -90,13 +89,12 @@ export default {
     isChecked() {
       return this.value === this.selected;
     },
-  },
-  methods: {
-    changeHandler() {
-      this.$emit("change", this.value);
-    },
-    inputHandler() {
-      this.$emit("input", this.value);
+    listeners() {
+      return {
+        ...this.$listeners,
+        input: () => this.$emit("input", this.value),
+        change: () => this.$emit("change", this.value),
+      };
     },
   },
 };


### PR DESCRIPTION
# Related issue
Closes #1803

# Scope of work
Add listeners to sfradio for every event.

# Screenshots of visual changes

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
