### PR TITLE
fix(SfGallery): also mount glide on update

### DIFF
--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
@@ -164,6 +164,13 @@ export default {
       this.glide = glide;
     });
   },
+  updated() {
+    if (this.glide) {
+      this.$nextTick(() => {
+        this.glide.mount();
+      });      
+    }    
+  },
   beforeDestroy() {
     if (this.glide) {
       this.glide.destroy();

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.0/v0.12.0.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.0/v0.12.0.stories.mdx
@@ -24,6 +24,7 @@ v0.12.0 contains API breaking changes and new features.
 - SfTabs: fixed issue with memory leak
 - transitions: remove SfExpand functional component and fix sf-expand css styles 
 - SfTextArea: Bug fix for SfTextarea in form for Mobile view
+- SfGallery: push new images to gallery not working correctly
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
When pushing new images to the gallery the glide functionality stops working. In my case the last images do not show when clicking its thumb. This fix will mount the glide again on `updated`.

On mounted
![image](https://user-images.githubusercontent.com/5166897/148078131-b4af378a-c6c6-4ebd-958a-480c2b7f8a36.png)

After adding a new image, the last image does not show anymore
![image](https://user-images.githubusercontent.com/5166897/148078449-833e94b8-93b2-4934-853b-242cff50fe63.png)

After fix the image show when clicking the thumb
![image](https://user-images.githubusercontent.com/5166897/148079359-c43d9d4e-644f-4687-a9f4-593011b477f1.png)

# Screenshots of visual changes

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
