### PR TITLE
feat: changed the order of css custom properties addon

### DIFF
--- a/packages/vue/.storybook/main.js
+++ b/packages/vue/.storybook/main.js
@@ -10,11 +10,11 @@ module.exports = {
   ],
   addons: [
     "@storybook/addon-essentials",
+    "@ljcl/storybook-addon-cssprops",
     "@storybook/addon-links",
     "@storybook/addon-a11y",
     "@storybook/preset-scss",
-    "@storybook/addon-storysource", 
-    "@ljcl/storybook-addon-cssprops",
+    "@storybook/addon-storysource"
   ],
   webpackFinal: async (config) => {
     config.module.rules.push({

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.1/v0.12.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.1/v0.12.1.stories.mdx
@@ -7,6 +7,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 ## 🚀 Features
 
 - SfImage: added slot for placeholder,
+- feat: changed the order of css custom properties addon
 
 ## 🐛 Fixes
 


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2149 

# Scope of work
<!-- describe what you did -->
Changed the order of addons in storybook main.js

# Screenshots of visual changes
<!-- if visual changes applied -->
After:
![image](https://user-images.githubusercontent.com/41404838/152282774-8593f7cd-7d7e-4685-adf9-61e35cc1c84b.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
