### PR TITLE
fix:#2255-home-page-e2e-issue

### DIFF
--- a/packages/nuxt/cypress.json
+++ b/packages/nuxt/cypress.json
@@ -2,5 +2,7 @@
   "baseUrl": "http://localhost:3000",
   "viewportWidth": 1400,
   "viewportHeight": 960,
-  "video": false
+  "video": false,
+  "pageLoadTimeout": 180000,
+  "defaultCommandTimeout": 10000
 }

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
@@ -13,5 +13,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 - SfGroupedProduct: fixed issue with display on mobile view
 
+- add timeout options to cypress configuration
+
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2255

# Scope of work
<!-- describe what you did -->
Randomly e2e tests fails for Home page because of SfHero component.
I've added timeout options to cypress config.

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
