### PR TITLE
fix: respect size of options list set as a prop on SfComponentSelect #1838 

### DIFF
--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
@@ -140,12 +140,7 @@ NoChevron.args = {
 export const LongOptionsList = Template.bind({});
 LongOptionsList.args = {
   ...Common.args,
-  options: [
-      ...optionsList,
-    { value: "red", color: "#ff0000", label: "Red" },
-    { value: "green", color: "#00ff00", label: "Green" },
-    { value: "blue", color: "#0000ff", label: "Blue" }
-  ],
+  size: 3,
 };
 
 export const UseLabelSlot = (args, { argTypes }) => ({

--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
@@ -137,6 +137,17 @@ NoChevron.args = {
   classes: "sf-component-select--no-chevron",
 };
 
+export const LongOptionsList = Template.bind({});
+LongOptionsList.args = {
+  ...Common.args,
+  options: [
+      ...optionsList,
+    { value: "red", color: "#ff0000", label: "Red" },
+    { value: "green", color: "#00ff00", label: "Green" },
+    { value: "blue", color: "#0000ff", label: "Blue" }
+  ],
+};
+
 export const UseLabelSlot = (args, { argTypes }) => ({
   components: { SfComponentSelect, SfProductOption },
   props: Object.keys(argTypes),

--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.vue
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.vue
@@ -182,7 +182,7 @@ export default {
     },
     maxHeight() {
       if (!this.options.length) return;
-      return `${this.optionHeight * this.options.length}px`;
+      return `${this.optionHeight * (this.size + 0.5)}px`;
     },
     isActive() {
       return this.open;

--- a/packages/vue/src/stories/releases/v0.10.8/v0.10.8.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.8/v0.10.8.stories.mdx
@@ -1,0 +1,15 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.10.6 - Latest/Change log" />
+
+# v0.10.6
+
+## 🚀 Features
+
+- adding Cypress e2e tests for storybook examples
+
+## 🐛 Fixes
+
+- SfHero: fix infinite image request loop by removing css variables for background image
+- unit tests warnings fixed,
+- Package.json - Removed unnecessary libraries

--- a/packages/vue/src/stories/releases/v0.10.8/v0.10.8.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.8/v0.10.8.stories.mdx
@@ -1,15 +1,9 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Releases/v0.10.6 - Latest/Change log" />
+<Meta title="Releases/v0.10.8/Change log" />
 
-# v0.10.6
-
-## 🚀 Features
-
-- adding Cypress e2e tests for storybook examples
+# v0.10.8
 
 ## 🐛 Fixes
 
-- SfHero: fix infinite image request loop by removing css variables for background image
-- unit tests warnings fixed,
-- Package.json - Removed unnecessary libraries
+- SfComponentSelect:  respect size of options list set as a prop


### PR DESCRIPTION
# Related issue
Closes #1835

for more details see #1838 

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
