### PR TITLE
feat: allow setting height for SfModal content

### DIFF
--- a/packages/shared/styles/components/molecules/SfModal.scss
+++ b/packages/shared/styles/components/molecules/SfModal.scss
@@ -31,6 +31,7 @@
       1.6,
       var(--font-family--primary)
     );
+    height: var(--modal-content-height);
   }
   &__close {
     position: absolute;
@@ -47,5 +48,6 @@
     --modal-height: auto;
     --modal-max-height: 90%;
     --modal-content-padding: var(--spacer-sm) var(--spacer-lg);
+    --modal-content-height: 100%;
   }
 }

--- a/packages/vue/src/components/molecules/SfModal/SfModal.stories.js
+++ b/packages/vue/src/components/molecules/SfModal/SfModal.stories.js
@@ -17,6 +17,7 @@ export default {
       "modal-border": { value: "", control: "text" },
       "modal-max-height": { value: "", control: "text" },
       "modal-background": { value: "var(--c-white)", control: "text" },
+      "modal-content-height": { value: "", control: "text" },
       "modal-content-padding": {
         value: "var(--spacer-base) var(--spacer-sm)",
         control: "text",

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
@@ -11,6 +11,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 `--hero-item-button-cursor`, `--hero-item-button-wrap`, `--hero-item-button-text-transform`, `--hero-item-button-text-decoration`, 
 `--hero-item-button-border-radius`)
 - feat: change the docs tab to the first place in toolbar
+- SfModal: new CSS var - `--modal-content-height`
 
 
 ## 🐛 Fixes


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1880

# Scope of work
<!-- describe what you did -->
New CSS var `--modal-content-height` for `SfModal` is added. Default value is `100%`. It allows setting height of SfModal content.
I have tested this solution responsively and in different browsers like: `Chrome`, `Safari`, `Firefox`. It seems that this feature works properly.
# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
