### PR TITLE
fix: accordion items can be opened when are closed by click

### DIFF
--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.stories.js
@@ -171,7 +171,7 @@ export const controlWithButtons = (args, { argTypes }) => ({
       :multiple="multiple"
       :show-chevron="showChevron"
       :transition="transition"
-      @click:open-header="change"
+      @click:open-header="change('')"
     >
       <SfAccordionItem 
         v-for="accordion in accordions" 

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
@@ -53,7 +53,7 @@ export default {
   },
   watch: {
     open(newValue, oldValue) {
-      if (newValue === oldValue) return;
+      if (!newValue || newValue === oldValue) return;
       const activeHeader = this.$children.find(
         (accordionItem) => accordionItem.header === newValue
       );
@@ -107,6 +107,13 @@ export default {
           return child._uid === slotId;
         });
         clickedHeader.isOpen = !clickedHeader.isOpen;
+      }
+      const headersAreClosed = this.$children
+        .map((header) => header.isOpen)
+        .every((header) => header === false);
+
+      if (headersAreClosed) {
+        this.openHeader = "";
       }
     },
   },

--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
@@ -51,6 +51,13 @@ export default {
       openHeader: this.open,
     };
   },
+  computed: {
+    headersAreClosed() {
+      return this.$children
+        .map((header) => header.isOpen)
+        .every((header) => header === false);
+    },
+  },
   watch: {
     open(newValue, oldValue) {
       if (!newValue || newValue === oldValue) return;
@@ -63,9 +70,11 @@ export default {
   mounted() {
     this.$on("toggle", this.toggleHandler);
     this.setAsOpen();
+    this.$emit("click:open-header");
   },
   updated() {
     this.setAsOpen();
+    this.$emit("click:open-header");
   },
   methods: {
     setAsOpen() {
@@ -97,7 +106,6 @@ export default {
           if (child._uid === slotId) {
             child.isOpen = !child.isOpen;
             this.openHeader = child.header;
-            this.$emit("click:open-header", child.header);
           } else {
             child.isOpen = false;
           }
@@ -108,11 +116,7 @@ export default {
         });
         clickedHeader.isOpen = !clickedHeader.isOpen;
       }
-      const headersAreClosed = this.$children
-        .map((header) => header.isOpen)
-        .every((header) => header === false);
-
-      if (headersAreClosed) {
+      if (this.headersAreClosed) {
         this.openHeader = "";
       }
     },


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
