### PR TITLE
feat: provide an option to exclude closing button for SfNotification

### DIFF
--- a/packages/vue/src/components/molecules/SfNotification/SfNotification.stories.js
+++ b/packages/vue/src/components/molecules/SfNotification/SfNotification.stories.js
@@ -38,6 +38,13 @@ export default {
         category: "Props",
       },
     },
+    persistent: {
+      control: "boolean",
+      defaultValue: false,
+      table: {
+        category: "Props",
+      },
+    },
     type: {
       control: {
         type: "select",
@@ -62,6 +69,7 @@ const Template = (args, { argTypes }) => ({
   template: `
   <SfNotification
     :visible="visible"
+    :persistent="persistent"
     :title="title"
     :message="message"
     :action="action"
@@ -117,6 +125,12 @@ export const WithAction = Template.bind({});
 WithAction.args = {
   ...Common.args,
   action: "View cart",
+};
+
+export const Persistent = Template.bind({});
+Persistent.args = {
+  ...Common.args,
+  persistent: true,
 };
 
 export const UseIconSlot = (args, { argTypes }) => ({

--- a/packages/vue/src/components/molecules/SfNotification/SfNotification.vue
+++ b/packages/vue/src/components/molecules/SfNotification/SfNotification.vue
@@ -36,7 +36,7 @@
         </slot>
       </div>
       <!--@slot Custom notification close icon. Slot content will replace default close icon.-->
-      <slot name="close" v-bind="{ closeHandler }">
+      <slot v-if="!persistent" name="close" v-bind="{ closeHandler }">
         <SfButton
           aria-label="Close notification"
           class="sf-button--pure sf-notification__close"
@@ -62,6 +62,13 @@ export default {
      * Visibility of the Notification. Default value is false.
      */
     visible: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * Persistence of the Notification. Default value is false.
+     */
+    persistent: {
       type: Boolean,
       default: false,
     },

--- a/packages/vue/src/stories/releases/v0.10.9/v0.10.9.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.9/v0.10.9.stories.mdx
@@ -14,3 +14,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfRadio: fixed to work on Safari 11 and older
 - SfProductCardHorizontal - access to quantity during adding to cart
 - SfRange - removed optional chaining
+- SfNotification - added persistent prop to exclude closing button


### PR DESCRIPTION
# Related issue
Closes #1765

# Scope of work
Added persistent prop to render close slot conditionally.

# Checklist

- [x] No commented blocks of code left
- [ ] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 
