### PR TITLE
add button feature for mobile

### DIFF
--- a/packages/shared/styles/components/molecules/SfBanner.scss
+++ b/packages/shared/styles/components/molecules/SfBanner.scss
@@ -97,4 +97,29 @@
       --banner-justify-content: flex-end;
     }
   }
+
+  @include for-mobile {
+    --banner-background-image: var(
+      --_banner-background-desktop-image,
+      var(--_banner-background-image)
+    );
+    --banner-wrapper-width: 50%;
+    --banner-description-display: block;
+    --banner-display-call-to-action: block;
+    --banner-title-margin: var(--spacer-sm) 0 0 0;
+    --banner-subtitle-color: var(--c-gray);
+    align-items: var(--banner-align-items, center);
+    min-height: var(--banner-height, 25rem);
+    &__wrapper {
+      pointer-events: none;
+    }
+    &__call-to-action {
+      --button-padding: var(--spacer-sm) var(--spacer-xl);
+      pointer-events: auto;
+    }
+    &--right {
+      --banner-justify-content: flex-end;
+    }
+  }
+
 }

--- a/packages/vue/src/components/molecules/SfBanner/SfBanner.vue
+++ b/packages/vue/src/components/molecules/SfBanner/SfBanner.vue
@@ -2,7 +2,6 @@
   <section
     class="sf-banner"
     :style="style"
-    v-on="isMobileView ? $listeners : {}"
   >
     <component :is="wrapper" class="sf-banner__wrapper" :link="link">
       <slot name="subtitle" v-bind="{ subtitle }">
@@ -22,11 +21,10 @@
       </slot>
       <slot name="call-to-action" v-bind="{ buttonText }">
         <SfButton
-          v-if="buttonText && !isMobileView"
+          v-if="buttonText"
           :link="link"
           class="sf-banner__call-to-action color-secondary"
           data-testid="banner-cta-button"
-          v-on="!isMobileView ? $listeners : {}"
         >
           {{ buttonText }}
         </SfButton>
@@ -107,7 +105,7 @@ export default {
       };
     },
     wrapper() {
-      return !this.isMobileView ? "div" : this.link ? "SfLink" : "SfButton";
+      return !this.isMobileView ? "div" : this.link ? "SfLink" : "";
     },
   },
   mounted() {


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #
https://github.com/vuestorefront/storefront-ui/issues/1934
# Scope of work
<!-- describe what you did -->
I made the button for SfBanner show up on mobile devices. SfBanner.vue and SfBanner.scss were changed. 

# Screenshots of visual changes
<!-- if visual changes applied -->
[
![sfbanner-mobile-compatible](https://user-images.githubusercontent.com/42985873/128565607-b10a1734-dda1-4373-af84-ebccb3b251c3.png)
](url)
# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
