### PR TITLE
fix: replace template tag with div SFProductCard

### DIFF
--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
@@ -84,7 +84,7 @@
           />
         </slot>
       </SfButton>
-      <template :class="{ 'display-none': !showAddToCartButton }">
+      <div :class="{ 'display-none': !showAddToCartButton }">
         <slot
           name="add-to-cart"
           v-bind="{
@@ -130,7 +130,7 @@
             </span>
           </SfCircleIcon>
         </slot>
-      </template>
+      </div>
     </div>
     <slot name="title" v-bind="{ title, link }">
       <SfButton

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.0/v0.12.0.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.0/v0.12.0.stories.mdx
@@ -20,10 +20,11 @@ v0.12.0 contains API breaking changes and new features.
 
 ## 🐛 Fixes
 
-- SfRating: easier to change color and size of icons by CCS properties 
+- SfRating: easier to change color and size of icons by CCS properties
 - SfTabs: fixed issue with memory leak
-- transitions: remove SfExpand functional component and fix sf-expand css styles 
+- transitions: remove SfExpand functional component and fix sf-expand css styles
 - SfTextArea: Bug fix for SfTextarea in form for Mobile view
+- SfProductCard: Replaced template tag with a div to fix showAddToCartButton prop not working
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2184

# Scope of work
Replaced template tag with a div and have a DOM element to be able to apply display: none

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
