### PR TITLE
bug: typo in SfBanner component

### DIFF
--- a/packages/vue/src/components/molecules/SfBanner/SfBanner.vue
+++ b/packages/vue/src/components/molecules/SfBanner/SfBanner.vue
@@ -11,9 +11,9 @@
         </span>
       </slot>
       <slot name="title" v-bind="{ title }">
-        <sapn v-if="title" class="sf-banner__title">
+        <span v-if="title" class="sf-banner__title">
           {{ title }}
-        </sapn>
+        </span>
       </slot>
       <slot name="description" v-bind="{ description }">
         <span v-if="description" class="sf-banner__description">


### PR DESCRIPTION


# Scope of work
Fix typo in SfBanner component.

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
