### PR TITLE
fix: Impossible to access quantity during adding to cart 

### DIFF
--- a/packages/vue/src/components/organisms/SfProductCardHorizontal/SfProductCardHorizontal.stories.js
+++ b/packages/vue/src/components/organisms/SfProductCardHorizontal/SfProductCardHorizontal.stories.js
@@ -139,6 +139,10 @@ export default {
       action: "Wishlist clicked",
       table: { category: "Events" },
     },
+    input: {
+      action: "Quantity changed",
+      table: { category: "Events" },
+    },
   },
 };
 
@@ -166,8 +170,8 @@ const Template = (args, { argTypes }) => ({
     :wishlist-icon="wishlistIcon"
     :reviews-count="reviewsCount"
     :description="description"
-    :qty="qty"
-    @input="quantity = $event"
+    :qty="quantity"
+    @input="input"
     :is-on-wishlist-icon="isOnWishlistIcon"
     :is-on-wishlist="isOnWishlist"
     @click:add-to-cart="this['click:addToCart']"

--- a/packages/vue/src/components/organisms/SfProductCardHorizontal/SfProductCardHorizontal.vue
+++ b/packages/vue/src/components/organisms/SfProductCardHorizontal/SfProductCardHorizontal.vue
@@ -8,7 +8,10 @@
       >
         <SfLink
           :link="link"
-          class="sf-product-card-horizontal__link sf-product-card-horizontal__link--image"
+          class="
+            sf-product-card-horizontal__link
+            sf-product-card-horizontal__link--image
+          "
         >
           <template v-if="Array.isArray(image)">
             <SfImage
@@ -93,10 +96,10 @@
           <!--@slot Use this slot to replace add to cart-->
           <slot name="add-to-cart">
             <SfAddToCart
-              :qty="qty"
+              v-model="quantity"
               class="sf-product-card-horizontal__add-to-cart desktop-only"
               @input="$emit('input', $event)"
-              @click="$emit('click:add-to-cart')"
+              @click="$emit('click:add-to-cart', quantity)"
             />
           </slot>
         </div>
@@ -138,9 +141,6 @@ export default {
     SfLink,
     SfButton,
     SfAddToCart,
-  },
-  model: {
-    prop: "qty",
   },
   props: {
     /**
@@ -261,6 +261,11 @@ export default {
       type: [Number, String],
       default: 1,
     },
+  },
+  data() {
+    return {
+      quantity: this.qty,
+    };
   },
   computed: {
     currentWishlistIcon() {

--- a/packages/vue/src/stories/releases/v0.10.9/v0.10.9.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.9/v0.10.9.stories.mdx
@@ -8,3 +8,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 - E2E tests moved to nuxt directory
 - SfButton - disabled state made more inclusive
+- SfProductCardHorizontal - access to quantity during adding to cart


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
