### PR TITLE
fix: core.js causes $ is not a function error

### DIFF
--- a/packages/nuxt-module/lib/module.js
+++ b/packages/nuxt-module/lib/module.js
@@ -48,6 +48,8 @@ module.exports = function (moduleOptions) {
       })
     }
 
+    // https://github.com/zloirock/core-js/issues/743
+    this.options.build.babel.exclude = [/\bcore-js\b/, /\bwebpack\/buildin\b/]
     this.options.build.transpile.push(packageName)
   }
 

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
@@ -19,8 +19,8 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfImage: when rendered on nuxt it has `image-tag` set to `img` as default, 
 - SfGroupedProduct: fixed issue with display on mobile view,
 - Nuxt Detailed Cart page not found fixed,
-
-- add timeout options to cypress configuration
+- add timeout options to cypress configuration,
+- Nuxt module: exclude core-js from transpiling process
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2126

# Scope of work
<!-- describe what you did -->
This PR resolve bug  with `$ is not a function error`. Bug happens after installing ui nuxt module.
According to author of `core-js`, library shouldn't be transpiled by babel -  https://github.com/zloirock/core-js/issues/912
I've excluded  from transpiling process: 
- `/\bcore-js\b/` - core js module
- `/\bwebpack\/buildin\b/` - fix potential bug related with older versions of `core-js`.

More info about problem - https://github.com/zloirock/core-js/issues/743


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
