### PR TITLE
#2262 - fix:'SfInput' attribute has invalid input in some cases

### DIFF
--- a/packages/vue/src/components/atoms/SfInput/SfInput.vue
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.vue
@@ -6,11 +6,11 @@
       'has-text': !!value,
       invalid: !valid,
     }"
-    :data-testid="name"
+    :data-testid="nameWithoutWhitespace"
   >
     <div class="sf-input__wrapper">
       <input
-        :id="idWithoutWhitespace"
+        :id="nameWithoutWhitespace"
         v-focus
         v-bind="$attrs"
         :value="value"
@@ -25,7 +25,7 @@
       <label
         :class="{ 'display-none': !label }"
         class="sf-input__label will-change"
-        :for="name"
+        :for="nameWithoutWhitespace"
       >
         <slot name="label" v-bind="{ label }">{{ label }}</slot>
       </label>
@@ -153,7 +153,7 @@ export default {
     isPassword() {
       return this.type === "password" && this.hasShowPassword;
     },
-    idWithoutWhitespace() {
+    nameWithoutWhitespace() {
       return this.name.replace(/\s/g, "");
     },
   },

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
@@ -13,7 +13,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfImage: when rendered on nuxt it has `image-tag` set to `img` as default, 
 - SfGroupedProduct: fixed issue with display on mobile view,
 - Nuxt Detailed Cart page not found fixed,
-- SfIcon: attribute has invalid input in some cases,
+- SfInput: attribute has invalid input in some cases,
 
 ## 🧹 Chores:
 

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
@@ -13,6 +13,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfImage: when rendered on nuxt it has `image-tag` set to `img` as default, 
 - SfGroupedProduct: fixed issue with display on mobile view,
 - Nuxt Detailed Cart page not found fixed,
+- SfIcon: attribute has invalid input in some cases,
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
https://github.com/vuestorefront/storefront-ui/issues/2262
Closes #

# Scope of work
<!-- describe what you did -->
The component `SfInput` had attributes that, when entering a value with a _whitespace_, led to an error, I replaced the value with a `computed`, which removes _whitespace_.

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
