### PR TITLE
fix: SfRadio not working on Safari 11 & older

### DIFF
--- a/packages/vue/src/components/molecules/SfRadio/SfRadio.vue
+++ b/packages/vue/src/components/molecules/SfRadio/SfRadio.vue
@@ -54,7 +54,7 @@ export default {
   },
   model: {
     prop: "selected",
-    event: "input",
+    event: "change",
   },
   props: {
     name: {

--- a/packages/vue/src/stories/releases/v0.10.9/v0.10.9.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.9/v0.10.9.stories.mdx
@@ -7,3 +7,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 ## 🚀 Features
 
 - E2E tests moved to nuxt directory
+
+## 🐛 Fixes
+
+- SfRadio: fixed to work on Safari 11 and older


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
