### PR TITLE
fix: bottom navigation adjusted the same wrapper size for the items

### DIFF
--- a/packages/shared/styles/components/organisms/SfBottomNavigation.scss
+++ b/packages/shared/styles/components/organisms/SfBottomNavigation.scss
@@ -4,55 +4,42 @@
   position: fixed;
   bottom: 0;
   left: 0;
-  z-index: var(--bottom-navigation-z-index, 1);
+  z-index: 1;
   display: flex;
   justify-content: space-around;
   align-items: flex-end;
   width: 100%;
-  height: var(--bottom-navigation-height, 3.75rem);
-  padding: var(--bottom-navigation-padding, 0 var(--spacer-sm));
-  background: var(--bottom-navigation-background, var(--c-white));
-  box-shadow: var(
-    --bottom-navigation-box-shadow,
-    0px -2px 10px rgba(var(--_c-gray-secondary-base), 0.15)
-  );
+  height: 3.75rem;
+  background: var(--c-white);
+  box-shadow: 0px -2px 10px rgba(var(--_c-gray-secondary-base), 0.15);
 }
 .sf-bottom-navigation-item {
   --icon-color: var(--c-link);
   background: transparent;
   border: 0;
-  top: var(--bottom-navigation-item-top);
-  display: flex;
+  flex: 1;
+  display: inline-flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  align-self: var(--bottom-navigation-item-align-self);
-  margin: var(--bottom-navigation-item-margin);
-  padding: var(
-    --bottom-navigation-item-padding,
-    var(--spacer-xs) 0 var(--spacer-xs) 0
-  );
-  color: var(--bottom-navigation-item-color, var(--c-link));
-  @include font(
-    --bottom-navigation-item-font,
-    var(--font-weight--light),
-    var(--font-size--xs),
-    1,
-    var(--font-family--primary)
-  );
+  padding: var(--spacer-xs) 0 var(--spacer-xs) 0;
+  color: var(--c-link);
+  font-weight: var(--font-weight--light);
+  font-size: var(--font-size--xs);
+  font-family: var(--font-family--primary);
+  cursor: pointer;
   & .sf-circle-icon {
     --button-size: 4.125rem;
   }
-  &__label {
-    margin: var(--bottom-navigation-item-label-margin);
-  }
   &.is-active {
+    color: var(--c-primary);
+    font-weight: var(--font-weight--normal);
     --icon-color: var(--c-primary);
-    --bottom-navigation-item-color: var(--c-primary);
-    --bottom-navigation-item-font-weight: var(--font-weight--normal);
   }
-  & .has-margin {
-    --bottom-navigation-item-label-margin: var(--spacer-xs) 0 0 0;
+  &__label {
+    &.has-margin {
+      margin: var(--spacer-xs) 0 0 0;
+    }
   }
   &__icon {
     background: transparent;
@@ -67,6 +54,6 @@
     }
   }
   &.center {
-    --bottom-navigation-item-align-self: center;
+    align-self: center;
   }
 }

--- a/packages/vue/src/stories/releases/v0.10.9/v0.10.9.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.10.9/v0.10.9.stories.mdx
@@ -47,3 +47,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfCart, SfDetailedCart: increasing quantity with "+" button fixed
 - SfImage: add dynamic styles to override default styles in ProductCard
 - add missing glob dependency to fix bug when adding SFUI to project on yarn2 in pnp mode
+- SfBottomNavigation - adjusted the same wrapper size for the items


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
