### PR TITLE
feat: add aria-label to only icon and only image button

### DIFF
--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
@@ -51,6 +51,7 @@
           :key="'img-' + index"
           class="sf-button--pure sf-gallery__item"
           :class="{ 'sf-gallery__item--selected': index === activeIndex }"
+          :aria-label="'Image ' + index"
           @click="go(index)"
         >
           <SfImage

--- a/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.vue
+++ b/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.vue
@@ -13,6 +13,7 @@
     <slot name="icon">
       <SfButton
         class="sf-search-bar__button sf-button--pure"
+        aria-label="Search"
         @click="$emit('click', value)"
       >
         <span v-if="icon" class="sf-search-bar__icon">

--- a/packages/vue/src/components/molecules/SfSlidingSection/SfSlidingSection.vue
+++ b/packages/vue/src/components/molecules/SfSlidingSection/SfSlidingSection.vue
@@ -10,6 +10,7 @@
         <slot name="close" v-bind="{ closeHandler }">
           <SfButton
             class="sf-button--pure sf-sliding-section__close"
+            aria-label="Close"
             @click="closeHandler"
           >
             <SfIcon icon="cross" size="14px" />

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.vue
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.vue
@@ -55,6 +55,7 @@
                 v-if="accountIcon"
                 class="sf-button--pure sf-header__action"
                 data-testid="accountIcon"
+                aria-label="Account"
                 @click="$emit('click:account')"
               >
                 <SfIcon
@@ -69,6 +70,7 @@
                 v-if="wishlistIcon"
                 class="sf-button--pure sf-header__action"
                 data-testid="wishlistIcon"
+                aria-label="Wishlist"
                 @click="$emit('click:wishlist')"
               >
                 <SfIcon
@@ -86,6 +88,7 @@
                 v-if="cartIcon"
                 class="sf-button--pure sf-header__action"
                 data-testid="cartIcon"
+                aria-label="Cart"
                 @click="$emit('click:cart')"
               >
                 <SfIcon

--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
@@ -9,6 +9,7 @@
           :link="link"
           class="sf-button--pure sf-product-card__link"
           data-testid="product-link"
+          aria-label="Go To Product"
           v-on="$listeners"
         >
           <template v-if="Array.isArray(image)">


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1940

# Scope of work
<!-- describe what you did -->
added aria-label to button (SfButton) that has no text and only has icon or image

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
