### PR TITLE
fix: change calc functions to have negative value first

### DIFF
--- a/packages/nuxt-module/example/pages/index.vue
+++ b/packages/nuxt-module/example/pages/index.vue
@@ -355,7 +355,7 @@ export default {
   }
 }
 .carousel {
-  margin: 0 calc(var(--spacer-sm) * -1) 0 0;
+  margin: 0 calc(-1 * var(--spacer-sm)) 0 0;
   @include for-desktop {
     margin: 0;
   }

--- a/packages/shared/styles/components/atoms/SfChevron.scss
+++ b/packages/shared/styles/components/atoms/SfChevron.scss
@@ -31,7 +31,7 @@
         var(--chevron-translateX, 0),
         var(--chevron-translateY, -50%)
       )
-        rotate(calc(var(--chevron-rotate, 45deg) * -1));
+        rotate(calc(-1 * var(--chevron-rotate, 45deg)));
     }
   }
   &--top {

--- a/packages/shared/styles/components/atoms/SfInput.scss
+++ b/packages/shared/styles/components/atoms/SfInput.scss
@@ -22,7 +22,7 @@
     background: var(--input-label-background);
     transform: var(
       --input-label-transform,
-      translate3d(0, calc(var(--input-label-top, 50%) * -1), 0)
+      translate3d(0, calc(-1 * var(--input-label-top, 50%)), 0)
     );
     transition: var(
       --input-label-transition,

--- a/packages/shared/styles/components/molecules/SfComponentSelect.scss
+++ b/packages/shared/styles/components/molecules/SfComponentSelect.scss
@@ -53,7 +53,7 @@
     color: var(--component-select-label-color, var(--c-secondary-variant));
     transform: var(
       --component-select-label-transform,
-      translate3d(0, calc(var(--component-select-label-top, 50%) * -1), 0)
+      translate3d(0, calc(-1 * var(--component-select-label-top, 50%)), 0)
     );
     transition: var(
       --component-select-label-transition,

--- a/packages/shared/styles/components/molecules/SfSteps.scss
+++ b/packages/shared/styles/components/molecules/SfSteps.scss
@@ -49,7 +49,7 @@
     transform: var(
       --steps-progress-transform,
       scale3d(
-        calc(var(--_steps-progress-active-step) - 0.5),
+        calc(-0.5 + var(--_steps-progress-active-step)),
         1,
         1
       ));

--- a/packages/shared/styles/components/organisms/SfContentPages.scss
+++ b/packages/shared/styles/components/organisms/SfContentPages.scss
@@ -29,7 +29,7 @@
   &__sidebar {
     box-sizing: border-box;
     overflow-y: auto;
-    height: calc(100vh - 5rem);
+    height: calc(-5rem + 100vh);
   }
   &__sidebar {
     flex: var(--content-pages-sidebar-flex, 0 0 100%);

--- a/packages/shared/styles/components/templates/checkout/SfShipping.scss
+++ b/packages/shared/styles/components/templates/checkout/SfShipping.scss
@@ -67,7 +67,7 @@
       }
       &__radio-group {
         flex: 0 0 calc(100% + var(--spacer-sm));
-        margin: 0 calc(var(--spacer-sm) * -1);
+        margin: 0 calc(-1 * var(--spacer-sm));
       }
     }
   }

--- a/packages/vue/src/components/pages/checkout/_internal/Shipping.vue
+++ b/packages/vue/src/components/pages/checkout/_internal/Shipping.vue
@@ -325,7 +325,7 @@ export default {
     }
     &__radio-group {
       flex: 0 0 calc(100% + var(--spacer-sm));
-      margin: 0 calc(var(--spacer-sm) * -1);
+      margin: 0 calc(-1 * var(--spacer-sm));
     }
   }
 }

--- a/packages/vue/src/components/pages/home/Home.vue
+++ b/packages/vue/src/components/pages/home/Home.vue
@@ -349,7 +349,7 @@ export default {
   }
 }
 .carousel {
-  margin: 0 calc(var(--spacer-sm) * -1) 0 0;
+  margin: 0 calc(-1 * var(--spacer-sm)) 0 0;
   @include for-desktop {
     margin: 0;
   }

--- a/packages/vue/src/stories/getting-started/2. development guide/1. customization.stories.mdx
+++ b/packages/vue/src/stories/getting-started/2. development guide/1. customization.stories.mdx
@@ -101,7 +101,7 @@ CSS Custom Properties (or so called CSS variables) are extremely powerful and ha
     padding: 20px 0;
     @include for-desktop {
       padding: 20px;
-      max-width: calc(100% - 216px);
+      max-width: calc(-216px + 100%);
     }
   }
 }
@@ -115,7 +115,7 @@ And how it looks now, thanks to the power of CSS Custom Properties:
   @include for-desktop {
     margin: var(--spacer-base) 0;
     --carousel-padding: var(--spacer-base);
-    --carousel-max-width: calc(100% - 13.5rem);
+    --carousel-max-width: calc(-13.5rem + 100%);
   }
 }
 ```

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.0/v0.11.0.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.0/v0.11.0.stories.mdx
@@ -14,6 +14,7 @@ v0.11.0 contains API breaking changes and new features.
 
 ## 🐛 Fixes
 - SfCircleIcon: remove unused badge props
+- postcss-calc bug during building projects
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue

Closes #

# Scope of work
Fixing bugs when building projects, probably connected with postcss. 
Move negative values in every css `calc` function  to the first place e.g.
from:
```
margin: 0 calc(var(--spacer-sm)  *  -1);
```
to:
```
margin: 0 calc(-1 * var(--spacer-sm));
```


# Screenshots of visual changes
![Screenshot from 2021-09-29 14-22-25](https://user-images.githubusercontent.com/32042425/135457476-0086c06b-98f3-4e31-8256-14fe21ae488a.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
