### PR TITLE
fix: enable label click

### DIFF
--- a/packages/shared/styles/components/molecules/SfSelect.scss
+++ b/packages/shared/styles/components/molecules/SfSelect.scss
@@ -19,6 +19,7 @@
       top 150ms linear,
       font-size 150ms linear
     );
+    pointer-events: none;
     @include font(
       --select-label-font,
       var(--font-weight--normal),
@@ -44,7 +45,7 @@
       0 0 0 0,
       solid,
       var(--c-secondary)
-    );
+    );    
   }
   &__option {
     background: var(--select-option-background, var(--c-white));


### PR DESCRIPTION
# Related issue
Closes #1735 

# Scope of work
I think it's connected with label not with placeholder like it was mentioned in issue.  
Adding possibility to click on label in SfSelect when it's in initial state.

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
