### PR TITLE
fix: mutating props error in stories

### DIFF
--- a/packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.stories.js
+++ b/packages/vue/src/components/molecules/SfAddToCart/SfAddToCart.stories.js
@@ -109,7 +109,12 @@ export default {
 const Template = (args, { argTypes }) => ({
   components: { SfAddToCart },
   props: Object.keys(argTypes),
-  template: `<SfAddToCart v-model="qty" :disabled="disabled"  @click="click" @input="input" />`,
+  data() {
+    return {
+      quantity: this.qty,
+    }
+  },
+  template: `<SfAddToCart v-model="quantity" :disabled="disabled"  @click="click" @input="input" />`,
 });
 
 export const Common = Template.bind({});
@@ -121,15 +126,20 @@ Disabled.args = { disabled: true };
 export const WithAddToCartSlot = (args, { argTypes }) => ({
   components: { SfAddToCart },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      quantity: this.qty,
+    }
+  },
   template: `
   <SfAddToCart 
     :disabled="disabled"
     @click="click"
     @input="input"
-    :qty="qty"
+    :qty="quantity"
   >
-    <template #quantity-select-input="{qty}">
-      <select v-model="qty">
+    <template #quantity-select-input="{quantity}">
+      <select v-model="quantity">
         <option value="1">1</option>
         <option value="5">5</option>
         <option value="25">25</option>

--- a/packages/vue/src/components/molecules/SfAddressPicker/SfAddressPicker.stories.js
+++ b/packages/vue/src/components/molecules/SfAddressPicker/SfAddressPicker.stories.js
@@ -159,8 +159,13 @@ export default {
 const Template = (args, { argTypes }) => ({
   components: { SfAddressPicker },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      checked: this.selected,
+    };
+  },
   template: `
-  <SfAddressPicker v-model="selected" @change="change">
+  <SfAddressPicker v-model="checked" @change="change">
     <SfAddress :name="name">
       <span>{{title}}</span>
       <span>{{street}}</span>

--- a/packages/vue/src/components/molecules/SfCheckbox/SfCheckbox.stories.js
+++ b/packages/vue/src/components/molecules/SfCheckbox/SfCheckbox.stories.js
@@ -231,9 +231,14 @@ export default {
 const Template = (args, { argTypes }) => ({
   components: { SfCheckbox },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      checked: this.selected,
+    };
+  },
   template: `
   <SfCheckbox 
-    v-model="selected"
+    v-model="checked"
     :name="name"      
     :label="label"
     :hintMessage="hintMessage"
@@ -292,6 +297,11 @@ Disabled.args = {
 export const UseCheckmarkSlot = (args, { argTypes }) => ({
   components: { SfCheckbox },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      checked: this.selected,
+    };
+  },
   template: `
   <SfCheckbox 
     v-model="checked"
@@ -311,15 +321,20 @@ export const UseCheckmarkSlot = (args, { argTypes }) => ({
 });
 UseCheckmarkSlot.args = {
   ...Common.args,
-  checked: true,
+  selected: true,
 };
 
 export const UseErrorMessageSlot = (args, { argTypes }) => ({
   components: { SfCheckbox },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      checked: this.selected,
+    };
+  },
   template: `
   <SfCheckbox 
-    v-model="selected"
+    v-model="checked"
     :name="name"      
     :label="label"
     :hint-message="hintMessage"

--- a/packages/vue/src/components/molecules/SfColorPicker/SfColorPicker.stories.js
+++ b/packages/vue/src/components/molecules/SfColorPicker/SfColorPicker.stories.js
@@ -245,13 +245,18 @@ export default {
 const Template = (args, { argTypes }) => ({
   components: { SfColorPicker, SfColor },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      opened: this.isOpen,
+    };
+  },
   template: `
   <SfColorPicker
     :class="classes"
     :label="label"
     :has-close="hasClose"
-    :isOpen="isOpen"
-    @click:toggle="() => {this['click:toggle'](); this.isOpen = !this.isOpen}"
+    :isOpen="opened"
+    @click:toggle="() => {this['click:toggle'](); this.opened = !this.opened}"
   >
     <SfColor style="margin: 0.4375rem" v-for="color in colors" :key="color.value" :color="color.color" :selected="color.selected" @click="color.selected = !color.selected"/>
   </SfColorPicker>`,

--- a/packages/vue/src/components/molecules/SfDropdown/SfDropdown.stories.js
+++ b/packages/vue/src/components/molecules/SfDropdown/SfDropdown.stories.js
@@ -192,7 +192,7 @@ const Template = (args, { argTypes }) => ({
     <template>
       <SfList>
         <SfListItem v-for="(action, key) in actionList" :key="key">
-          <SfButton class="sf-button--full-width sf-button--underlined color-primary" @click.stop="isOpen = false">{{ action }}</SfButton>
+          <SfButton class="sf-button--full-width sf-button--underlined color-primary" @click.stop="isDropdownOpen = false">{{ action }}</SfButton>
         </SfListItem>
       </SfList>
     </template> 
@@ -207,14 +207,14 @@ Common.args = {
 export const Persistent = Template.bind({});
 Persistent.args = {
   ...Common.args,
-  isDropdownOpen: true,
+  isOpen: true,
   persistent: true,
 };
 
 export const IsOpened = Template.bind({});
 IsOpened.args = {
   ...Common.args,
-  isDropdownOpen: true,
+  isOpen: true,
 };
 
 export const WithUpModifier = Template.bind({});

--- a/packages/vue/src/components/molecules/SfPagination/SfPagination.stories.js
+++ b/packages/vue/src/components/molecules/SfPagination/SfPagination.stories.js
@@ -131,13 +131,18 @@ export default {
 const Template = (args, { argTypes }) => ({
   components: { SfPagination },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      currentPage: this.current,
+    };
+  },
   template: `
   <SfPagination
-  :current="current"
+  :current="currentPage"
   :visible="visible"
   :total="total"
   :has-arrows="hasArrows"
-  @click="(current) => { this.click(current); this.current = current }"
+  @click="(current) => { this.click(current); this.currentPage = current }"
   />`,
 });
 
@@ -152,13 +157,18 @@ WithoutArrows.args = { ...Common.args, hasArrows: false };
 export const UsePointsSlot = (args, { argTypes }) => ({
   components: { SfPagination },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      currentPage: this.current,
+    };
+  },
   template: `
   <SfPagination
-  :current="current"
+  :current="currentPage"
   :visible="visible"
   :total="total"
   :has-arrows="hasArrows"
-  @click="click"
+  @click="(current) => { this.click(current); this.currentPage = current }"
   >
     <template #points >🎉</template>
   </SfPagination>`,
@@ -168,13 +178,18 @@ UsePointsSlot.args = { ...Common.args };
 export const UsePrevSlot = (args, { argTypes }) => ({
   components: { SfPagination },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      currentPage: this.current,
+    };
+  },
   template: `
   <SfPagination
-  :current="current"
+  :current="currentPage"
   :visible="visible"
   :total="total"
   :has-arrows="hasArrows"
-  @click="click"
+  @click="(current) => { this.click(current); this.currentPage = current }"
   >
     <template #prev="{ go, prev}">
       <button @click="go(prev)">prev</button>
@@ -186,13 +201,18 @@ UsePrevSlot.args = { ...Common.args };
 export const UseNextSlot = (args, { argTypes }) => ({
   components: { SfPagination },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      currentPage: this.current,
+    };
+  },
   template: `
   <SfPagination
-  :current="current"
+  :current="currentPage"
   :visible="visible"
   :total="total"
   :has-arrows="hasArrows"
-  @click="click"
+  @click="(current) => { this.click(current); this.currentPage = current }"
   >
     <template #next="{ go, next}">
       <button @click="go(next)">next</button>
@@ -204,18 +224,25 @@ UseNextSlot.args = { ...Common.args };
 export const UseNumberSlot = (args, { argTypes }) => ({
   components: { SfPagination },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      currentPage: this.current,
+    };
+  },
   template: `
   <SfPagination
-  :current="current"
+  :current="currentPage"
   :visible="visible"
   :total="total"
-  :has-arrows="hasArrows"
-  @click="click"
+  :has-arrows="hasArrows"  
   >
-    <template #number="{page}">
+    <template #number="{ page, currentPage, go }">
       <button 
         class="sf-pagination__item"
-        :class="{'current': current === page}">{{page}}</button>
+        :class="{current: currentPage === page}"
+      >
+        {{page}}
+      </button>
     </template>
   </SfPagination>`,
 });

--- a/packages/vue/src/components/organisms/SfContentPages/SfContentPages.stories.js
+++ b/packages/vue/src/components/organisms/SfContentPages/SfContentPages.stories.js
@@ -278,11 +278,16 @@ export default {
 const Template = (args, { argTypes }) => ({
   components: { SfContentPages, SfTabs },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      opened: this.active,
+    };
+  },
   template: `
   <SfContentPages
     :title="title"
-    :active="active"
-    @click:change="(active) => { this['click:change'](active); this.active = active }"
+    :active="opened"
+    @click:change="(active) => { this['click:change'](active); this.opened = active }"
   >
   <SfContentPage v-for="(page, key) in pages" :key="page.title+key" :title="page.title">
     <SfTabs v-if="page.tabs" :open-tab="1">
@@ -308,11 +313,16 @@ HasActive.args = {
 export const WithCategories = (args, { argTypes }) => ({
   components: { SfContentPages, SfTabs },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      opened: this.active,
+    };
+  },
   template: `
   <SfContentPages
     :title="title"
-    :active="active"
-    @click:change="(active) => { this['click:change'](active); this.active = active }"
+    :active="opened"
+    @click:change="(active) => { this['click:change'](active); this.opened = active }"
   >
   <SfContentPage v-for="(page, key) in pages" :key="page.title+key" :title="page.title">
     <SfTabs v-if="page.tabs" :open-tab="1">
@@ -330,11 +340,16 @@ WithCategories.args = {
 export const WithCategoryIcon = (args, { argTypes }) => ({
   components: { SfContentPages, SfTabs },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      opened: this.active,
+    };
+  },
   template: `
   <SfContentPages
     :title="title"
-    :active="active"
-    @click:change="(active) => { this['click:change'](active); this.active = active }"
+    :active="opened"
+    @click:change="(active) => { this['click:change'](active); this.opened = active }"
   >
     <SfContentPage v-for="(page, key) in pages" :key="page.title+key" :title="page.title" :icon="page.icon">
     <SfTabs v-if="page.tabs" :open-tab="1">
@@ -396,13 +411,18 @@ WithCategoryIcon.args = {
 export const UseMenuItemSlot = (args, { argTypes }) => ({
   components: { SfContentPages, SfTabs },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      opened: this.active,
+    };
+  },
   template: `
   <SfContentPages
     :title="title"
-    :active="active"
-    @click:change="(active) => { this['click:change'](active); this.active = active }"
+    :active="opened"
+    @click:change="(active) => { this['click:change'](active); this.opened = active }"
   >
-  <template #menu-item="{ updatePage, page, active }">
+  <template #menu-item="{ updatePage, page, opened }">
     <button @click="updatePage(page.title)">{{page.title}}</button>
   </template>
   <SfContentPage v-for="(page, key) in pages" :key="page.title+key" :title="page.title">

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
@@ -12,3 +12,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🧹 Chores:
 
+docs: mutating props error in following stories: SfAddressPicker, SfAddToCart, SfColorPicker, SfComponentSelect, SfDropdown, SfCheckbox, SfPagination, SfContentPages,


### PR DESCRIPTION
# Related issue
Closes #2128 

# Scope of work
Get rid of mutating prop directly issue in Storybook stories: 

- SfAddressPicker - selected
- SfAddToCart - qty
- SfColorPicker - isOpen
- SfDropdown - isOpen
- SfCheckbox - selected
- SfPagination - current
- SfContentPages - active

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
