### PR TITLE
fix: SfComponentSelect - add cancelLabel prop and binding for cancel slot

### DIFF
--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
@@ -242,6 +242,19 @@ export default {
       defaultValue: "",
       description: "The content of the option",
     },
+    cancelLabel: {
+      control: "text",
+      table: {
+        category: "Props for main component",
+        type: {
+          summary: "string",
+        },
+        defaultValue: {
+          summary: "Cancel",
+        },
+      },
+      description: "Cancel label text",
+    },
     options: {
       control: "array",
       description:

--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
@@ -282,6 +282,7 @@ const Template = (args, { argTypes }) => ({
     :disabled="disabled"
     :error-message="errorMessage"
     :persistent="persistent"
+    :cancel-label="cancelLabel"
     style="max-width: 30rem"
   >
     <SfComponentSelectOption v-for="(option, key) in options" :key="key" :value="option.value">
@@ -352,6 +353,7 @@ export const UseLabelSlot = (args, { argTypes }) => ({
     :valid="valid"
     :disabled="disabled"
     :error-message="errorMessage" 
+    :cancel-label="cancelLabel"
     :persistent="persistent"       
     >
     <SfComponentSelectOption v-for="(option, key) in options" :key="key" :value="option.value">
@@ -381,6 +383,7 @@ export const UseErrorMessageSlot = (args, { argTypes }) => ({
     :disabled="disabled"
     :error-message="errorMessage"
     :persistent="persistent"
+    :cancel-label="cancelLabel"
     >
     <SfComponentSelectOption v-for="(option, key) in options" :key="key" :value="option.value">
       <SfProductOption :color="option.color" :label="option.label"></SfProductOption>
@@ -407,6 +410,7 @@ export const UseCancelSlot = (args, { argTypes }) => ({
     :disabled="disabled"
     :error-message="errorMessage"
     :persistent="persistent"
+    :cancel-label="cancelLabel"
     >
     <SfComponentSelectOption v-for="(option, key) in options" :key="key" :value="option.value">
       <SfProductOption :color="option.color" :label="option.label"></SfProductOption>

--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
@@ -253,6 +253,7 @@ export default {
           summary: "Cancel",
         },
       },
+      defaultValue: "",
       description: "Cancel label text",
     },
     options: {

--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.vue
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.vue
@@ -52,7 +52,7 @@
           >
             <slot />
           </ul>
-          <slot name="cancel">
+          <slot name="cancel" v-bind="{ cancelLabel, cancelHandler }">
             <SfButton
               ref="cancel"
               class="
@@ -62,7 +62,7 @@
               "
               @click="closeHandler"
             >
-              Cancel
+              {{ cancelLabel }}
             </SfButton>
           </slot>
         </div>
@@ -131,6 +131,10 @@ export default {
     persistent: {
       type: Boolean,
       default: false,
+    },
+    cancelLabel: {
+      type: String,
+      default: "Cancel",
     },
   },
   data() {
@@ -256,6 +260,7 @@ export default {
     },
     closeHandler() {
       this.open = false;
+      this.$emit("click:close");
     },
   },
 };

--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.vue
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.vue
@@ -52,7 +52,7 @@
           >
             <slot />
           </ul>
-          <slot name="cancel" v-bind="{ cancelLabel, cancelHandler }">
+          <slot name="cancel" v-bind="{ cancelLabel, closeHandler }">
             <SfButton
               ref="cancel"
               class="

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.3/v0.11.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.3/v0.11.3.stories.mdx
@@ -12,5 +12,6 @@ import { Meta } from "@storybook/addon-docs/blocks";
 ## 🚀 Features
 
 ## 🐛 Fixes
+- SfComponentSelect: added cancelLabel prop and binding for cancelHandler
 
 ## 🧹 Chores:


### PR DESCRIPTION
# Related issue
Closes #2094

# Scope of work
- added binding for cancelHandler
- added cancelLabel prop

# Screenshots of visual changes
no visual changes

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
