### PR TITLE
fix: SfRange optional chaining removed

### DIFF
--- a/packages/vue/src/components/molecules/SfRange/SfRange.vue
+++ b/packages/vue/src/components/molecules/SfRange/SfRange.vue
@@ -44,15 +44,19 @@ export default {
   watch: {
     config: {
       handler(newConfig) {
-        this.$refs.range?.noUiSlider?.destroy();
-        const newSlider = this.noUiSliderInit(newConfig);
-        return newSlider;
+        if (this.$refs && this.$refs.range && this.$refs.range.noUiSlider) {
+          this.$refs.range.noUiSlider.destroy();
+          const newSlider = this.noUiSliderInit(newConfig);
+          return newSlider;
+        }
       },
       deep: true,
     },
     value: {
       handler(values) {
-        return this.$refs.range?.noUiSlider?.set(values);
+        if (this.$refs && this.$refs.range && this.$refs.range.noUiSlider) {
+          return this.$refs.range.noUiSlider.set(values);
+        }
       },
       immediate: true,
     },
@@ -61,7 +65,9 @@ export default {
     this.noUiSliderInit(this.config);
   },
   beforeDestroy() {
-    this.$refs.range?.noUiSlider?.destroy();
+    if (this.$refs && this.$refs.range && this.$refs.range.noUiSlider) {
+      this.$refs.range.noUiSlider.destroy();
+    }
   },
   methods: {
     noUiSliderInit(config) {

--- a/packages/vue/src/stories/releases/v0.10.9/v0.10.9.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.9/v0.10.9.stories.mdx
@@ -8,3 +8,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 - E2E tests moved to nuxt directory
 - SfButton - disabled state made more inclusive
+- SfRange - removed optional chaining


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
