### PR TITLE
fix: class in <template> results in unexpected behavior #2239

### DIFF
--- a/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
+++ b/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
@@ -81,21 +81,19 @@
       </template>
     </slot>
     <slot name="more-actions" v-bind="{ actionsHandler }">
-      <template>
-        <div :class="{ 'display-none': !hasMoreActions }">
-          <SfButton
-            aria-label="More actions"
-            class="
-              sf-button--pure
-              sf-collected-product__more-actions
-              smartphone-only
-            "
-            @click="actionsHandler"
-          >
-            <SfIcon icon="more" size="18px" />
-          </SfButton>
-        </div>
-      </template>
+      <div :class="{ 'display-none': !hasMoreActions }">
+        <SfButton
+          aria-label="More actions"
+          class="
+            sf-button--pure
+            sf-collected-product__more-actions
+            smartphone-only
+          "
+          @click="actionsHandler"
+        >
+          <SfIcon icon="more" size="18px" />
+        </SfButton>
+      </div>
     </slot>
   </div>
 </template>

--- a/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
+++ b/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
@@ -58,7 +58,7 @@
       </slot>
     </div>
     <slot name="remove" v-bind="{ removeHandler }">
-      <template :class="{ 'display-none': !hasRemove }">
+      <div :class="{ 'display-none': !hasRemove }">
         <SfCircleIcon
           icon="cross"
           aria-label="Remove"
@@ -78,7 +78,7 @@
           @click="removeHandler"
           >Remove</SfButton
         >
-      </template>
+      </div>
     </slot>
     <slot name="more-actions" v-bind="{ actionsHandler }">
       <div :class="{ 'display-none': !hasMoreActions }">

--- a/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
+++ b/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
@@ -81,18 +81,20 @@
       </template>
     </slot>
     <slot name="more-actions" v-bind="{ actionsHandler }">
-      <template :class="{ 'display-none': !hasMoreActions }">
-        <SfButton
-          aria-label="More actions"
-          class="
-            sf-button--pure
-            sf-collected-product__more-actions
-            smartphone-only
-          "
-          @click="actionsHandler"
-        >
-          <SfIcon icon="more" size="18px" />
-        </SfButton>
+      <template>
+        <div :class="{ 'display-none': !hasMoreActions }">
+          <SfButton
+            aria-label="More actions"
+            class="
+              sf-button--pure
+              sf-collected-product__more-actions
+              smartphone-only
+            "
+            @click="actionsHandler"
+          >
+            <SfIcon icon="more" size="18px" />
+          </SfButton>
+        </div>
       </template>
     </slot>
   </div>

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.1/v0.12.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.1/v0.12.1.stories.mdx
@@ -10,6 +10,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
+- SfCollectedProduct: bug with unexpected class behavior in "more-actions" element 
 - used "SfButton" instead of role="button" in "Category" page and "SfShippingDetails" template
 - SfHero: removed duplicate classes "sf-arrow" from "SfArrow" component
 - E2E test for login page fixed

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.1/v0.12.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.1/v0.12.1.stories.mdx
@@ -10,7 +10,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
-- SfCollectedProduct: bug with unexpected class behavior in "more-actions" element 
+- SfCollectedProduct: bug with unexpected class behavior in "more-actions" and "remove" element 
 - used "SfButton" instead of role="button" in "Category" page and "SfShippingDetails" template
 - SfHero: removed duplicate classes "sf-arrow" from "SfArrow" component
 - E2E test for login page fixed


### PR DESCRIPTION
# Related issue
(https://github.com/vuestorefront/storefront-ui/issues/2239)
Closes #

# Scope of work
`<template>` had a class set that used props, but since you can't set `<template>` classes, because of this the class did not work, I created a wrapper for the content, which I set the desired class.

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
