### PR TITLE
hotfix: chevron in SfTabs on desktop

### DIFF
--- a/packages/shared/styles/components/organisms/SfTabs.scss
+++ b/packages/shared/styles/components/organisms/SfTabs.scss
@@ -55,7 +55,7 @@
   &__tab {
     display: contents;
   }
-  &__chevron {
+  &__chevron, .sf-chevron {
     display: var(--tabs-chevron-display);
   }
   @include for-desktop {
@@ -67,7 +67,9 @@
     --tabs-title-color: var(--c-text-muted);
     --tabs-title-font-size: var(--h4-font-size);
     --tabs-content-tab-padding: var(--spacer-xl) 0;
-    --tabs-chevron-display: none;
+    &__chevron, .sf-chevron {
+      --tabs-chevron-display: none;
+    }
     &__title {
       &.is-active {
         --tabs-title-border-width: 0 0 2px 0;


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
