### PR TITLE
[WIP] feat: add helper hiding data-test attribute on production

### DIFF
--- a/packages/vue/src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.vue
+++ b/packages/vue/src/components/atoms/SfBreadcrumbs/SfBreadcrumbs.vue
@@ -21,7 +21,7 @@
               :is="injections.components.SfLink"
               class="sf-breadcrumbs__breadcrumb"
               :link="breadcrumb.link"
-              :data-testid="breadcrumb.text"
+              :data-testid="$options.dataTestDisplay(breadcrumb.text)"
             >
               {{ breadcrumb.text }}
             </component>
@@ -44,6 +44,7 @@
 </template>
 <script>
 import SfLink from "../SfLink/SfLink";
+import { dataTestDisplay } from "../../../utilities/helpers";
 export default {
   name: "SfBreadcrumbs",
   inject: {
@@ -60,6 +61,7 @@ export default {
   breadcrumbLast(breadcrumbs) {
     return breadcrumbs.length - 1;
   },
+  dataTestDisplay,
 };
 </script>
 <style lang="scss">

--- a/packages/vue/src/components/atoms/SfBullets/SfBullets.vue
+++ b/packages/vue/src/components/atoms/SfBullets/SfBullets.vue
@@ -14,7 +14,7 @@
             class="sf-button--pure sf-bullet"
             type="button"
             :aria-label="'Go to slide ' + (index + 1)"
-            :data-testid="'bullet-' + (index + 1)"
+            :data-testid="dataTestDisplay('bullet-' + (index + 1))"
             @click="listeners.click && listeners.click(index)"
           ></component>
         </li>
@@ -52,9 +52,11 @@
             "
             class="sf-button--pure sf-bullet"
             :data-testid="
-              'bullet-' +
-              $options.inactiveLeft(props.total, props.current) +
-              (2 + index)
+              dataTestDisplay(
+                'bullet-' +
+                  $options.inactiveLeft(props.total, props.current) +
+                  (2 + index)
+              )
             "
             @click="
               listeners.click &&
@@ -70,6 +72,7 @@
 </template>
 <script>
 import SfButton from "../SfButton/SfButton.vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
 export default {
   name: "SfBullets",
   inject: {
@@ -93,6 +96,7 @@ export default {
   inactiveLeft(total, current) {
     return total - (total - 1 - current) - 1;
   },
+  dataTestDisplay,
 };
 </script>
 <style lang="scss">

--- a/packages/vue/src/components/atoms/SfColor/SfColor.vue
+++ b/packages/vue/src/components/atoms/SfColor/SfColor.vue
@@ -13,7 +13,7 @@
       '--color-background': props.color,
     }"
     :aria-pressed="props.selected.toString()"
-    :data-testid="props.color"
+    :data-testid="dataTestDisplay(props.color)"
     v-bind="data.attrs"
     v-on="listeners"
   >
@@ -43,6 +43,7 @@
 import SfBadge from "../SfBadge/SfBadge.vue";
 import SfIcon from "../SfIcon/SfIcon.vue";
 import SfButton from "../SfButton/SfButton.vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
 export default {
   name: "SfColor",
   inject: {
@@ -68,6 +69,7 @@ export default {
       default: true,
     },
   },
+  dataTestDisplay,
 };
 </script>
 <style lang="scss">

--- a/packages/vue/src/components/atoms/SfImage/SfImage.vue
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.vue
@@ -1,5 +1,8 @@
 <template>
-  <span class="sf-image--wrapper" data-testid="image-wrapper">
+  <span
+    class="sf-image--wrapper"
+    :data-testid="dataTestDisplay('image-wrapper')"
+  >
     <component
       :is="imageComponentTag"
       :loading="loading"
@@ -43,6 +46,7 @@
 </template>
 <script>
 import imagePlaceholder from "@storefront-ui/shared/images/product_placeholder.svg";
+import { dataTestDisplay } from "../../../utilities/helpers";
 
 export default {
   name: "SfImage",
@@ -204,6 +208,7 @@ export default {
         ? `${Number.parseInt(srcset.width) || ""}w`
         : this.formatResolution(srcset.resolution);
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/atoms/SfInput/SfInput.vue
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.vue
@@ -6,7 +6,7 @@
       'has-text': !!value,
       invalid: !valid,
     }"
-    :data-testid="name"
+    :data-testid="dataTestDisplay('name')"
   >
     <div class="sf-input__wrapper">
       <input
@@ -84,6 +84,8 @@ import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
 import SfButton from "../../atoms/SfButton/SfButton.vue";
 import { focus } from "../../../utilities/directives";
 import { willChange } from "../../../utilities/directives";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfInput",
   directives: {
@@ -193,6 +195,7 @@ export default {
       this.isPasswordVisible = !this.isPasswordVisible;
       this.inputType = this.isPasswordVisible ? "text" : "password";
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.vue
+++ b/packages/vue/src/components/atoms/SfQuantitySelector/SfQuantitySelector.vue
@@ -9,7 +9,7 @@
         props.disabled || Boolean(props.min !== null && props.qty <= props.min)
       "
       class="sf-button--pure sf-quantity-selector__button"
-      data-testid="decrease"
+      :data-testid="$options.dataTestDisplay('decrease')"
       @click="
         $options.handleInput(
           Number(props.qty) - 1,
@@ -28,7 +28,7 @@
       :value="Number(props.qty)"
       :disabled="props.disabled"
       class="sf-quantity-selector__input"
-      data-testid="sf-quantity-selector input"
+      :data-testid="$options.dataTestDisplay('sf-quantity-selector input')"
       @input="$options.handleInput($event, listeners, props.min, props.max)"
       @blur="$options.handleBlur(listeners)"
     />
@@ -38,7 +38,7 @@
         props.disabled || Boolean(props.max !== null && props.qty >= props.max)
       "
       class="sf-button--pure sf-quantity-selector__button"
-      data-testid="increase"
+      :data-testid="$options.dataTestDisplay('increase')"
       @click="
         $options.handleInput(
           Number(props.qty) + 1,
@@ -55,6 +55,7 @@
 <script>
 import SfInput from "../../atoms/SfInput/SfInput.vue";
 import SfButton from "../../atoms/SfButton/SfButton.vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
 
 export default {
   name: "SfQuantitySelector",
@@ -104,6 +105,7 @@ export default {
     const key = Math.random().toString(16).slice(2);
     return "quantitySelector" + key;
   },
+  dataTestDisplay,
 };
 </script>
 <style lang="scss">

--- a/packages/vue/src/components/molecules/SfBanner/SfBanner.vue
+++ b/packages/vue/src/components/molecules/SfBanner/SfBanner.vue
@@ -31,7 +31,7 @@
           v-if="buttonText && !isMobileView"
           :link="link"
           class="sf-banner__call-to-action color-secondary"
-          data-testid="banner-cta-button"
+          :data-testid="dataTestDisplay('banner-cta-button')"
           v-on="!isMobileView ? $listeners : {}"
         >
           {{ buttonText }}
@@ -44,6 +44,7 @@
 <script>
 import SfButton from "../../atoms/SfButton/SfButton.vue";
 import SfLink from "../../atoms/SfLink/SfLink.vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
 import {
   mapMobileObserver,
   unMapMobileObserver,
@@ -133,6 +134,9 @@ export default {
   },
   beforeDestroy() {
     unMapMobileObserver();
+  },
+  methods: {
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/molecules/SfCallToAction/SfCallToAction.vue
+++ b/packages/vue/src/components/molecules/SfCallToAction/SfCallToAction.vue
@@ -23,7 +23,7 @@
         :class="{ 'display-none': !buttonText }"
         :link="link"
         class="sf-call-to-action__button"
-        data-testid="cta-button"
+        :data-testid="dataTestDisplay('cta-button')"
         @click="$emit('click')"
       >
         {{ buttonText }}
@@ -33,6 +33,8 @@
 </template>
 <script>
 import SfButton from "../../atoms/SfButton/SfButton.vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfCallToAction",
   components: {
@@ -77,6 +79,9 @@ export default {
         "--_call-to-action-background-color": background,
       };
     },
+  },
+  methods: {
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/molecules/SfCheckbox/SfCheckbox.vue
+++ b/packages/vue/src/components/molecules/SfCheckbox/SfCheckbox.vue
@@ -7,7 +7,7 @@
       'has-error': !valid,
       'is-required': required,
     }"
-    :data-testid="name"
+    :data-testid="dataTestDisplay('name')"
   >
     <label class="sf-checkbox__container">
       <input
@@ -54,6 +54,8 @@
 <script>
 import SfIcon from "../../atoms/SfIcon/SfIcon";
 import { focus } from "../../../utilities/directives";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfCheckbox",
   directives: {
@@ -163,6 +165,7 @@ export default {
         return "";
       }
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/molecules/SfMenuItem/SfMenuItem.vue
+++ b/packages/vue/src/components/molecules/SfMenuItem/SfMenuItem.vue
@@ -3,7 +3,7 @@
     :is="componentIs"
     class="sf-menu-item"
     v-bind="bind"
-    :data-testid="label"
+    :data-testid="dataTestDisplay('label')"
     v-on="$listeners"
   >
     <slot name="icon" />
@@ -27,6 +27,8 @@
 import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
 import SfLink from "../../atoms/SfLink/SfLink.vue";
 import SfButton from "../../atoms/SfButton/SfButton.vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfMenuItem",
   components: {
@@ -65,6 +67,9 @@ export default {
     componentIs() {
       return this.link ? "SfLink" : "SfButton";
     },
+  },
+  methods: {
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/molecules/SfModal/SfModal.vue
+++ b/packages/vue/src/components/molecules/SfModal/SfModal.vue
@@ -27,7 +27,7 @@
           class="sf-button--pure sf-modal__close desktop-only"
           aria-label="Close modal"
           type="button"
-          data-testid="close-button"
+          :data-testid="dataTestDisplay('close-button')"
           @click="close"
         >
           <slot name="close">
@@ -50,6 +50,8 @@ import { disableBodyScroll, clearAllBodyScrollLocks } from "body-scroll-lock";
 import { focusTrap } from "../../../utilities/directives";
 import { clickOutside } from "../../../utilities/directives";
 import { isClient } from "../../../utilities/helpers";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfModal",
   directives: { focusTrap, clickOutside },
@@ -141,6 +143,7 @@ export default {
         this.className = this.$vnode.data.class;
       }
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/molecules/SfPagination/SfPagination.vue
+++ b/packages/vue/src/components/molecules/SfPagination/SfPagination.vue
@@ -14,7 +14,7 @@
           :link="hasRouter ? getLinkTo(getPrev) : null"
           :disabled="!hasRouter && !canGoPrev ? true : false"
           aria-label="Go to previous page"
-          data-testid="pagination-button-prev"
+          :data-testid="dataTestDisplay('pagination-button-prev')"
           @click="hasRouter ? null : go(getPrev)"
         >
           <SfIcon icon="arrow_left" size="1.125rem" />
@@ -101,7 +101,7 @@
           :link="hasRouter ? getLinkTo(getNext) : null"
           :disabled="!hasRouter && !canGoNext ? true : false"
           aria-label="Go to previous next"
-          data-testid="pagination-button-next"
+          :data-testid="dataTestDisplay('pagination-button-next')"
           @click="hasRouter ? null : go(getNext)"
         >
           <SfIcon icon="arrow_right" size="1.125rem" />
@@ -114,6 +114,8 @@
 import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
 import SfLink from "../../atoms/SfLink/SfLink.vue";
 import SfButton from "../../atoms/SfButton/SfButton.vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfPagination",
   components: {
@@ -222,6 +224,7 @@ export default {
         return pageNumber;
       }
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/molecules/SfSteps/SfSteps.vue
+++ b/packages/vue/src/components/molecules/SfSteps/SfSteps.vue
@@ -16,7 +16,7 @@
             current: step.current,
             'is-disabled': step.disabled,
           }"
-          data-testid="steps-button"
+          :data-testid="dataTestDisplay('steps-button')"
           @click="stepClick(step)"
         >
           <span class="sf-steps__title">{{ step.step }}</span>
@@ -25,7 +25,7 @@
       <div
         class="sf-steps__progress"
         :style="progress"
-        data-testid="steps-progress"
+        :data-testid="dataTestDisplay('steps-progress')"
       ></div>
     </div>
     <div class="sf-steps__content">
@@ -37,7 +37,9 @@
 import Vue from "vue";
 import SfStep from "./_internal/SfStep.vue";
 import SfButton from "../../atoms/SfButton/SfButton.vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
 Vue.component("SfStep", SfStep);
+
 export default {
   name: "SfSteps",
   components: {
@@ -110,6 +112,7 @@ export default {
         this.$emit("change", index);
       }
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/_internal/SfAccordionItem.vue
@@ -14,7 +14,7 @@
         :aria-expanded="isOpen.toString()"
         :class="{ 'is-open': isOpen }"
         class="sf-button--pure sf-accordion-item__header"
-        :data-testid="'accordion-item-' + header"
+        :data-testid="dataTestDisplay(`accordion-item-${header}`)"
         @click="accordionClick"
       >
         {{ header }}
@@ -40,6 +40,8 @@ import { focus } from "../../../../utilities/directives";
 import SfTransition from "../../../../utilities/transitions/component/SfTransition";
 import SfChevron from "../../../atoms/SfChevron/SfChevron.vue";
 import SfButton from "../../../atoms/SfButton/SfButton.vue";
+import { dataTestDisplay } from "../../../../utilities/helpers";
+
 export default {
   name: "SfAccordionItem",
   directives: { focus },
@@ -63,6 +65,7 @@ export default {
     accordionClick() {
       this.$parent.$emit("toggle", this._uid);
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.vue
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.vue
@@ -4,7 +4,7 @@
       <slot name="prev" v-bind="{ go: () => go('prev') }">
         <SfArrow
           aria-label="previous"
-          data-testid="carousel-prev-button"
+          :data-testid="dataTestDisplay('carousel-prev-button')"
           @click="go('prev')"
         />
       </slot>
@@ -12,7 +12,7 @@
         <SfArrow
           aria-label="next"
           class="sf-arrow--right"
-          data-testid="carousel-next-button"
+          :data-testid="dataTestDisplay('carousel-next-button')"
           @click="go('next')"
         />
       </slot>
@@ -33,6 +33,8 @@ import Vue from "vue";
 import SfCarouselItem from "./_internal/SfCarouselItem.vue";
 import SfArrow from "../../atoms/SfArrow/SfArrow.vue";
 import Glide from "@glidejs/glide";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 Vue.component("SfCarouselItem", SfCarouselItem);
 export default {
   name: "SfCarousel",
@@ -135,6 +137,7 @@ export default {
           break;
       }
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
+++ b/packages/vue/src/components/organisms/SfCollectedProduct/SfCollectedProduct.vue
@@ -62,19 +62,12 @@
         <SfCircleIcon
           icon="cross"
           aria-label="Remove"
-          class="
-            sf-circle-icon--small
-            sf-collected-product__remove
-            sf-collected-product__remove--circle-icon
-          "
+          class="sf-circle-icon--small sf-collected-product__remove sf-collected-product__remove--circle-icon"
           @click="removeHandler"
         />
         <SfButton
-          class="
-            sf-button--text
-            sf-collected-product__remove sf-collected-product__remove--text
-          "
-          data-testid="collected-product-desktop-remove"
+          class="sf-button--text sf-collected-product__remove sf-collected-product__remove--text"
+          :data-testid="dataTestDisplay('collected-product-desktop-remove')"
           @click="removeHandler"
           >Remove</SfButton
         >
@@ -84,11 +77,7 @@
       <div :class="{ 'display-none': !hasMoreActions }">
         <SfButton
           aria-label="More actions"
-          class="
-            sf-button--pure
-            sf-collected-product__more-actions
-            smartphone-only
-          "
+          class="sf-button--pure sf-collected-product__more-actions smartphone-only"
           @click="actionsHandler"
         >
           <SfIcon icon="more" size="18px" />
@@ -106,6 +95,8 @@ import SfButton from "../../atoms/SfButton/SfButton.vue";
 import SfQuantitySelector from "../../atoms/SfQuantitySelector/SfQuantitySelector.vue";
 import SfLink from "../../atoms/SfLink/SfLink.vue";
 import SfProperty from "../../atoms/SfProperty/SfProperty.vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfCollectedProduct",
   components: {
@@ -186,6 +177,7 @@ export default {
     actionsHandler() {
       this.$emit("click:actions");
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/organisms/SfHeader/SfHeader.vue
+++ b/packages/vue/src/components/organisms/SfHeader/SfHeader.vue
@@ -50,7 +50,7 @@
               <SfButton
                 :class="{ 'display-none': !accountIcon }"
                 class="sf-button--pure sf-header__action"
-                data-testid="accountIcon"
+                :data-testid="dataTestDisplay('accountIcon')"
                 aria-label="Account"
                 @click="$emit('click:account')"
               >
@@ -65,7 +65,7 @@
               <SfButton
                 :class="{ 'display-none': !wishlistIcon }"
                 class="sf-button--pure sf-header__action"
-                data-testid="wishlistIcon"
+                :data-testid="dataTestDisplay('wishlistIcon')"
                 aria-label="Wishlist"
                 @click="$emit('click:wishlist')"
               >
@@ -83,7 +83,7 @@
               <SfButton
                 :class="{ 'display-none': !cartIcon }"
                 class="sf-button--pure sf-header__action"
-                data-testid="cartIcon"
+                :data-testid="dataTestDisplay('cartIcon')"
                 aria-label="Cart"
                 @click="$emit('click:cart')"
               >
@@ -109,6 +109,8 @@
 import Vue from "vue";
 import SfHeaderNavigationItem from "./_internal/SfHeaderNavigationItem.vue";
 import SfHeaderNavigation from "./_internal/SfHeaderNavigation.vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 Vue.component("SfHeaderNavigation", SfHeaderNavigation);
 Vue.component("SfHeaderNavigationItem", SfHeaderNavigationItem);
 import {
@@ -269,6 +271,7 @@ export default {
       }
       this.lastScrollPosition = currentScrollPosition;
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
@@ -2,7 +2,7 @@
   <div
     class="sf-product-card"
     :class="{ 'has-colors': colors.length }"
-    data-testid="product-card"
+    :data-testid="dataTestDisplay('product-card')"
   >
     <div class="sf-product-card__image-wrapper">
       <slot
@@ -20,7 +20,7 @@
         <SfButton
           :link="link"
           class="sf-button--pure sf-product-card__link"
-          data-testid="product-link"
+          :data-testid="dataTestDisplay('product-link')"
           aria-label="Go To Product"
           v-on="$listeners"
         >
@@ -84,7 +84,7 @@
       <SfButton
         :aria-label="`${ariaLabel} ${title}`"
         :class="[wishlistIconClasses, { 'display-none': !wishlistIcon }]"
-        data-testid="product-wishlist-button"
+        :data-testid="dataTestDisplay('product-wishlist-button')"
         @click="toggleIsInWishlist"
       >
         <slot name="wishlist-icon" v-bind="{ currentWishlistIcon }">
@@ -111,7 +111,7 @@
             :aria-label="`Add to Cart ${title}`"
             :has-badge="showAddedToCartBadge"
             :disabled="addToCartDisabled"
-            data-testid="product-add-icon"
+            :data-testid="dataTestDisplay('product-add-icon')"
             @click="onAddToCart"
           >
             <span class="sf-product-card__add-button--icons">
@@ -148,7 +148,7 @@
       <SfButton
         :link="link"
         class="sf-button--pure sf-product-card__link"
-        data-testid="product-link"
+        :data-testid="dataTestDisplay('product-link')"
         v-on="$listeners"
       >
         <span class="sf-product-card__title">
@@ -179,7 +179,7 @@
           :class="{ 'display-none': !reviewsCount }"
           :aria-label="`Read ${reviewsCount} reviews about ${title}`"
           class="sf-button--pure sf-product-card__reviews-count"
-          data-testid="product-review-button"
+          :data-testid="dataTestDisplay('product-review-button')"
           @click="$emit('click:reviews')"
         >
           ({{ reviewsCount }})
@@ -203,6 +203,8 @@ import {
   mapMobileObserver,
   unMapMobileObserver,
 } from "../../../utilities/mobile-observer";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfProductCard",
   components: {
@@ -364,6 +366,7 @@ export default {
             if (this.isMobile) {
               this.toggleColorPicker();
             }
+            dataTestDisplay;
           }
         });
       }
@@ -371,6 +374,7 @@ export default {
     toggleColorPicker() {
       this.openColorPicker = !this.openColorPicker;
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/organisms/SfProductCardHorizontal/SfProductCardHorizontal.vue
+++ b/packages/vue/src/components/organisms/SfProductCardHorizontal/SfProductCardHorizontal.vue
@@ -15,10 +15,7 @@
       >
         <SfLink
           :link="link"
-          class="
-            sf-product-card-horizontal__link
-            sf-product-card-horizontal__link--image
-          "
+          class="sf-product-card-horizontal__link sf-product-card-horizontal__link--image"
         >
           <template v-if="Array.isArray(image)">
             <SfImage
@@ -119,7 +116,7 @@
           <SfIcon
             :icon="currentWishlistIcon"
             size="19px"
-            data-test="sf-wishlist-icon"
+            :data-test="dataTestDisplay('sf-wishlist-icon')"
           />
         </slot>
       </SfButton>
@@ -134,6 +131,7 @@ import SfRating from "../../atoms/SfRating/SfRating.vue";
 import SfImage from "../../atoms/SfImage/SfImage.vue";
 import SfButton from "../../atoms/SfButton/SfButton.vue";
 import SfAddToCart from "../../molecules/SfAddToCart/SfAddToCart.vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
 
 export default {
   name: "SfProductCardHorizontal",
@@ -257,6 +255,7 @@ export default {
     toggleIsInWishlist() {
       this.$emit("click:wishlist", !this.isInWishlist);
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/pages/checkout/Checkout.vue
+++ b/packages/vue/src/components/pages/checkout/Checkout.vue
@@ -78,16 +78,12 @@
     <div class="actions">
       <SfButton
         class="sf-button--full-width actions__button"
-        data-testid="next-button"
+        :data-testid="dataTestDisplay('next-button')"
         @click="currentStep++"
         >{{ steps[currentStep] }}</SfButton
       >
       <SfButton
-        class="
-          sf-button--full-width sf-button--underlined
-          actions__button
-          smartphone-only
-        "
+        class="sf-button--full-width sf-button--underlined actions__button smartphone-only"
         @click="currentStep--"
         >Go back</SfButton
       >
@@ -106,6 +102,8 @@ import {
   SfOrderReview,
 } from "@storefront-ui/vue";
 import { countries, months, years } from "../../templates/internalData.js";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "Checkout",
   components: {
@@ -320,6 +318,7 @@ export default {
         this.currentStep = next;
       }
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/pages/checkout/_internal/ConfirmOrder.vue
+++ b/packages/vue/src/components/pages/checkout/_internal/ConfirmOrder.vue
@@ -20,13 +20,13 @@
         v-for="(product, index) in products"
         :key="index"
         class="table__row"
-        data-testid="product-table-row"
+        :data-testid="dataTestDisplay('product-table-row')"
       >
         <SfTableData class="table__image">
           <SfImage
             :src="product.image"
             :alt="product.title"
-            data-testid="product-image-table-data"
+            :data-testid="dataTestDisplay('product-image-table-data')"
           />
         </SfTableData>
         <SfTableData class="table__data"
@@ -35,7 +35,7 @@
 
         <SfTableData
           class="table__description"
-          data-testid="product-description-table-data"
+          :data-testid="dataTestDisplay('product-description-table-data')"
         >
           <div class="product-title">{{ product.title }}</div>
           <div class="product-sku">{{ product.sku }}</div>
@@ -122,6 +122,8 @@ import {
   SfProperty,
   SfLink,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "ReviewOrder",
   components: {
@@ -201,6 +203,9 @@ export default {
       const total = subtotal + (isNaN(shipping) ? 0 : shipping);
       return "$" + total.toFixed(2);
     },
+  },
+  methods: {
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/pages/checkout/_internal/OrderReview.vue
+++ b/packages/vue/src/components/pages/checkout/_internal/OrderReview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-testid="review">
+  <div :data-testid="dataTestDisplay('review')">
     <SfHeading
       title="Order review"
       :level="3"
@@ -9,7 +9,7 @@
       <p class="review__title">Personal details</p>
       <SfButton
         class="sf-button--text"
-        data-testid="personal-edit-button"
+        :data-testid="dataTestDisplay('personal-edit-button')"
         @click="$emit('click:edit', 0)"
         >Edit
       </SfButton>
@@ -31,7 +31,7 @@
       <p class="review__title">Shipping details</p>
       <SfButton
         class="sf-button--text"
-        data-testid="shipping-edit-button"
+        :data-testid="dataTestDisplay('shipping-edit-button')"
         @click="$emit('click:edit', 1)"
       >
         Edit
@@ -50,7 +50,7 @@
       <p class="review__title">Billing address</p>
       <SfButton
         class="sf-button--text"
-        data-testid="billing-edit-button"
+        :data-testid="dataTestDisplay('billing-edit-button')"
         @click="$emit('click:edit', 2)"
       >
         Edit
@@ -73,7 +73,7 @@
       <p class="review__title">Payment method</p>
       <SfButton
         class="sf-button--text"
-        data-testid="payment-edit-button"
+        :data-testid="dataTestDisplay('payment-edit-button')"
         @click="$emit('click:edit', 2)"
       >
         Edit
@@ -89,7 +89,7 @@
       />
       <SfButton
         class="promo-code__button"
-        data-testid="apply-button"
+        :data-testid="dataTestDisplay('apply-button')"
         @click="$emit('click:apply')"
       >
         Apply
@@ -115,6 +115,8 @@ import {
   SfCharacteristic,
   SfInput,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "OrderReview",
   components: {
@@ -167,6 +169,9 @@ export default {
       );
       return method ? method : { label: "" };
     },
+  },
+  methods: {
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/pages/checkout/_internal/OrderSummary.vue
+++ b/packages/vue/src/components/pages/checkout/_internal/OrderSummary.vue
@@ -37,7 +37,7 @@
       />
       <SfButton
         class="promo-code__button"
-        data-testid="apply-button"
+        :data-testid="dataTestDisplay('apply-button')"
         @click="$emit('click:apply')"
       >
         Apply
@@ -79,6 +79,8 @@ import {
   SfCharacteristic,
   SfInput,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "OrderSummary",
   components: {
@@ -168,6 +170,9 @@ export default {
       const total = subtotal + (isNaN(shipping) ? 0 : shipping);
       return "$" + total.toFixed(2);
     },
+  },
+  methods: {
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/pages/checkout/_internal/Payment.vue
+++ b/packages/vue/src/components/pages/checkout/_internal/Payment.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-testid="payment">
+  <div :data-testid="dataTestDisplay('payment')">
     <SfHeading
       title="Billing address"
       :level="3"
@@ -81,15 +81,9 @@
         v-model="country"
         :value="country"
         placeholder="Country"
-        class="
-          form__element
-          form__element--half
-          form__element--half-even
-          form__select
-          sf-select--underlined
-        "
+        class="form__element form__element--half form__element--half-even form__select sf-select--underlined"
         required
-        data-testid="country"
+        :data-testid="dataTestDisplay('country')"
         @change="updateField('country', $event)"
       >
         <SfSelectOption
@@ -124,7 +118,10 @@
       class="sf-heading--left sf-heading--no-underline title"
     />
     <div class="form">
-      <div class="payment-methods" data-testid="payment-methods">
+      <div
+        class="payment-methods"
+        :data-testid="dataTestDisplay('payment-methods')"
+      >
         <SfRadio
           v-for="item in paymentMethods"
           :key="item.value"
@@ -179,11 +176,7 @@
           />
           <div class="credit-card-form__group">
             <span
-              class="
-                credit-card-form__label
-                credit-card-form__label--small
-                credit-card-form__label--required
-              "
+              class="credit-card-form__label credit-card-form__label--small credit-card-form__label--required"
               >Expiry date:</span
             >
             <div class="credit-card-form__element">
@@ -191,11 +184,7 @@
                 v-model="cardMonth"
                 :value="cardMonth"
                 label="Month"
-                class="
-                  credit-card-form__input credit-card-form__input--with-spacer
-                  form__select
-                  sf-select--underlined
-                "
+                class="credit-card-form__input credit-card-form__input--with-spacer form__select sf-select--underlined"
                 @change="updateField('cardMonth', $event)"
               >
                 <SfSelectOption
@@ -210,11 +199,7 @@
                 v-model="cardYear"
                 :value="cardYear"
                 label="Year"
-                class="
-                  credit-card-form__input
-                  form__select
-                  sf-select--underlined
-                "
+                class="credit-card-form__input form__select sf-select--underlined"
                 @change="updateField('cardYear', $event)"
               >
                 <SfSelectOption
@@ -234,11 +219,7 @@
               type="number"
               label="Code CVC"
               name="cardCVC"
-              class="
-                credit-card-form__input
-                credit-card-form__input--small
-                credit-card-form__input--with-spacer
-              "
+              class="credit-card-form__input credit-card-form__input--small credit-card-form__input--with-spacer"
               @input="updateField('cardCVC', $event)"
             />
             <SfButton class="sf-button--text credit-card-form__button"
@@ -268,6 +249,8 @@ import {
   SfImage,
   SfCheckbox,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "Payment",
   components: {

--- a/packages/vue/src/components/pages/checkout/_internal/PersonalDetails.vue
+++ b/packages/vue/src/components/pages/checkout/_internal/PersonalDetails.vue
@@ -3,7 +3,7 @@
     <div class="log-in">
       <SfButton
         class="log-in__button sf-button--full-width color-secondary"
-        data-testid="login-button"
+        :data-testid="dataTestDisplay('login-button')"
         >Log into your account</SfButton
       >
       <p class="log-in__info">or fill the details below:</p>
@@ -58,7 +58,7 @@
           name="createAccount"
           label="I want to create an account"
           class="form__checkbox"
-          data-testid="create-account-checkbox"
+          :data-testid="dataTestDisplay('create-account-checkbox')"
         />
       </div>
       <transition name="sf-fade">
@@ -70,7 +70,7 @@
           label="Create Password"
           class="form__element"
           required
-          data-testid="create-password-input"
+          :data-testid="dataTestDisplay('create-password-input')"
         />
       </transition>
     </div>
@@ -84,6 +84,8 @@ import {
   SfHeading,
   SfCharacteristic,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "PersonalDetails",
   components: {
@@ -138,6 +140,7 @@ export default {
         [fieldName]: fieldValue,
       });
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/pages/checkout/_internal/Shipping.vue
+++ b/packages/vue/src/components/pages/checkout/_internal/Shipping.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-testid="shipping">
+  <div :data-testid="dataTestDisplay('shipping')">
     <SfHeading
       title="Shipping"
       :level="3"
@@ -63,15 +63,9 @@
       <SfSelect
         v-model="country"
         placeholder="Country"
-        class="
-          form__element
-          form__element--half
-          form__element--half-even
-          form__select
-          sf-select--underlined
-        "
+        class="form__element form__element--half form__element--half-even form__select sf-select--underlined"
         :valid="true"
-        data-testid="country"
+        :data-testid="dataTestDisplay('country')"
         @input="updateField('country', $event)"
       >
         <SfSelectOption
@@ -98,7 +92,10 @@
       class="sf-heading--left sf-heading--no-underline title"
     />
     <div class="form">
-      <div class="form__radio-group" data-testid="shipping-method">
+      <div
+        class="form__radio-group"
+        :data-testid="dataTestDisplay('shipping-method')"
+      >
         <SfRadio
           v-for="item in shippingMethods"
           :key="item.value"
@@ -149,6 +146,8 @@ import {
   SfSelect,
   SfRadio,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "Shipping",
   components: {
@@ -253,6 +252,7 @@ export default {
         [fieldName]: fieldValue,
       });
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/pages/home/Home.vue
+++ b/packages/vue/src/components/pages/home/Home.vue
@@ -167,7 +167,7 @@
       class="app-banner desktop-only"
       subtitle="fashion to take away"
       image="/assets/storybook/Home/bannerD.png"
-      data-testid="application-banner"
+      :data-testid="dataTestDisplay('application-banner')"
     >
       <template #title>
         <span class="app-banner__title"
@@ -179,7 +179,7 @@
           <SfButton
             class="app-banner__button sf-banner__call-to-action"
             aria-label="Go to Apple Product"
-            data-testid="banner-cta-button"
+            :data-testid="dataTestDisplay('banner-cta-button')"
           >
             <SfImage
               src="/assets/storybook/Home/apple.png"
@@ -191,7 +191,7 @@
           <SfButton
             class="app-banner__button sf-banner__call-to-action"
             aria-label="Go to Google Product"
-            data-testid="banner-cta-button"
+            :data-testid="dataTestDisplay('banner-cta-button')"
           >
             <SfImage
               src="/assets/storybook/Home/google.png"
@@ -222,6 +222,7 @@ import {
   mapMobileObserver,
   unMapMobileObserver,
 } from "../../../utilities/mobile-observer";
+import { dataTestDisplay } from "../../../utilities/helpers";
 
 export default {
   name: "Home",
@@ -397,6 +398,7 @@ export default {
       return (this.products[index].isInWishlist =
         !this.products[index].isInWishlist);
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/pages/login/Login.vue
+++ b/packages/vue/src/components/pages/login/Login.vue
@@ -11,7 +11,7 @@
           v-if="isLogIn"
           key="log-in"
           class="modal-content"
-          data-testid="login-modal"
+          :data-testid="dataTestDisplay('login-modal')"
         >
           <form class="form" @submit.prevent="() => false">
             <SfInput
@@ -38,14 +38,14 @@
             <SfButton
               type="submit"
               class="sf-button--full-width form__submit"
-              data-testid="log-in-button"
+              :data-testid="dataTestDisplay('log-in-button')"
             >
               Log In
             </SfButton>
           </form>
           <SfButton
             class="sf-button--text action-button"
-            data-testid="forgotten-password-button"
+            :data-testid="dataTestDisplay('forgotten-password-button')"
           >
             Forgotten password?
           </SfButton>
@@ -57,7 +57,7 @@
             />
             <SfButton
               class="sf-button--text"
-              data-testid="register-now-button"
+              :data-testid="dataTestDisplay('register-now-button')"
               @click="isLogIn = false"
             >
               Register now
@@ -68,7 +68,7 @@
           v-else
           key="sign-up"
           class="modal-content"
-          data-testid="signin-modal"
+          :data-testid="dataTestDisplay('signin-modal')"
         >
           <form class="form" @submit.prevent="() => false">
             <SfInput
@@ -100,14 +100,14 @@
             <SfButton
               type="submit"
               class="sf-button--full-width form__submit"
-              data-testid="create-acount-button"
+              :data-testid="dataTestDisplay('create-acount-button')"
             >
               Create an account
             </SfButton>
           </form>
           <SfButton
             class="sf-button--text action-button"
-            data-testid="log-in-account"
+            :data-testid="dataTestDisplay('log-in-account')"
             @click="isLogIn = true"
           >
             or Log In To Your Account
@@ -117,7 +117,7 @@
     </SfModal>
     <SfButton
       class="open-button"
-      data-testid="open-modal-button"
+      :data-testid="dataTestDisplay('open-modal-button')"
       @click="toggleModal"
     >
       Open Modal
@@ -132,6 +132,8 @@ import {
   SfCheckbox,
   SfHeading,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "Login",
   components: {
@@ -172,6 +174,7 @@ export default {
     toggleModal() {
       this.openModal = !this.openModal;
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/pages/my-account/MyAccount.vue
+++ b/packages/vue/src/components/pages/my-account/MyAccount.vue
@@ -11,19 +11,25 @@
       @click:change="changeActivePage"
     >
       <SfContentCategory title="Personal Details">
-        <SfContentPage title="My profile" data-testid="my-profile">
+        <SfContentPage
+          title="My profile"
+          :data-testid="dataTestDisplay('my-profile')"
+        >
           <SfMyProfile
             :account="account"
-            data-testid="my-profile-tabs"
+            :data-testid="dataTestDisplay('my-profile-tabs')"
             @update:personal="account = { ...account, ...$event }"
             @update:password="account = { ...account, ...$event }"
           />
         </SfContentPage>
-        <SfContentPage title="Shipping details" data-testid="shipping-details">
+        <SfContentPage
+          title="Shipping details"
+          :data-testid="dataTestDisplay('shipping-details')"
+        >
           <SfShippingDetails
             :account="account"
             :countries="countries"
-            data-testid="shipping-details-tabs"
+            :data-testid="dataTestDisplay('shipping-details-tabs')"
             @update:shipping="account = { ...account, ...$event }"
           />
         </SfContentPage>
@@ -49,6 +55,8 @@ import {
   SfOrderHistory,
 } from "@storefront-ui/vue";
 import { countries } from "../../templates/internalData.js";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "MyAccount",
   components: {
@@ -119,6 +127,7 @@ export default {
       }
       this.activePage = title;
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/pages/product/Product.vue
+++ b/packages/vue/src/components/pages/product/Product.vue
@@ -51,7 +51,7 @@
             </div>
             <SfButton
               class="sf-button--text"
-              data-testid="read-all-reviews"
+              :data-testid="dataTestDisplay('read-all-reviews')"
               @click="changeTab(2)"
             >
               Read all reviews
@@ -191,6 +191,8 @@ import {
   SfBreadcrumbs,
   SfNotification,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "Product",
   components: {
@@ -359,6 +361,7 @@ export default {
         .scrollIntoView({ behavior: "smooth", block: "end" });
       this.openTab = tabNumber;
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/templates/SfConfirmOrder/SfConfirmOrder.vue
+++ b/packages/vue/src/components/templates/SfConfirmOrder/SfConfirmOrder.vue
@@ -4,10 +4,7 @@
       <SfHeading
         :title="orderTitle"
         :level="orderTitleLevel"
-        class="
-          sf-heading--left sf-heading--no-underline
-          sf-confirm-order__heading
-        "
+        class="sf-heading--left sf-heading--no-underline sf-confirm-order__heading"
       />
     </slot>
     <slot name="table" v-bind="{ tableHeaders, orderItems }">
@@ -32,7 +29,7 @@
           v-for="(product, index) in orderItems"
           :key="index"
           class="sf-confirm-order__table-row"
-          data-testid="product-table-row"
+          :data-testid="dataTestDisplay('product-table-row')"
         >
           <SfTableData class="sf-confirm-order__table-image">
             <SfImage
@@ -41,7 +38,7 @@
               :alt="product.title"
               :width="82"
               :height="124"
-              data-testid="product-image-table-data"
+              :data-testid="dataTestDisplay('product-image-table-data')"
             />
             <SfImage
               v-else
@@ -49,7 +46,7 @@
               :alt="product.title"
               :width="44"
               :height="66"
-              data-testid="product-image-table-data"
+              :data-testid="dataTestDisplay('product-image-table-data')"
             />
           </SfTableData>
           <SfTableData class="sf-confirm-order__table-data"
@@ -57,7 +54,7 @@
           </SfTableData>
           <SfTableData
             class="sf-confirm-order__table-description"
-            data-testid="product-description-table-data"
+            :data-testid="dataTestDisplay('product-description-table-data')"
           >
             <div class="sf-confirm-order__product-title">
               {{ product.title }}
@@ -89,10 +86,7 @@
         <SfProperty
           :name="propertiesNames[0]"
           :value="subtotal"
-          class="
-            sf-property--full-width
-            sf-confirm-order__property sf-confirm-order__property-subtotal
-          "
+          class="sf-property--full-width sf-confirm-order__property sf-confirm-order__property-subtotal"
         >
         </SfProperty>
         <SfProperty
@@ -105,10 +99,7 @@
         <SfProperty
           :name="propertiesNames[2]"
           :value="total"
-          class="
-            sf-property--full-width sf-property--large
-            sf-confirm-order__property-total
-          "
+          class="sf-property--full-width sf-property--large sf-confirm-order__property-total"
         >
         </SfProperty>
         <slot name="checkbox" v-bind="{ terms }">
@@ -143,6 +134,8 @@ import {
   mapMobileObserver,
   unMapMobileObserver,
 } from "../../../utilities/mobile-observer";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfConfirmOrder",
   components: {
@@ -216,6 +209,9 @@ export default {
   },
   beforeDestroy() {
     unMapMobileObserver();
+  },
+  methods: {
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/templates/SfMyNewsletter/SfMyNewsletter.vue
+++ b/packages/vue/src/components/templates/SfMyNewsletter/SfMyNewsletter.vue
@@ -1,6 +1,6 @@
 <template>
   <SfTabs :open-tab="1" class="sf-my-newsletter tab-orphan">
-    <SfTab :title="tabTitle" data-testid="newsletter-tab">
+    <SfTab :title="tabTitle" :data-testid="dataTestDisplay('newsletter-tab')">
       <slot name="tab-description" v-bind="{ tabDescription }">
         <p class="message">
           {{ tabDescription }}
@@ -25,7 +25,7 @@
         <slot name="form-button" v-bind="{ buttonText }">
           <SfButton
             class="form__button"
-            data-testid="save-changes-button"
+            :data-testid="dataTestDisplay('save-changes-button')"
             @click="$emit('save-changes', newsletter)"
             >{{ buttonText }}</SfButton
           >
@@ -43,6 +43,8 @@
 </template>
 <script>
 import { SfTabs, SfCheckbox, SfButton } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfMyNewsletter",
   components: { SfTabs, SfCheckbox, SfButton },
@@ -73,6 +75,9 @@ export default {
     return {
       newsletter: [],
     };
+  },
+  methods: {
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/templates/SfMyProfile/SfMyProfile.vue
+++ b/packages/vue/src/components/templates/SfMyProfile/SfMyProfile.vue
@@ -35,7 +35,7 @@
           />
           <SfButton
             class="form__button"
-            data-testid="save-changes-button"
+            :data-testid="dataTestDisplay('save-changes-button')"
             @click="updatePersonal"
           >
             {{ saveButtonText }}
@@ -91,7 +91,7 @@
           />
           <SfButton
             class="form__button"
-            data-testid="update-password-button"
+            :data-testid="dataTestDisplay('update-password-button')"
             @click="updatePassword"
           >
             {{ updateButtonText }}
@@ -103,6 +103,8 @@
 </template>
 <script>
 import { SfTabs, SfInput, SfButton } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfMyProfile",
   components: {
@@ -177,6 +179,7 @@ export default {
       this.$emit("update:password", password);
     },
   },
+  dataTestDisplay,
 };
 </script>
 <style lang="scss" scoped>

--- a/packages/vue/src/components/templates/SfOrderHistory/SfOrderHistory.vue
+++ b/packages/vue/src/components/templates/SfOrderHistory/SfOrderHistory.vue
@@ -2,9 +2,9 @@
   <SfTabs
     class="sf-order-history"
     :open-tab="1"
-    data-testid="order-history-tabs"
+    :data-testid="dataTestDisplay('order-history-tabs')"
   >
-    <SfTab :title="tabTitle" data-testid="my-orders">
+    <SfTab :title="tabTitle" :data-testid="dataTestDisplay('my-orders')">
       <slot
         name="order-history-description"
         v-bind="{ orderHistoryDescription }"
@@ -36,7 +36,7 @@
                     <span class="smartphone-only">Download</span>
                     <SfButton
                       class="desktop-only sf-button--text orders__download-all"
-                      data-testid="download-all-button"
+                      :data-testid="dataTestDisplay('download-all-button')"
                       @click="$emit('download-all')"
                       >Download all
                     </SfButton>
@@ -67,7 +67,7 @@
                     >
                     <SfButton
                       class="sf-button--text desktop-only"
-                      data-testid="view-details-button"
+                      :data-testid="dataTestDisplay('view-details-button')"
                       @click="$emit('view-details')"
                       >View details</SfButton
                     >
@@ -83,6 +83,7 @@
 </template>
 <script>
 import { SfTabs, SfTable, SfButton } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
 
 export default {
   name: "SfOrderHistory",
@@ -133,6 +134,9 @@ export default {
     ordersHistory() {
       return this.orders;
     },
+  },
+  methods: {
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/templates/SfOrderReview/SfOrderReview.vue
+++ b/packages/vue/src/components/templates/SfOrderReview/SfOrderReview.vue
@@ -1,13 +1,10 @@
 <template>
-  <div class="sf-order-review" data-testid="review">
+  <div class="sf-order-review" :data-testid="dataTestDisplay('review')">
     <slot name="heading" v-bind="{ reviewTitle, reviewTitleLevel }">
       <SfHeading
         :title="reviewTitle"
         :level="reviewTitleLevel"
-        class="
-          sf-heading--left sf-heading--no-underline
-          sf-order-review__heading
-        "
+        class="sf-heading--left sf-heading--no-underline sf-order-review__heading"
       />
     </slot>
     <slot name="personal-details" v-bind="{ order, shipping, buttonText }">
@@ -15,7 +12,7 @@
         <p class="sf-order-review__title">Personal details</p>
         <SfButton
           class="sf-button--text"
-          data-testid="personal-edit-button"
+          :data-testid="dataTestDisplay('personal-edit-button')"
           @click="$emit('click:personal-details-edit', 0)"
           >{{ buttonText }}
         </SfButton>
@@ -43,7 +40,7 @@
         <p class="sf-order-review__title">Shipping details</p>
         <SfButton
           class="sf-button--text"
-          data-testid="shipping-edit-button"
+          :data-testid="dataTestDisplay('shipping-edit-button')"
           @click="$emit('click:shipping-details-edit', 1)"
         >
           {{ buttonText }}
@@ -51,9 +48,7 @@
       </div>
       <p class="sf-order-review__content">
         <span
-          class="
-            sf-order-review__content-label sf-order-review__content-shipping
-          "
+          class="sf-order-review__content-label sf-order-review__content-shipping"
           >{{ shippingMethod.value }}</span
         ><br />
         {{ shipping.streetName }} {{ shipping.apartment }} <br />
@@ -65,7 +60,7 @@
         <p class="sf-order-review__title">Billing address</p>
         <SfButton
           class="sf-button--text"
-          data-testid="billing-edit-button"
+          :data-testid="dataTestDisplay('billing-edit-button')"
           @click="$emit('click:billing-details-edit', 2)"
         >
           {{ buttonText }}
@@ -92,7 +87,7 @@
         <p class="sf-order-review__title">Payment method</p>
         <SfButton
           class="sf-button--text"
-          data-testid="payment-edit-button"
+          :data-testid="dataTestDisplay('payment-edit-button')"
           @click="$emit('click:payment-details-edit', 2)"
         >
           {{ buttonText }}
@@ -110,7 +105,7 @@
         />
         <SfButton
           class="sf-order-review__promo-code-button"
-          data-testid="apply-button"
+          :data-testid="dataTestDisplay('apply-button')"
           @click="$emit('click:promo-code-apply')"
         >
           Apply
@@ -139,6 +134,8 @@ import {
   SfCharacteristic,
   SfInput,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfOrderReview",
   components: {
@@ -214,6 +211,9 @@ export default {
     paymentMethod() {
       return this.payment.paymentMethod;
     },
+  },
+  methods: {
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/templates/SfOrderSummary/SfOrderSummary.vue
+++ b/packages/vue/src/components/templates/SfOrderSummary/SfOrderSummary.vue
@@ -4,10 +4,7 @@
       <SfHeading
         :title="orderTitle"
         :level="orderTitleLevel"
-        class="
-          sf-heading--left sf-heading--no-underline
-          sf-order-summary__heading
-        "
+        class="sf-heading--left sf-heading--no-underline sf-order-summary__heading"
       />
     </slot>
     <div class="highlighted highlighted--total">
@@ -24,35 +21,23 @@
         <SfProperty
           :name="propertiesNames[0]"
           :value="totalItems"
-          class="
-            sf-property--full-width sf-property--large
-            sf-order-summary__property
-          "
+          class="sf-property--full-width sf-property--large sf-order-summary__property"
         />
         <SfProperty
           :name="propertiesNames[1]"
           :value="subtotal"
-          class="
-            sf-property--full-width sf-property--large
-            sf-order-summary__property
-          "
+          class="sf-property--full-width sf-property--large sf-order-summary__property"
         />
         <SfProperty
           :name="propertiesNames[2]"
           :value="shippingMethod.price"
-          class="
-            sf-property--full-width sf-property--large
-            sf-order-summary__property
-          "
+          class="sf-property--full-width sf-property--large sf-order-summary__property"
         />
         <SfDivider class="sf-order-summary__divider" />
         <SfProperty
           :name="propertiesNames[3]"
           :value="total"
-          class="
-            sf-property--full-width sf-property--large
-            sf-order-summary__property
-          "
+          class="sf-property--full-width sf-property--large sf-order-summary__property"
         />
       </slot>
     </div>
@@ -66,7 +51,7 @@
         />
         <SfButton
           class="sf-order-summary__promo-code-button"
-          data-testid="apply-button"
+          :data-testid="dataTestDisplay('apply-button')"
           @click="$emit('click:apply-code')"
         >
           Apply
@@ -99,6 +84,8 @@ import {
   SfCharacteristic,
   SfInput,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfOrderSummary",
   components: {
@@ -173,6 +160,9 @@ export default {
       const total = subtotal + (isNaN(shipping) ? 0 : shipping);
       return "$" + total.toFixed(2);
     },
+  },
+  methods: {
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/templates/SfPayment/SfPayment.vue
+++ b/packages/vue/src/components/templates/SfPayment/SfPayment.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sf-payment" data-testid="payment">
+  <div class="sf-payment" :data-testid="dataTestDisplay('payment')">
     <slot
       name="billing-heading"
       v-bind="{ billingHeading, billingHeadingLevel }"
@@ -105,15 +105,9 @@
           v-model="country"
           :value="country"
           :placeholder="billingSelectLabel"
-          class="
-            form__element
-            form__element--half
-            form__element--half-even
-            form__select
-            sf-select--underlined
-          "
+          class="form__element form__element--half form__element--half-even form__select sf-select--underlined"
           required
-          data-testid="country"
+          :data-testid="dataTestDisplay('country')"
           @change="updateField('country', $event)"
         >
           <SfSelectOption
@@ -155,7 +149,10 @@
     </slot>
     <div class="form">
       <slot name="payment-form" v-bind="{ paymentMethods }">
-        <div class="payment-methods" data-testid="payment-methods">
+        <div
+          class="payment-methods"
+          :data-testid="dataTestDisplay('payment-methods')"
+        >
           <slot name="payment-methods">
             <SfRadio
               v-for="item in paymentMethods"
@@ -218,11 +215,7 @@
               />
               <div class="credit-card-form__group">
                 <span
-                  class="
-                    credit-card-form__label
-                    credit-card-form__label--small
-                    credit-card-form__label--required
-                  "
+                  class="credit-card-form__label credit-card-form__label--small credit-card-form__label--required"
                   >{{ expiryDateLabel }}</span
                 >
                 <div class="credit-card-form__element">
@@ -230,12 +223,7 @@
                     v-model="cardMonth"
                     :value="cardMonth"
                     label="Month"
-                    class="
-                      credit-card-form__input
-                      credit-card-form__input--with-spacer
-                      form__select
-                      sf-select--underlined
-                    "
+                    class="credit-card-form__input credit-card-form__input--with-spacer form__select sf-select--underlined"
                     @change="updateField('cardMonth', $event)"
                   >
                     <SfSelectOption
@@ -250,11 +238,7 @@
                     v-model="cardYear"
                     :value="cardYear"
                     label="Year"
-                    class="
-                      credit-card-form__input
-                      form__select
-                      sf-select--underlined
-                    "
+                    class="credit-card-form__input form__select sf-select--underlined"
                     @change="updateField('cardYear', $event)"
                   >
                     <SfSelectOption
@@ -274,11 +258,7 @@
                   type="number"
                   label="Code CVC"
                   name="cardCVC"
-                  class="
-                    credit-card-form__input
-                    credit-card-form__input--small
-                    credit-card-form__input--with-spacer
-                  "
+                  class="credit-card-form__input credit-card-form__input--small credit-card-form__input--with-spacer"
                   @input="updateField('cardCVC', $event)"
                 />
                 <SfButton
@@ -312,6 +292,8 @@ import {
   SfImage,
   SfCheckbox,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfPayment",
   components: {
@@ -505,6 +487,7 @@ export default {
         [fieldName]: fieldValue,
       });
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/templates/SfPersonalDetails/SfPersonalDetails.vue
+++ b/packages/vue/src/components/templates/SfPersonalDetails/SfPersonalDetails.vue
@@ -4,7 +4,7 @@
       <slot name="log-in" v-bind="{ buttonText, logInInfo }">
         <SfButton
           class="log-in__button sf-button--full-width color-secondary"
-          data-testid="login-button"
+          :data-testid="dataTestDisplay('login-button')"
           @click="$emit('log-in')"
           >{{ buttonText }}</SfButton
         >
@@ -81,7 +81,7 @@
             name="createAccount"
             :label="createAccountCheckboxLabel"
             class="form__checkbox"
-            data-testid="create-account-checkbox"
+            :data-testid="dataTestDisplay('create-account-checkbox')"
             @change="$emit('create-account', createAccount)"
           />
           <transition :name="transition">
@@ -93,7 +93,7 @@
               :label="createAccountInputLabel"
               class="form__element"
               required
-              data-testid="create-password-input"
+              :data-testid="dataTestDisplay('create-password-input')"
             />
           </transition>
         </slot>
@@ -109,6 +109,8 @@ import {
   SfHeading,
   SfCharacteristic,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfPersonalDetails",
   components: {
@@ -206,6 +208,7 @@ export default {
         [fieldName]: fieldValue,
       });
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/templates/SfShipping/SfShipping.vue
+++ b/packages/vue/src/components/templates/SfShipping/SfShipping.vue
@@ -66,15 +66,9 @@
         <SfSelect
           v-model="country"
           :placeholder="selectLabel"
-          class="
-            form__element
-            form__element--half
-            form__element--half-even
-            form__select
-            sf-select--underlined
-          "
+          class="form__element form__element--half form__element--half-even form__select sf-select--underlined"
           :valid="true"
-          data-testid="country"
+          :data-testid="dataTestDisplay('country')"
           @input="updateField('country', $event)"
         >
           <SfSelectOption
@@ -163,6 +157,8 @@ import {
   SfSelect,
   SfRadio,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfShipping",
   components: {
@@ -254,6 +250,7 @@ export default {
         [fieldName]: fieldValue,
       });
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/components/templates/SfShippingDetails/SfShippingDetails.vue
+++ b/packages/vue/src/components/templates/SfShippingDetails/SfShippingDetails.vue
@@ -6,7 +6,7 @@
         key="edit-address"
         :open-tab="1"
         class="tab-orphan"
-        data-testid="shipping-details-tabs"
+        :data-testid="dataTestDisplay('shipping-details-tabs')"
       >
         <SfTab :title="changeAddressTabTitle">
           <slot name="change-address-description">
@@ -28,9 +28,7 @@
                 name="lastName"
                 :label="inputsLabels[1]"
                 required
-                class="
-                  form__element form__element--half form__element--half-even
-                "
+                class="form__element form__element--half form__element--half-even"
               />
               <SfInput
                 v-model="streetName"
@@ -58,9 +56,7 @@
                 name="state"
                 :label="inputsLabels[5]"
                 required
-                class="
-                  form__element form__element--half form__element--half-even
-                "
+                class="form__element form__element--half form__element--half-even"
               />
               <SfInput
                 v-model="zipCode"
@@ -74,14 +70,8 @@
                 name="country"
                 :label="selectLabel"
                 required
-                class="
-                  sf-component-select--underlined
-                  form__select
-                  form__element
-                  form__element--half
-                  form__element--half-even
-                "
-                data-testid="country"
+                class="sf-component-select--underlined form__select form__element form__element--half form__element--half-even"
+                :data-testid="dataTestDisplay('country')"
               >
                 <SfComponentSelectOption
                   v-for="countryOption in countries"
@@ -101,7 +91,7 @@
               <SfButton
                 v-if="updateAddressButtonText"
                 class="action-button"
-                data-testid="update-address-button"
+                :data-testid="dataTestDisplay('update-address-button')"
                 @click="updateAddress"
               >
                 {{ updateAddressButtonText }}</SfButton
@@ -109,7 +99,7 @@
               <SfButton
                 v-if="cancelButtonText"
                 class="action-button color-secondary cancel-button"
-                data-testid="update-address-button"
+                :data-testid="dataTestDisplay('update-address-button')"
                 @click="cancelEditing"
               >
                 {{ cancelButtonText }}</SfButton
@@ -131,7 +121,7 @@
                 v-for="(shipping, key) in account.shipping"
                 :key="shipping.streetName + shipping.apartment"
                 class="shipping"
-                data-testid="shipping-address-list-item"
+                :data-testid="dataTestDisplay('shipping-address-list-item')"
               >
                 <div class="shipping__content">
                   <slot name="shipping-details">
@@ -160,7 +150,7 @@
                   </SfButton>
                   <SfButton
                     v-if="changeButtonText"
-                    data-testid="change-address"
+                    :data-testid="dataTestDisplay('change-address')"
                     @click="changeAddress(key)"
                   >
                     {{ changeButtonText }}
@@ -168,7 +158,7 @@
                   <SfButton
                     v-if="deleteButtonText"
                     class="shipping__button-delete desktop-only"
-                    data-testid="delete-address"
+                    :data-testid="dataTestDisplay('delete-address')"
                     @click="deleteAddress(key)"
                   >
                     {{ deleteButtonText }}
@@ -180,7 +170,7 @@
           <SfButton
             v-if="addNewAddressButtonText"
             class="action-button"
-            data-testid="add-new-address"
+            :data-testid="dataTestDisplay('add-new-address')"
             @click="changeAddress(-1)"
           >
             {{ addNewAddressButtonText }}</SfButton
@@ -198,6 +188,8 @@ import {
   SfComponentSelect,
   SfIcon,
 } from "@storefront-ui/vue";
+import { dataTestDisplay } from "../../../utilities/helpers";
+
 export default {
   name: "SfShippingDetails",
   components: {
@@ -341,6 +333,7 @@ export default {
       account.shipping.splice(index, 1);
       this.$emit("delete-address", index);
     },
+    dataTestDisplay,
   },
 };
 </script>

--- a/packages/vue/src/utilities/helpers/data-test-display.js
+++ b/packages/vue/src/utilities/helpers/data-test-display.js
@@ -1,0 +1,4 @@
+export const dataTestDisplay = (id) => {
+  if (process.env.NODE_ENV === "production") return undefined;
+  return id;
+};

--- a/packages/vue/src/utilities/helpers/index.js
+++ b/packages/vue/src/utilities/helpers/index.js
@@ -1,2 +1,3 @@
 export * from "./check-environment";
 export * from "./deprecation-warning";
+export * from "./data-test-display";


### PR DESCRIPTION
# Related issue
Closes #1679 

# Scope of work
Added helper function to hide `data-testid` attribute on production. Added this function to components where it is needed.


# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [ ] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
