### PR TITLE
fix: attribute link not allowed on element button

### DIFF
--- a/packages/vue/src/components/atoms/SfButton/SfButton.stories.js
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.stories.js
@@ -47,9 +47,12 @@ export default {
     },
     link: {
       control: "text",
-      defaultValue: "",
+      defaultValue: undefined,
       table: {
         category: "Props",
+        defaultValue: {
+          summary: "null",
+        },
       },
       description: "Link for 'a' tag.",
     },

--- a/packages/vue/src/components/atoms/SfButton/SfButton.vue
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.vue
@@ -15,7 +15,7 @@
     ]"
     :style="[data.style, data.staticStyle]"
     :aria-disabled="props.disabled"
-    :link="props.link"
+    :link="props.link || null"
     v-bind="data.attrs"
     v-on="!props.disabled ? listeners : {}"
   >

--- a/packages/vue/src/components/atoms/SfButton/SfButton.vue
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.vue
@@ -15,7 +15,7 @@
     ]"
     :style="[data.style, data.staticStyle]"
     :aria-disabled="props.disabled"
-    :link="props.link || null"
+    :link="props.link"
     v-bind="data.attrs"
     v-on="!props.disabled ? listeners : {}"
   >
@@ -43,7 +43,7 @@ export default {
     },
     link: {
       type: [String, Object],
-      default: "",
+      default: null,
     },
   },
   linkActive(link, disabled) {

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.2/v0.11.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.2/v0.11.2.stories.mdx
@@ -13,7 +13,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 ## 🐛 Fixes
 
 - SfBadge, SfChevron, SfImage, SfBanner, SfHero, SfFooter, Home, SfProductCard: divs inside buttons changed on allowed elements
-- SfButton: link attribute isn't added to SfButton if there's no link passed by link prop 
+- SfButton: link default value changed to null
 
 ## 🧹 Chores:
 

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.2/v0.11.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.2/v0.11.2.stories.mdx
@@ -13,6 +13,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 ## 🐛 Fixes
 
 - SfBadge, SfChevron, SfImage, SfBanner, SfHero, SfFooter, Home, SfProductCard: divs inside buttons changed on allowed elements
+- SfButton: link attribute isn't added to SfButton if there's no link passed by link prop 
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2064 

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes

![Screenshot from 2021-10-29 13-08-59](https://user-images.githubusercontent.com/46591755/139424683-9325461d-ce3d-41b0-b65a-65b578ca8a2f.png)

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
