### PR TITLE
feat: add min/max props to QuantitySelector

### DIFF
--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -146,5 +146,5 @@ export {
   SfStoreLocator,
   SfTable,
   SfTabs,
-  SfTopBar,
+  SfTopBar
 };

--- a/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.stories.js
+++ b/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.stories.js
@@ -26,6 +26,20 @@ export default {
         category: "Props",
       },
     },
+    min: {
+      control: "number",
+      defaultValue: null,
+      table: {
+        category: "Props",
+      },
+    },
+    max: {
+      control: "number",
+      defaultValue: null,
+      table: {
+        category: "Props",
+      },
+    },
     input: { action: "Quantity changed!", table: { category: "Events" } },
   },
 };
@@ -42,6 +56,8 @@ const Template = (args, { argTypes }) => ({
   <SfQuantitySelector
     v-model="value"
     :disabled="disabled"
+    :min="min"
+    :max="max"
     aria-label="Quantity"
     :class="classes"
     @input="input"

--- a/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.vue
+++ b/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="sf-quantity-selector">
     <SfButton
-      :disabled="disabled"
+      :disabled="isMinusDisabled"
       class="sf-button--pure sf-quantity-selector__button"
       data-testid="+"
       @click="$emit('input', parseInt(qty, 10) - 1)"
@@ -18,7 +18,7 @@
       @blur="$emit('blur', $event)"
     />
     <SfButton
-      :disabled="disabled"
+      :disabled="isPlusDisabled"
       class="sf-button--pure sf-quantity-selector__button"
       data-testid="-"
       @click="$emit('input', parseInt(qty, 10) + 1)"
@@ -49,11 +49,38 @@ export default {
       type: Boolean,
       default: false,
     },
+    /** Minimum allowed quantity */
+    min: {
+      type: Number,
+      required: false,
+      default: null,
+    },
+    /** Maximum allowed quantity */
+    max: {
+      type: Number,
+      required: false,
+      default: null,
+    },
+  },
+  computed: {
+    isMinusDisabled() {
+      return (
+        this.disabled || Boolean(this.min !== null && this.qty <= this.min)
+      );
+    },
+    isPlusDisabled() {
+      return (
+        this.disabled || Boolean(this.max !== null && this.qty >= this.max)
+      );
+    },
   },
   watch: {
     qty(val) {
-      if (val < 1 || isNaN(val)) {
-        this.$emit("input", 1);
+      const min = this.min || 1;
+      if (val < min || isNaN(val)) {
+        this.$emit("input", min);
+      } else if (this.max !== null && val > this.max) {
+        this.$emit("input", this.max);
       }
     },
   },


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1824

# Scope of work
<!-- describe what you did -->
* Added optional props for min and max quantity.
* Added computed props to tell Minus and Plus buttons to disable if min/max are provided and the value is under/over (respectfully).
* Updated watcher to adjust the value if min/max are provided and the input is under/over accordingly.
* Added the optional props to the story for QuantitySelector

# Screenshots of visual changes
<!-- if visual changes applied -->
<img width="1015" alt="Screen Shot 2021-06-23 at 10 23 03" src="https://user-images.githubusercontent.com/4626224/123062902-398ae780-d40d-11eb-9d57-7e103e5682e9.png">
<img width="1015" alt="Screen Shot 2021-06-23 at 10 23 28" src="https://user-images.githubusercontent.com/4626224/123062912-3abc1480-d40d-11eb-8c20-979919afd31b.png">

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
