### PR TITLE
#2245-fix: SfGroupedProduct mobile issue

### DIFF
--- a/packages/shared/styles/components/organisms/SfGroupedProduct.scss
+++ b/packages/shared/styles/components/organisms/SfGroupedProduct.scss
@@ -28,11 +28,6 @@
   &__quantity-selector {
     --quantity-selector-background: var(--c-light);
     display: var(--grouped-product-item-quantity-selector-display, flex);
-    position: absolute;
-    bottom: var(
-      --grouped-product-item-quantity-selector-bottom,
-      var(--spacer-sm)
-    );
     left: var(--grouped-product-item-quantity-selector-left, 50%);
     right: var(--grouped-product-item-quantity-selector-right);
     transform: var(
@@ -84,6 +79,11 @@
     --grouped-product-item-price-margin: 0 0 0 auto;
     &__quantity-selector {
       --quantity-selector-background: var(--c-light);
+      position: absolute;
+      bottom: var(
+        --grouped-product-item-quantity-selector-bottom,
+        var(--spacer-sm)
+      );
     }
   }
 }
@@ -132,6 +132,11 @@
     --grouped-product-item-price-margin: 0 0 0 auto;
     .sf-grouped-product-item__quantity-selector {
       --quantity-selector-background: var(--c-light);
+      position: absolute;
+      bottom: var(
+        --grouped-product-item-quantity-selector-bottom,
+        var(--spacer-sm)
+      );
     }
   }
   &.without-quantity {

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
@@ -11,5 +11,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 ## 🐛 Fixes
 - SfImage: fix invalid attribute at `srcset`
 
+- SfGroupedProduct: fixed issue with display on mobile view
+
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2245 

# Scope of work
<!-- describe what you did -->
Add styles for classes `.sf-grouped-product-item__quantity-selector`, `.sf-grouped-product.without-carousel .sf-grouped-product-item__quantity-selector`  for desktop view 

```
position: absolute;
bottom: var(--grouped-product-item-quantity-selector-bottom, var(--spacer-sm));
```

# Screenshots of visual changes
<!-- if visual changes applied -->
<img width="238" alt="Screenshot 2022-02-08 at 16 12 31" src="https://user-images.githubusercontent.com/9588193/153016108-5a631e9c-b3a8-48f7-90cf-16af47d25239.png">

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
