### PR TITLE
SfAddressPicker center icon inside circle container

### DIFF
--- a/packages/shared/styles/components/molecules/SfAddressPicker.scss
+++ b/packages/shared/styles/components/molecules/SfAddressPicker.scss
@@ -31,6 +31,9 @@
   &__icon {
     --icon-color: var(--c-white);
     --icon-size: 0.875rem;
+    svg {
+      display: block;
+    }
   }
   &.sf-radio {
     --radio-content-margin: 0;

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.1/v0.11.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.1/v0.11.1.stories.mdx
@@ -12,6 +12,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
+- SfAddressPicker: center icon inside circle container
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1982

# Scope of work
css: adding display block to icon

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/7550130/136171709-49791ac2-5d6c-4470-840c-b38eb2f56fec.png)

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
