### PR TITLE
#2237 fix: sfaccordion stops toggling items correctly

### DIFF
--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
@@ -64,7 +64,7 @@ export default {
   methods: {
     setAccordionItems() {
       if (this.$children && this.$children.length) {
-        this.items.push(...this.$children);
+        this.items = this.$children;
       }
     },
     setAsOpen() {


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2247 

# Scope of work
Replaced `this.items.push(...this.$children)` with `this.items = this.$children`. This way we're not pushing new items to the array on every component update.

# Screenshots of visual changes
https://www.loom.com/share/4066dadc32684209afb10f324de27ac3

# Fun fact
In the video you can see that the problem appears after I had toggled the checkbox. The SfAccordion's `updated` hook gets triggered even though the property managed with the checkbox is neither passed to SfAccordion as a prop nor related to it in any way.

Turns out it has to do with the SfAccordion **default** slot. When I replace it with a **named** slot, the SfAccordion is not updated on checkbox toggling.

# Checklist

- [x] No commented blocks of code left
- [x] Self code-reviewed
