### PR TITLE
fix: changed date prop format to text in SfReview story

### DIFF
--- a/packages/vue/src/components/molecules/SfReview/SfReview.stories.js
+++ b/packages/vue/src/components/molecules/SfReview/SfReview.stories.js
@@ -125,7 +125,7 @@ export default {
       description: "Author of the review",
     },
     date: {
-      control: "date",
+      control: "text",
       table: {
         category: "Props",
         defaultValue: {

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
@@ -12,3 +12,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🧹 Chores:
 
+- docs: changed date format to text in SfReview component story,  


### PR DESCRIPTION
# Related issue

Closes #1623 

# Scope of work
Changed the date prop format to text to display the value that is actually passed. Users need to implement the proper date format by themselves and pass the result into the component. 

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
