### PR TITLE
feat: added new modifier for SfComponentSelect

### DIFF
--- a/packages/shared/styles/components/molecules/SfComponentSelect.scss
+++ b/packages/shared/styles/components/molecules/SfComponentSelect.scss
@@ -147,6 +147,9 @@
     --component-select-border-width: 0 0 1px 0;
     --component-select-border-color: var(--c-link);
   }
+  &--label-right {
+    --component-select-label-left: 85%;
+  }
   &.is-selected {
     --component-select-label-top: 0;
     --component-select-label-font-size: var(--font-size--xs);

--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
@@ -142,6 +142,7 @@ export default {
           "",
           "sf-component-select--underlined",
           "sf-component-select--no-chevron",
+          "sf-component-select--label-right",
         ],
       },
       table: {
@@ -391,6 +392,12 @@ export const NoChevron = Template.bind({});
 NoChevron.args = {
   ...Common.args,
   classes: "sf-component-select--no-chevron",
+};
+
+export const WithLabelOnRight = Template.bind({});
+WithLabelOnRight.args = {
+  ...Common.args,
+  classes: "sf-component-select--label-right",
 };
 
 export const LongOptionsList = Template.bind({});

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.0/v0.12.0.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.0/v0.12.0.stories.mdx
@@ -17,6 +17,7 @@ v0.12.0 contains API breaking changes and new features.
 ## 🚀 Features
 
 - SfBanner: new slot `img-tag`
+- SfComponentSelect: new modifier for positioning label on the right
 
 ## 🐛 Fixes
 


### PR DESCRIPTION
# Related issue
Closes #1306 

# Scope of work
- added modifier for positioning SfComponentSelect label on the right

# Screenshots of visual changes
<img width="488" alt="Zrzut ekranu 2022-01-14 o 14 20 49" src="https://user-images.githubusercontent.com/41487496/149525211-c8bc346f-2c71-435f-ac59-f4c5e994905a.png">

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
