### PR TITLE
fix: gallery missing alt on zoom

### DIFF
--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
@@ -35,10 +35,11 @@
           <SfImage
             ref="imgZoom"
             class="sf-gallery__zoom"
-            :src="pictureSelected"
+            :src="pictureSelectedUrl"
             :width="imageWidth"
             :height="imageHeight"
             :lazy="false"
+            :alt="pictureSelected.alt"
           />
         </div>
       </transition>
@@ -150,7 +151,7 @@ export default {
     return {
       positionStatic: {},
       eventHover: {},
-      pictureSelected: "",
+      pictureSelected: { alt: "" },
       glide: null,
       activeIndex: this.current - 1,
       style: "",
@@ -166,6 +167,11 @@ export default {
     },
     updatedSliderOptions() {
       return { ...this.sliderOptions, startAt: this.activeIndex };
+    },
+    pictureSelectedUrl() {
+      const { zoom, big, desktop } = this.pictureSelected;
+      const definedPicture = zoom || big || desktop;
+      return definedPicture ? definedPicture.url : "";
     },
   },
   mounted() {
@@ -213,8 +219,7 @@ export default {
     },
     startZoom(picture) {
       if (this.enableZoom) {
-        const { zoom, big, desktop } = picture;
-        this.pictureSelected = (zoom || big || desktop).url;
+        this.pictureSelected = picture;
       }
     },
     moveZoom($event, index) {

--- a/packages/vue/src/stories/releases/v0.10.9/v0.10.9.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.9/v0.10.9.stories.mdx
@@ -47,3 +47,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfCart, SfDetailedCart: increasing quantity with "+" button fixed
 - SfImage: add dynamic styles to override default styles in ProductCard
 - add missing glob dependency to fix bug when adding SFUI to project on yarn2 in pnp mode
+- SfGallery - fix missing alt on a SfImage which displays the zoomed image when outsideZoom is enabled


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
