### PR TITLE
SfCollectedProduct - Add possibility to setup min and max qty

### DIFF
--- a/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.stories.js
+++ b/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.stories.js
@@ -227,6 +227,34 @@ export default {
       defaultValue: 1,
       description: "Selected quantity",
     },
+    minQty: {
+      control: "number",
+      table: {
+        category: "Props",
+        type: {
+          summary: "number",
+        },
+        defaultValue: {
+          summary: "null",
+        },
+      },
+      defaultValue: null,
+      description: "Minimum quantity value",
+    },
+    maxQty: {
+      control: "number",
+      table: {
+        category: "Props",
+        type: {
+          summary: "number",
+        },
+        defaultValue: {
+          summary: "null",
+        },
+      },
+      defaultValue: null,
+      description: "Maximum quantity value",
+    },
     link: {
       control: "text",
       table: {
@@ -310,6 +338,8 @@ const Template = (args, { argTypes }) => ({
     :image-height="imageHeight"
     :title="title"
     :link="link"
+    :minQty="minQty"
+    :maxQty="maxQty"
     :regular-price="regularPrice"
     :special-price="specialPrice"
     :hasMoreActions="hasMoreActions"
@@ -348,6 +378,8 @@ export const UseActionsSlot = (args, { argTypes }) => ({
     :image-height="imageHeight"
     :title="title"
     :link="link"
+    :minQty="minQty"
+    :maxQty="maxQty"
     :regular-price="regularPrice"
     :special-price="specialPrice"
     :special-price="specialPrice"
@@ -372,6 +404,8 @@ export const UseConfigurationSlot = (args, { argTypes }) => ({
     :image-height="imageHeight"
     :title="title"
     :link="link"
+    :minQty="minQty"
+    :maxQty="maxQty"
     :regular-price="regularPrice"
     :special-price="specialPrice"
     :special-price="specialPrice"
@@ -396,6 +430,8 @@ export const UseImageSlot = (args, { argTypes }) => ({
     :image-height="imageHeight"
     :title="title"
     :link="link"
+    :minQty="minQty"
+    :maxQty="maxQty"
     :regular-price="regularPrice"
     :special-price="specialPrice"
     :special-price="specialPrice"
@@ -420,6 +456,8 @@ export const UseInputSlot = (args, { argTypes }) => ({
     :image-height="imageHeight"
     :title="title"
     :link="link"
+    :minQty="minQty"
+    :maxQty="maxQty"
     :regular-price="regularPrice"
     :special-price="specialPrice"
     :special-price="specialPrice"
@@ -444,6 +482,8 @@ export const UseTitleSlot = (args, { argTypes }) => ({
     :image-height="imageHeight"
     :title="title"
     :link="link"
+    :minQty="minQty"
+    :maxQty="maxQty"
     :regular-price="regularPrice"
     :special-price="specialPrice"
     :special-price="specialPrice"
@@ -468,6 +508,8 @@ export const UsePriceSlot = (args, { argTypes }) => ({
     :image-height="imageHeight"
     :title="title"
     :link="link"
+    :minQty="minQty"
+    :maxQty="maxQty"
     :regular-price="regularPrice"
     :special-price="specialPrice"
     :special-price="specialPrice"

--- a/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
+++ b/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
@@ -49,6 +49,8 @@
         <div class="sf-collected-product__quantity-wrapper">
           <SfQuantitySelector
             :qty="quantity"
+            :min="minQty"
+            :max="maxQty"
             class="sf-collected-product__quantity-selector"
             @input="$emit('input', $event)"
           />
@@ -147,6 +149,14 @@ export default {
     qty: {
       type: [Number, String],
       default: 1,
+    },
+    minQty: {
+      type: Number,
+      default: null,
+    },
+    maxQty: {
+      type: Number,
+      default: null,
     },
     link: {
       type: [String, Object],

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.3/v0.11.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.3/v0.11.3.stories.mdx
@@ -10,7 +10,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfContentPages: Detecting active page regardless of the casing
 
 ## 🚀 Features
-
+- SfCollectedProduct: added max and min prop for quantity selector
 ## 🐛 Fixes
 
 ## 🧹 Chores:


### PR DESCRIPTION
# Related issue
Closes #2111 

# Scope of work
- added missing props
- updated docs

# Screenshots of visual changes
no visual change

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
