### PR TITLE
fix: SfTabs - adjusted tabs logic to avoid mutating readonly properties

### DIFF
--- a/packages/vue/src/components/organisms/SfTabs/SfTabs.vue
+++ b/packages/vue/src/components/organisms/SfTabs/SfTabs.vue
@@ -30,6 +30,7 @@ export default {
   },
   data() {
     return {
+      tabs: [],
       initialTabActivated: false,
     };
   },
@@ -41,20 +42,20 @@ export default {
   },
   mounted() {
     this.$on("toggle", this.toggle);
+    this.tabs.push(...this.$children);
     if (this.openTab) this.openChild();
   },
   methods: {
     toggle(id) {
-      this.$children.forEach((child) => {
-        child.isActive = child._uid === id;
+      this.tabs.forEach((tab) => {
+        tab.isActive = tab._uid === id;
       });
-      const activeTab =
-        this.$children.findIndex((child) => child.isActive === true) + 1;
+      const activeTab = this.tabs.findIndex((tab) => tab.isActive === true) + 1;
       this.$emit("click:tab", activeTab);
     },
     openChild() {
       if (this.openTab < this.$children.length + 1) {
-        this.$children[this.openTab - 1].isActive = true;
+        this.tabs[this.openTab - 1].isActive = true;
         this.initialTabActivated = true;
       }
     },

--- a/packages/vue/src/stories/releases/v0.11.x/v0.11.3/v0.11.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.11.x/v0.11.3/v0.11.3.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Releases/v0.11.x - Latest Minor/v0.11.3/Change log" />
+<Meta title="Releases/v0.11.x - Minor/v0.11.3/Change log" />
 
 # v0.11.3
 

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.0/v0.12.0.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.0/v0.12.0.stories.mdx
@@ -1,0 +1,18 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.12.x - Latest Minor/v0.12.0/Change log" />
+
+# v0.12.0
+
+v0.12.0 contains API breaking changes and new features.
+
+## ❗ Breaking Changes
+
+
+## 🚀 Features
+
+## 🐛 Fixes
+
+- SfTabs: fixed issue with memory leak
+
+## 🧹 Chores:


### PR DESCRIPTION
# Related issue
Closes #2152 

# Scope of work
- removed mutating $children directly issue

# Screenshots of visual changes
-

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
