### PR TITLE
fix: sfimage image-tag set to img on nuxt

### DIFF
--- a/packages/vue/src/components/atoms/SfImage/SfImage.vue
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.vue
@@ -137,7 +137,7 @@ export default {
       }
     },
     imageComponentTag() {
-      return !this.$nuxt ? "img" : this.imageTag;
+      return !this.$nuxt ? "img" : this.imageTag || "img";
     },
     isPlaceholderVisible() {
       return (

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
@@ -9,6 +9,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
+- SfImage: when rendered on nuxt it has `image-tag` set to `img` as default, 
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
Closes #

# Scope of work
Added default value of `img` for `image-tag` prop when SfImage is rendered on nuxt, to avoid passing empty string when this prop is not set. 

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
