### PR TITLE
fix: SfButton as link - full width is not working

### DIFF
--- a/packages/shared/styles/components/atoms/SfButton.scss
+++ b/packages/shared/styles/components/atoms/SfButton.scss
@@ -210,4 +210,7 @@
       --button-background: transparent;
     }
   }
+  &.sf-button--full-width {
+    --button-width: 100%;
+  }
 }

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.3/v0.11.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.3/v0.11.3.stories.mdx
@@ -12,5 +12,6 @@ import { Meta } from "@storybook/addon-docs/blocks";
 ## 🚀 Features
 
 ## 🐛 Fixes
+-SfButton: link button was not setup as full width
 
 ## 🧹 Chores:


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1715

# Scope of work
- fixed issue with specificity
# Screenshots of visual changes
<img width="605" alt="Zrzut ekranu 2021-11-10 o 15 55 53" src="https://user-images.githubusercontent.com/41487496/141136371-65da5801-f2da-434b-9113-8a32969231a5.png">


# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
