### PR TITLE
#2272 fix:  SfSearchBar takes up the entire space in header

### DIFF
--- a/packages/shared/styles/components/molecules/SfSearchBar.scss
+++ b/packages/shared/styles/components/molecules/SfSearchBar.scss
@@ -12,7 +12,6 @@
   box-sizing: border-box;
   position: relative;
   display: var(--search-bar-display, flex);
-  flex-grow: 1; 
   align-items: center;
   background: var(--search-bar-background, transparent);       
   text-align: var(--search-bar-input-text-align);


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2272 

# Scope of work
<!-- describe what you did -->
Removed `flex-grow: 1` from SfSearchBar stylesheet

# Checklist

- [x] No commented blocks of code left

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
