### PR TITLE
fix: type attribute added to SfButton in SfSearchBar

### DIFF
--- a/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.vue
+++ b/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.vue
@@ -13,6 +13,7 @@
     <slot name="icon">
       <SfButton
         class="sf-search-bar__button sf-button--pure"
+        type="button"
         aria-label="Search"
         @click="$emit('click', value)"
       >

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.4/v0.11.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.4/v0.11.4.stories.mdx
@@ -10,7 +10,8 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🚀 Features
 
-- SfFooterColumn: SfButton with attribute type `button` instead of button tag 
+- SfFooterColumn: SfButton with attribute type `button` instead of button tag
+- SfSearchBar: attribute type `button` added to SfButton
 - global: added html-validator for nuxt
 
 ## 🐛 Fixes


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2103

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
