### PR TITLE
chore: update docs to use root selector

### DIFF
--- a/packages/vue/src/stories/getting-started/2. development guide/1. customization.stories.mdx
+++ b/packages/vue/src/stories/getting-started/2. development guide/1. customization.stories.mdx
@@ -137,10 +137,9 @@ You can override them to shape the look and feel of your project. There are two 
 ```scss
 /*
  * use id of DOM root element
- * vue-cli -> #app
- * nuxt-app -> :root
+ * vue-cli or nuxt-app -> :root
  */
-#app {
+:root {
   --font-family--primary: "Raleway", serif;
 }
 ```
@@ -232,6 +231,10 @@ This code will generate the following variables:
 #### How to override color variables?
 
 <YouTube youTubeId="dwj2snJegYU" />
+<div class="alert tip">
+Please note that since 0.12.0 version of Storefront UI we recommend using <strong>:root</strong> tag to overwrite global styles instead of <strong>#app</strong> tag.  
+</div> 
+
 
 <div class="alert tip">
 

--- a/packages/vue/src/stories/getting-started/2. development guide/6. FAQ.stories.mdx
+++ b/packages/vue/src/stories/getting-started/2. development guide/6. FAQ.stories.mdx
@@ -38,30 +38,21 @@ Currently we are in the process of collecting your frequently asked questions so
 
 If you have some questions that someone would appreciate of its answer - please [contact us](meet-the-team.md) :)
 
-## 1. I got problem working with Vue Storefront (APIs, Capybara theme, etc.). Please help
+## 1. I got a problem working with Vue Storefront (APIs, Capybara theme, etc.). Please help
 
-Despit the fact that our name is similar (both are Storefront) and both projects are from the same creator, StorefrontUI is independent project and our team, unfortunately, won't have the right answer for issues related to Vue Storefront (VSF). Please [visit the VSF team's Slack channel](https://vuestorefront.slack.com/join/shared_invite/enQtOTUwNjQyNjY5MDI0LWFmYzE4NTYxNDBhZDRlMjM5MDUzY2RiMjU0YTRjYWQ3YzdkY2YzZjZhZDZmMDUwMWQyOWRmZjQ3NDgwZGQ3NTk#/) for a better support 😉
+Despite the fact that our name is similar (both are Storefront) and both projects are from the same creator, StorefrontUI is independent project and our team, unfortunately, won't have the right answer for issues related to Vue Storefront (VSF). Please [visit the VSF team's Slack channel](https://vuestorefront.slack.com/join/shared_invite/enQtOTUwNjQyNjY5MDI0LWFmYzE4NTYxNDBhZDRlMjM5MDUzY2RiMjU0YTRjYWQ3YzdkY2YzZjZhZDZmMDUwMWQyOWRmZjQ3NDgwZGQ3NTk#/) for a better support 😉
 
 ## 2. How can I override StorefrontUI (SFUI) global CSS variables?
 
 To override SFUI CSS variables globally, declare their new values within the main `id` or `class` selector of the application, such as:
 
-- `app` for Vue application created by `vue-cli`
-- `__nuxt` for Nuxt application created by `create-nuxt-app`
+- `:root` for Vue and Nuxt applications 
 - any `id` or main `class` set for the main entry element to the application.
 
 For example, to override the variable `--font-family-primary` to `"Raleway", serif`, use the following:
 
 ```css
-#app {
-  --font-family-primary: "Raleway", serif;
-}
-```
-
-Or
-
-```css
-#__nuxt {
+:root {
   --font-family-primary: "Raleway", serif;
 }
 ```
@@ -79,14 +70,14 @@ body {
 }
 ```
 
-You can expand it whenever necessary. Keep in mind that Storefront UI components have styles for fonts, spacer's etc. inside. We don't set global styles for `<a>` and `<p>`, you can set global styles yourself according to your project needs.
+You can expand it whenever necessary. Keep in mind that Storefront UI components have styles for fonts, spacer's etc., inside. We don't set global styles for `<a>` and `<p>`, you can set global styles yourself according to your project needs.
 
 ## 4. I decided to use deprecated features for now. Is it possible to turn off the warnings?
 
-Yes! Deprecation warning will show only in development mode and you may find some options to turn off this warnings also in development mode by passing your own environmental variable:
+Yes! Deprecation warning will show only in development mode and you may find some options to turn off that warnings also in development mode by passing your own environmental variable:
 
 1. Create a file in the root folder `.env`
-2. Add variable that we use to detect your decision about turning off deprecation warnings:
+2. Add the variable that we use to detect your decision about turning off deprecation warnings:
    `VUE_APP_NO_DEPRECATED_WARNINGS=no-deprecated-warnings`
 3. Don't forget to restart serve/dev mode if it is currently running
 4. Clear cache if needed

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.0/v0.12.0.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.0/v0.12.0.stories.mdx
@@ -23,3 +23,5 @@ v0.12.0 contains API breaking changes and new features.
 - transitions: remove SfExpand functional component and fix sf-expand css styles 
 
 ## 🧹 Chores:
+
+- docs: change selector to overwrite global styles to `:root`


### PR DESCRIPTION
# Related issue
Closes #2180 

# Scope of work
Update docs to recommend using `:root` selector for overwriting global styles for Vue and Nuxt apps. Changes made in #1969 PR.

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
