### PR TITLE
refactor: detecting active page in SfContentPages regardless of the casing

### DIFF
--- a/packages/vue/src/components/organisms/SfContentPages/SfContentPages.spec.js
+++ b/packages/vue/src/components/organisms/SfContentPages/SfContentPages.spec.js
@@ -17,4 +17,20 @@ describe("SfContentPages.vue", () => {
     });
     expect(component.classes("sf-content-pages")).toBe(true);
   });
+
+  it("marks menu-item slot as active when active and page.title casing differs", () => {
+    const component = mount(SfContentPages, {
+      propsData: {
+        active: "My Title",
+      },
+      data() {
+        return {
+          items: [{ title: "my title" }],
+        };
+      },
+    });
+
+    const menuItem = component.find(".sf-content-pages__menu");
+    expect(menuItem.classes()).toContain("is-active");
+  });
 });

--- a/packages/vue/src/components/organisms/SfContentPages/SfContentPages.vue
+++ b/packages/vue/src/components/organisms/SfContentPages/SfContentPages.vue
@@ -28,7 +28,7 @@
               <!-- @slot Custom menu-item markup -->
               <slot name="menu-item" v-bind="{ updatePage, page, active }">
                 <SfMenuItem
-                  :class="{ 'is-active': page.title === active }"
+                  :class="{ 'is-active': isPageActive(page) }"
                   :label="page.title"
                   class="sf-content-pages__menu"
                   @click="updatePage(page.title)"
@@ -149,6 +149,9 @@ export default {
        */
       this.$emit("click:change", title);
     },
+    isPageActive (page) {
+      return page.title.toLowerCase() === this.active.toLowerCase();
+    }
   },
 };
 </script>

--- a/packages/vue/src/components/organisms/SfContentPages/_internal/SfContentPage.spec.js
+++ b/packages/vue/src/components/organisms/SfContentPages/_internal/SfContentPage.spec.js
@@ -20,4 +20,29 @@ describe("SfContentPage.vue", () => {
     });
     expect(component.classes("sf-content-page")).toBe(true);
   });
+  it("compares page title and provided active with different casing correctly", () => {
+    const testClass = "visible-when-active";
+    const component = shallowMount(SfContentPage, {
+      slots: {
+        default: `<div class="${testClass}" />`,
+      },
+      propsData: {
+        title: "My Title",
+      },
+      provide: {
+        provided: {
+          active: "my title",
+        },
+      },
+      parentComponent: {
+        data() {
+          return {
+            items: [],
+          };
+        },
+      },
+    });
+    const testDiv = component.find(`.${testClass}`);
+    expect(testDiv.exists()).toBe(true);
+  });
 });

--- a/packages/vue/src/components/organisms/SfContentPages/_internal/SfContentPage.vue
+++ b/packages/vue/src/components/organisms/SfContentPages/_internal/SfContentPage.vue
@@ -26,7 +26,7 @@ export default {
   inject: ["provided"],
   computed: {
     isActive() {
-      return this.provided.active === this.title;
+      return this.provided.active.toLowerCase() === this.title.toLowerCase();
     },
   },
   mounted() {

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.3/v0.11.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.3/v0.11.3.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.11.x - Latest Minor/v0.11.3 - Latest/Change log" />
+
+# v0.11.3
+
+## ❗ Breaking Changes
+
+## 🔨 Refactors
+- SfContentPages: Detecting active page regardless of the casing
+
+## 🚀 Features
+
+## 🐛 Fixes
+
+## 🧹 Chores:


### PR DESCRIPTION
# Scope of work
<!-- describe what you did -->
In our core repository we have a page component `MyAccount.vue`. We're using `SfContentPages` there to display content pages depending on the slug that comes after the `/my-account` part.

We can pass an unlimited number of content pages there. Which one should be displayed is determined by two things: 
- the `active` prop passed to the `SfContentPages` component
- the `title` prop passed to `SfContentPage` components passed as slots

```
<SfContentPages active="...">
  <SfContentCategory title="Personal Details">
    <SfContentPage title="...">
      <MyProfile />
    </SfContentPage>
 </SfContentCategory>
</SfContentPages>
```
The problem is, the values of the `active` and `title` props might now always have a matching casing even if they're supposed to point to the same page. For example, in `MyAccount.vue` we can observe that the `active` prop is derived from the `$route.params.pageName` which is all lowercase.

We're currently capitalizing it there so that the matching is done correctly: 
```
const activePage = computed(() => {
  const { pageName } = $route.params;
  if (pageName) {
    return (pageName.charAt(0).toUpperCase() + pageName.slice(1)).replace('-', ' ');
  } else if (!isMobile.value) {
    return 'My profile';
  } else {
    return '';
  }
});
```

However, making it work would not be possible if I wanted to have some pages' titles with only the first word capitalized and some with all pages capitalized (i.e. "My Page Title" vs "My page title"). Therefore, I believe it would be more generic if we compared the `active` and `title` props with both values converted to lower case.
 
# Screenshots of visual changes
<!-- if visual changes applied -->
![image](https://user-images.githubusercontent.com/39009379/140712861-4bed884b-7c5b-46cb-9b80-675b77fe0032.png)

![image](https://user-images.githubusercontent.com/39009379/140712906-e326dd3d-a06a-468d-af17-fdf8ca9d0b02.png)
# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
