### PR TITLE
feat: add descriptions for v-model custom usage

### DIFF
--- a/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.stories.js
+++ b/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.stories.js
@@ -176,9 +176,18 @@ export default {
       description: "Emits when input field loses focus",
     },
     "v-model": {
+      control: "number",
       table: {
-        disable: true,
+        type: {
+          summary: "number",
+        },
+        category: "v-model",
+        defaultValue: {
+          summary: 1,
+        },
       },
+      defaultValue: 1,
+      description: "v-model accepts `qty` prop and emits native events",
     },
   },
 };

--- a/packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.stories.js
+++ b/packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.stories.js
@@ -61,9 +61,18 @@ export default {
       description: "Selected quantity",
     },
     "v-model": {
+      control: "number",
       table: {
-        disable: true,
+        type: {
+          summary: "number",
+        },
+        category: "v-model",
+        defaultValue: {
+          summary: 1,
+        },
       },
+      defaultValue: 1,
+      description: "v-model accepts `qty` prop and emits native events",
     },
     click: {
       action: "Click on button event emitted",

--- a/packages/vue/src/components/molecules/SfAddressPicker/SfAddressPicker.stories.js
+++ b/packages/vue/src/components/molecules/SfAddressPicker/SfAddressPicker.stories.js
@@ -139,6 +139,20 @@ export default {
       },
       description: "Use this slot to have custom checkmark",
     },
+    "v-model": {
+      control: "text",
+      table: {
+        type: {
+          summary: "text",
+        },
+        category: "v-model",
+        defaultValue: {
+          summary: "",
+        },
+      },
+      defaultValue: "",
+      description: "v-model accepts `selected` prop and emits `change` event",
+    },
   },
 };
 

--- a/packages/vue/src/components/molecules/SfCheckbox/SfCheckbox.stories.js
+++ b/packages/vue/src/components/molecules/SfCheckbox/SfCheckbox.stories.js
@@ -162,9 +162,18 @@ export default {
       description: "Indicates which checkbox is selected.",
     },
     "v-model": {
+      control: "text",
       table: {
-        disable: true,
+        type: {
+          summary: "text",
+        },
+        category: "v-model",
+        defaultValue: {
+          summary: "",
+        },
       },
+      defaultValue: "",
+      description: "v-model accepts `selected` prop and emits `change` event",
     },
     change: {
       action: "Change event emitted",

--- a/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
+++ b/packages/vue/src/components/molecules/SfComponentSelect/SfComponentSelect.stories.js
@@ -265,9 +265,18 @@ export default {
       description: "Emits change event when option is chosen",
     },
     "v-model": {
+      control: "text",
       table: {
-        disable: true,
+        type: {
+          summary: "text",
+        },
+        category: "v-model",
+        defaultValue: {
+          summary: "",
+        },
       },
+      defaultValue: "",
+      description: "v-model accepts `selected` prop and emits `change` event",
     },
     default: {
       table: {

--- a/packages/vue/src/components/molecules/SfModal/SfModal.stories.js
+++ b/packages/vue/src/components/molecules/SfModal/SfModal.stories.js
@@ -112,9 +112,18 @@ export default {
         "Modal transition effect. Could be one of [the default ones](https://docs.storefrontui.io/?path=/docs/utilities-transitions-docs--page).",
     },
     "v-model": {
+      control: "boolean",
       table: {
-        disable: true,
+        type: {
+          summary: "boolean",
+        },
+        category: "v-model",
+        defaultValue: {
+          summary: false,
+        },
       },
+      defaultValue: false,
+      description: "v-model accepts `visible` prop and emits `close` event",
     },
     close: {
       action: "close event emitted",

--- a/packages/vue/src/components/molecules/SfRadio/SfRadio.stories.js
+++ b/packages/vue/src/components/molecules/SfRadio/SfRadio.stories.js
@@ -123,9 +123,18 @@ export default {
       defaultValue: false,
     },
     "v-model": {
+      control: "text",
       table: {
-        disable: true,
+        type: {
+          summary: "text",
+        },
+        category: "v-model",
+        defaultValue: {
+          summary: "",
+        },
       },
+      defaultValue: "",
+      description: "v-model accepts `selected` prop and emits `change` event",
     },
     change: {
       action: "change event emitted",

--- a/packages/vue/src/components/molecules/SfSteps/SfSteps.stories.js
+++ b/packages/vue/src/components/molecules/SfSteps/SfSteps.stories.js
@@ -118,9 +118,18 @@ export default {
       description: "Name of the step.",
     },
     "v-model": {
+      control: "number",
       table: {
-        disable: true,
+        type: {
+          summary: "number",
+        },
+        category: "v-model",
+        defaultValue: {
+          summary: 0,
+        },
       },
+      defaultValue: 0,
+      description: "v-model accepts `active` prop and emits `change` event",
     },
     change: {
       action: "change event emitted",

--- a/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.stories.js
+++ b/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.stories.js
@@ -253,9 +253,18 @@ export default {
       description: "Link to product",
     },
     "v-model": {
+      control: "number",
       table: {
-        disable: true,
+        type: {
+          summary: "number",
+        },
+        category: "v-model",
+        defaultValue: {
+          summary: 1,
+        },
       },
+      defaultValue: 1,
+      description: "v-model accepts `qty` prop and emits native events",
     },
     hasMoreActions: {
       control: "boolean",

--- a/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.stories.js
+++ b/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.stories.js
@@ -273,9 +273,19 @@ export default {
       description: "Link to product",
     },
     "v-model": {
+      control: "number",
       table: {
-        disabled: true,
+        type: {
+          summary: "number",
+        },
+        category: "v-model",
+        defaultValue: {
+          summary: 1,
+        },
       },
+      defaultValue: 1,
+      description:
+        "v-model in SfGroupedProductItem accepts `qty` prop and emits native events",
     },
     input: {
       action: "input event emitted",

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.1/v0.12.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.1/v0.12.1.stories.mdx
@@ -17,3 +17,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🧹 Chores:
 
+- docs: added the description for v-modal custom props and events in components stories,


### PR DESCRIPTION
# Related issue
Closes #2148 

# Scope of work
Added description for v-model in components where it used with custom props or events: 

- SfQuantitySelectos,
- SfAddressPicker
- SfAddToCart
- SfCheckbox
- SfComponentSelect
- SfModal
- SfRadio
- SfSteps
- SfCollectedProduct
- SfGroupedProduct.

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
