### PR TITLE
fix: adding width and height when nuxt-img is used

### DIFF
--- a/packages/vue/src/components/atoms/SfImage/SfImage.vue
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.vue
@@ -163,6 +163,8 @@ export default {
           }
         : {
             ...this.$attrs,
+            width: this.width ? this.width : null,
+            height: this.height ? this.height : null,
             ...this.nuxtImgConfig,
           };
     },

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
@@ -18,6 +18,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 - SfImage: fix invalid attribute at `srcset`,
 - SfImage: when rendered on nuxt it has `image-tag` set to `img` as default, 
+- SfImage: cannot add width and height as attributes when using `nuxt-img`,
 - SfGroupedProduct: fixed issue with display on mobile view,
 - Nuxt Detailed Cart page not found fixed,
 - SfInput: attribute has invalid input in some cases,

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
@@ -18,7 +18,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 - SfImage: fix invalid attribute at `srcset`,
 - SfImage: when rendered on nuxt it has `image-tag` set to `img` as default, 
-- SfImage: cannot add width and height as attributes when using `nuxt-img`,
+- SfImage: cannot add width and height as separate props when using `nuxt-img`,
 - SfGroupedProduct: fixed issue with display on mobile view,
 - Nuxt Detailed Cart page not found fixed,
 - SfInput: attribute has invalid input in some cases,


### PR DESCRIPTION
# Related issue
Closes #2277 

# Scope of work
`Width` and `height` props passed to attributes to be added when `nuxt-img` is used.  

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
