### PR TITLE
fix: discord links, become a contributor page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ However, there are several general guidelines, FQAs and rules we would like you 
 
 ## What kind of issues should I start?
 
-Any of our [Github issues](https://github.com/DivanteLtd/storefront-ui/issues), which have **no assignee**. In case there is someone assigned to it and there has been a while since their last update, feel free to ping any of our core maintainers by leave a comment inside the ticket, or in our [Discord channel](https://discord.gg/GS8hqFS)
+Any of our [Github issues](https://github.com/DivanteLtd/storefront-ui/issues), which have **no assignee**. In case there is someone assigned to it and there has been a while since their last update, feel free to ping any of our core maintainers by leave a comment inside the ticket, or in our [Discord channel](https://discord.com/invite/TJpdzzN6q5)
 
 Also, we label some issues with label `hackotoberfest` for easy and smooth start, you can refer to the [relevant list of issues here](https://github.com/DivanteLtd/storefront-ui/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest)
 
@@ -27,7 +27,7 @@ If you can't handle some parts of the issue feel free to ask in the comment. It'
 ## Rules
 
 1. **No** spam allowed. Such activities will be labeled as `invalid` and you will be blocked from contributing.
-2. Spam also includes unwanted fixes such as removing commas, changing texts, adding comments, removing codes where we do not ask for. If you see something needs attention on docs and not reported, please raise the question the **#docs** channel of [our Discord Server](https://discord.gg/GS8hqFS), and/or open a Github issue before making a PR.
+2. Spam also includes unwanted fixes such as removing commas, changing texts, adding comments, removing codes where we do not ask for. If you see something needs attention on docs and not reported, please raise the question the **#docs** channel of [our Discord Server](https://discord.com/invite/TJpdzzN6q5), and/or open a Github issue before making a PR.
 3. **Do not** use `asap` word (as soon as possible) in communicating about PR review. Unless it's a hot fix, your fixes will only be available when we release a new version, and that won't happen the same day of your PR. Also, it makes maintainers and code reviewers uncomfortable. There is a buffer of minimum 24 hours before a maintainer start reviewing your code. Please be patient 😉.
 4. **Do not** ping any maintainer *especially* during weekends. Everyone needs to have a life and family time 😄.
 5. If you know it's a holiday for a specific maintainer, please **do not** ping him/her directly on that day regardless. It's called **consideration**.

--- a/packages/vue/src/stories/contributing-guide/1. contribute.stories.mdx
+++ b/packages/vue/src/stories/contributing-guide/1. contribute.stories.mdx
@@ -43,8 +43,8 @@ We want you to have fun contributing with us, so let's go over a few important g
         <a href="#contribute-code">Contribute Code</a>
       </li>
       <li>
-        <a href="#report-bug-or-request-a-feature">
-          Report bug or request a feature
+        <a href="#report-a-bug-or-request-a-feature">
+          Report a bug or request a feature
         </a>
       </li>
       <li>
@@ -59,7 +59,7 @@ We want you to have fun contributing with us, so let's go over a few important g
 
 ## Important resources
 
-- [Our Discord Server](https://discord.gg/GS8hqFS) - This is the place where we discussed about new features, exchanging questions between the core team, contributors (`#contributors`) and StorefrontUI users.
+- [Our Discord Server](https://discord.com/invite/TJpdzzN6q5) - This is the place where we discussed about new features, exchanging questions between the core team, contributors (`#contributors`) and StorefrontUI users.
 - [Our component storybook](https://storybook.storefrontui.io/) - Playground for our components
 - [Our current issues](https://github.com/DivanteLtd/storefront-ui/issues) - Where we keep track of all the bugs, feature requests reported by our community members.
 - [Our current Roadmap](https://github.com/DivanteLtd/storefront-ui/blob/develop/ROADMAP.md) - The status of our library in long term.
@@ -98,41 +98,41 @@ We selected this strategy to enable the reusability of resources between future 
   <h5>WORK WITH GITHUB</h5>
   <p>
     StorefrontUI is a Github repository. If you are new to Github, please check{" "}
-    <a href="">our Github guidelines</a> for instructions.
+    <a href="?path=/story/contributing-guide-guide-working-with-github--page">our Github guidelines</a> for instructions.
   </p>
 </div>
 
-Anything for a better StorefrontUI and bulding the community is considered contributions :wink:, which include:
+Anything for a better StorefrontUI and building the community is considered contributions 😉, which include:
 
 ### Contribute Code
 
-We have a lot of features that need good helping hand, as always. However, there are coding rules you need to follow, for maintaining readability and for us to process your pull request as quickly as possible. Please read [our code contributing guide](?path=/story/introduction-contributing-guide-code-guidelines--page#coding-guidelines).
+We have a lot of features that need a good helping hand, as always. However, there are coding rules you need to follow, for maintaining readability and for us to process your pull request as quickly as possible. Please read [our code contributing guide](?path=/story/contributing-guide-guide-code-guidelines--page).
 
-Then you'll be ready to [pick your first issue](https://github.com/DivanteLtd/storefront-ui/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) and contribute to [StorefrontUI](https://github.com/DivanteLtd/storefront-ui) core respository.
+Then you'll be ready to [pick your first issue](https://github.com/DivanteLtd/storefront-ui/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) and contribute to [StorefrontUI](https://github.com/DivanteLtd/storefront-ui) core repository.
 
 <div class="alert tip">
   <h5>DON'T KNOW WHICH ISSUE TO SELECT?</h5>
   <p>
     We <b>have our issues labelled</b> to make it easier in selecting an issue
-    to work with. You can also check about{" "}
-    <a href="?path=/story/introduction-contributing-guide-working-with-github--page--page#_3-select-a-github-issue">
+    to work with. You can also check{" "}
+    <a href="?path=/story/contributing-guide-guide-working-with-github--page#3-select-a-github-issue">
       our labels system
     </a>{" "}
     for more information.
   </p>
 </div>
 
-### Report bug or request a feature
+### Report a bug or request a feature
 
 Our goal is to make StorefrontUI customisable as much as possible. Hence issue reporting, either a bug or a feature request, is extremely valuable to us.
 
-In order to maintain an effective workflow and make sure all issues reported will be solved, we'd like you to follow [some simple guidelines]((?path=/story/introduction-contributing-guide-how-to-report-an-issue--page).
+In order to maintain an effective workflow and make sure all issues reported will be solved, we'd like you to follow [some simple guidelines](?path=/story/contributing-guide-guide-how-to-report-an-issue--page).
 
-If you are sure your issue is a bug, or a valid feature request, [file a new issue in our Github issue tracker](https://github.com/DivanteLtd/storefront-ui/issues/new) following the [template](issue-report-guidelines#issue-template) and guidelines.
+If you are sure your issue is a bug, or a valid feature request, [file a new issue in our Github issue tracker](https://github.com/vuestorefront/storefront-ui/issues/new/choose) following the [template](?path=/story/contributing-guide-guide-how-to-report-an-issue--page#issue-template) and guidelines.
 
 ### Work on Documentation
 
-Good and friendly documentation is **extremly significant** for our community, for every reason. Currently we have lots of work needed to be done on this matter. Would you like to help us a hand to build the best documentation? 😉
+Good and friendly documentation is **extremely significant** for our community, for every reason. Currently, we have lots of work needed to be done on this matter. Would you like to help us a hand to build the best documentation? 😉
 
 StorefrontUI aims to be an international community, with the core team coming from different timezones across the globe. Thus, we are actively looking for contributors on the following:
 
@@ -142,17 +142,17 @@ StorefrontUI aims to be an international community, with the core team coming fr
 
 - **Fix current documentation** (on dictation error, word usage, etc)
 
-- **Write documentation** for our components, or [select an docs issue](https://github.com/DivanteLtd/storefront-ui/issues?q=is%3Aopen+is%3Aissue+label%3Adocs) to start.
+- **Write documentation** for our components, or [select a docs issue](https://github.com/DivanteLtd/storefront-ui/issues?q=is%3Aopen+is%3Aissue+label%3Adocs) to start.
 
 <div class="alert warning">
   <h5>WORK WITH DOCUMENTATION</h5>
   <p>
     Certainly, make sure you read and follow{" "}
-    <a href="">our documentation guidelines</a> for instructions.
+    <a href="?path=/story/contributing-guide-guide-documentation-guidelines--page">our documentation guidelines</a> for instructions.
   </p>
 </div>
 
-### Speard the words
+### Spread the words
 
 There is a lot more you can help StorefrontUI community grow besides the above:
 
@@ -160,6 +160,6 @@ There is a lot more you can help StorefrontUI community grow besides the above:
 
 - **Talk** about how awesome StorefrontUI is to you in a conference, meetup or simple at your work 😉.
 
-- **Integrate** StorefrontUI with other awesome frameworks, such as Nuxt.js, Gridsome.js. Write a StorefrontUI plugin for any of the frameworks you work with, and we will love to add it in our ecosystem.
+- **Integrate** StorefrontUI with other awesome frameworks, such as Nuxt.js, Gridsome.js. Write a StorefrontUI plugin for any of the frameworks you work with, and we will love to add it to our ecosystem.
 
-If you have any question on how you can be more involved in contributing other than these, reach out to us [@StorefrontUI](https://twitter.com/StorefrontUI) or in [our Discord Server](https://discord.gg/GS8hqFS)
+If you have any question on how you can be more involved in contributing other than these, reach out to us [@StorefrontUI](https://twitter.com/StorefrontUI) or in [our Discord Server](https://discord.com/invite/TJpdzzN6q5)

--- a/packages/vue/src/stories/contributing-guide/2. github.stories.mdx
+++ b/packages/vue/src/stories/contributing-guide/2. github.stories.mdx
@@ -254,7 +254,7 @@ We recommend first-time contributor to select issues with label `Good first issu
 <div class="alert tip" >
   <h5>ANY TROUBLE?</h5>
   <p>
-    Feeling some issue's level <b>does not</b> match the label assigned? <a href="https://discord.gg/GS8hqFS">Drop us a message in Discord</a> or leave a comment inside the issue.
+    Feeling some issue's level <b>does not</b> match the label assigned? <a href="https://discord.com/invite/TJpdzzN6q5">Drop us a message in Discord</a> or leave a comment inside the issue.
   </p>
 
 </div>
@@ -336,7 +336,7 @@ If this is your first time in StorefrontUI codebase, you need to either:
 
 or
 
-- **copy the link** to the issue and \*\*drop it" inside [Discord server - #contributors](https://discord.gg/GS8hqFS) with a note that you'd like to take it.
+- **copy the link** to the issue and \*\*drop it" inside [Discord server - #contributors](https://discord.com/invite/TJpdzzN6q5) with a note that you'd like to take it.
 
 And we will make sure it happen.
 

--- a/packages/vue/src/stories/contributing-guide/9. issue-report.stories.mdx
+++ b/packages/vue/src/stories/contributing-guide/9. issue-report.stories.mdx
@@ -42,7 +42,7 @@ As part of maintaining our OSS workflow, StorefrontUI uses Github issue tracker 
 
 <div class="alert warning">
 
-- It is **NOT** for requesting personal support or asking a question. Use [our Discord Server](https://discord.gg/GS8hqFS) or [Stack Overflow](https://stackoverflow.com) or even [Twitter](https://twitter.com/home).
+- It is **NOT** for requesting personal support or asking a question. Use [our Discord Server](https://discord.com/invite/TJpdzzN6q5) or [Stack Overflow](https://stackoverflow.com) or even [Twitter](https://twitter.com/home).
 - It is **NOT** for social media, respect others' opinions, and proper languages are **required**.
 
 </div>
@@ -60,7 +60,7 @@ Please do the following checks:
 
 - **Double-check** [the current issues](https://github.com/DivanteLtd/storefront-ui/issues) with the help of Github issue search, to avoid report duplication.
 - If it is an issue about **component behavior**, check our [Components Playground](http://storybook.storefrontui.io) or [Components Documentation](/components/Accordion.md) to make sure it is indeed a bug 🐛 and not an intended feature.
-- If it's about **technical questions** or just to **verify it is technical related**, refer to our [Discord Server](https://discord.gg/GS8hqFS) first. Our contributors and core team will be more than happy to help.
+- If it's about **technical questions** or just to **verify it is technical related**, refer to our [Discord Server](https://discord.com/invite/TJpdzzN6q5) first. Our contributors and core team will be more than happy to help.
 - Besides, if it is about **feature request**, refer to our current [Roadmap](https://github.com/vuestorefront/storefront-ui/blob/develop/ROADMAP.md) to see if your request exists.
 
 Once you verify your issue from the above checks, it's time to create a new report using [Github issue tracker](https://github.com/DivanteLtd/storefront-ui/issues/new) with the right template recommendations below.
@@ -85,7 +85,7 @@ OSS projects can't live without improvements 😉. So feature requests are alway
 
 <div class="alert warning">
 
-Please take a moment to validate if your request is within the scope of StorefrontUI by contacting us on [Discord Server](https://discord.gg/GS8hqFS), or DM to [@StorefronUI](https://twitter.com/StorefrontUI)
+Please take a moment to validate if your request is within the scope of StorefrontUI by contacting us on [Discord Server](https://discord.com/invite/TJpdzzN6q5), or DM to [@StorefronUI](https://twitter.com/StorefrontUI)
 
 </div>
 
@@ -172,4 +172,4 @@ In addition to the above fields, more information may be required to speed up bu
 
 ---
 
-Interested in becoming contributors? Reach out to us [@StorefrontUI](https://twitter.com/StorefrontUI) or in [our Discord Server](https://discord.gg/GS8hqFS) 🔥
+Interested in becoming contributors? Reach out to us [@StorefrontUI](https://twitter.com/StorefrontUI) or in [our Discord Server](https://discord.com/invite/TJpdzzN6q5) 🔥

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.2/v0.11.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.2/v0.11.2.stories.mdx
@@ -18,4 +18,5 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfButton: link default value changed to null
 
 ## 🧹 Chores:
-
+- docs: fix discord invitation links
+- docs(Become a Contributor): fix typos, links, grammar


### PR DESCRIPTION
# Related issue
There is no related issue.

# Scope of work

- fix all discord invitation links
- fix typos, grammar mistakes and links on _Become a Contributor_ page 

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [X] No commented blocks of code left
- [X] Run tests and docs
- [X] Self code-reviewed
- [X] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
   
# Questions for maintainers

- What does `{" "} ` do?
- I don't think there is the main documentation under the docs folder. This statement may be wrong.

> vue - This is the main project that contains main Storefront UI Vue components code in src, storybook config in config, customized scripts in scripts and main documentation written in vuepress will be found in docs.
