### PR TITLE
fix: SfArrow layout in storybook and add changelog note

### DIFF
--- a/packages/vue/src/components/atoms/SfArrow/SfArrow.stories.js
+++ b/packages/vue/src/components/atoms/SfArrow/SfArrow.stories.js
@@ -4,12 +4,64 @@ export default {
   title: "Components/Atoms/Arrow",
   component: SfArrow,
   parameters: {
-    cssprops: {"arrow-justify-content":{"value":"center","control":"text"},"arrow-icon-transform":{"value":"","control":"text"},"button-width":{"value":"2.75rem","description":"Overridden other component's CSS variable","control":"text"},"button-height":{"value":"2.75rem","description":"Overridden other component's CSS variable","control":"text"},"button-padding":{"value":"0 0.625rem","description":"Overridden other component's CSS variable","control":"text"},"button-background":{"value":"var(--c-light)","description":"Overridden other component's CSS variable","control":"text"},"button-transition":{"value":"background 150ms linear","description":"Overridden other component's CSS variable","control":"text"},"icon-color":{"value":"var(--c-dark)","description":"Overridden other component's CSS variable","control":"text"},"button-box-shadow":{"value":"0px 4px 4px var(--c-black)","description":"Overridden other component's CSS variable","control":"text"},"box-shadow-transition-opacity-duration":{"value":"150ms","description":"Overridden other component's CSS variable","control":"text"},"button-box-shadow-opacity":{"value":"0.25","description":"Overridden other component's CSS variable","control":"text"},"button-border-radius":{"value":"100%","description":"Overridden other component's CSS variable","control":"text"}},
+    cssprops: {
+      "arrow-justify-content": { value: "center", control: "text" },
+      "arrow-icon-transform": { value: "", control: "text" },
+      "button-width": {
+        value: "2.75rem",
+        description: "Overridden other component's CSS variable",
+        control: "text",
+      },
+      "button-height": {
+        value: "2.75rem",
+        description: "Overridden other component's CSS variable",
+        control: "text",
+      },
+      "button-padding": {
+        value: "0 0.625rem",
+        description: "Overridden other component's CSS variable",
+        control: "text",
+      },
+      "button-background": {
+        value: "var(--c-light)",
+        description: "Overridden other component's CSS variable",
+        control: "text",
+      },
+      "button-transition": {
+        value: "background 150ms linear",
+        description: "Overridden other component's CSS variable",
+        control: "text",
+      },
+      "icon-color": {
+        value: "var(--c-dark)",
+        description: "Overridden other component's CSS variable",
+        control: "text",
+      },
+      "button-box-shadow": {
+        value: "0px 4px 4px var(--c-black)",
+        description: "Overridden other component's CSS variable",
+        control: "text",
+      },
+      "box-shadow-transition-opacity-duration": {
+        value: "150ms",
+        description: "Overridden other component's CSS variable",
+        control: "text",
+      },
+      "button-box-shadow-opacity": {
+        value: "0.25",
+        description: "Overridden other component's CSS variable",
+        control: "text",
+      },
+      "button-border-radius": {
+        value: "",
+        description: "Overridden other component's CSS variable",
+        control: "text",
+      },
+    },
     docs: {
       description: {
-        component:
-          `Arrow component for sliders and navigation. It's Vue 2 functional component. To see css vars used in component please switch to canvas and CSS Custom Properties tab.`,
-      },      
+        component: `Arrow component for sliders and navigation. It's Vue 2 functional component. To see css vars used in component please switch to canvas and CSS Custom Properties tab.`,
+      },
     },
   },
   argTypes: {

--- a/packages/vue/src/components/organisms/SfMegaMenu/SfMegaMenu.stories.js
+++ b/packages/vue/src/components/organisms/SfMegaMenu/SfMegaMenu.stories.js
@@ -77,13 +77,13 @@ export default {
         control: "text",
       },
       "mega-menu-column-content-position": {
-        value: "absolute",
+        value: "",
         control: "text",
       },
       "mega-menu-column-content-top": { value: "0", control: "text" },
       "mega-menu-column-content-display": { value: "", control: "text" },
       "mega-menu-column-content-transform": {
-        value: "translateX(100%)",
+        value: "",
         control: "text",
       },
       "list-item-padding": {

--- a/packages/vue/src/components/organisms/SfTabs/SfTabs.stories.js
+++ b/packages/vue/src/components/organisms/SfTabs/SfTabs.stories.js
@@ -13,11 +13,10 @@ export default {
       "tabs-title-padding": { value: "var(--spacer-sm)", control: "text" },
       "tabs-title-background": { value: "", control: "text" },
       "tabs-title-border": {
-        value:
-          "var(--tabs-title-border-style, solid) var(--tabs-title-border-color, var(--c-light))",
+        value: "",
         control: "text",
       },
-      "tabs-title-border-width": { value: "0 0 1px 0", control: "text" },
+      "tabs-title-border-width": { value: "", control: "text" },
       "tabs-title-color": { value: "", control: "text" },
       "tabs-title-font": { value: "", control: "text" },
       "tabs-title-font-weight": {
@@ -66,7 +65,7 @@ export default {
         control: "text",
       },
       "tabs-title-border-color": {
-        value: "var(--c-text)",
+        value: "",
         control: "text",
       },
     },

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.2/v0.11.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.2/v0.11.2.stories.mdx
@@ -21,3 +21,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🧹 Chores:
 - SfRadio, SfCheckbox: replaced divs with span for a11y reasons
+- docs: add new addon with css vars list 


### PR DESCRIPTION
# Scope of work

1. add changelog note for adding css vars docs. 
2. fix SfArrow, SfMegaMenu and SfTabs layout when switching to css custom properties tab.

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
