### PR TITLE
feat: allow overrides default breakpoints value for mixins

### DIFF
--- a/packages/shared/styles/helpers/_breakpoints.scss
+++ b/packages/shared/styles/helpers/_breakpoints.scss
@@ -6,13 +6,13 @@ $desktop-l-min: 1200px;
 $desktop-xl-min: 1440px;
 $desktop-xxl-min: 1920px;
 // Media mixins
-@mixin for-mobile {
-  @media (max-width: $desktop-min - 1px) {
+@mixin for-mobile($resolution: $desktop-min) {
+  @media (max-width: $resolution - 1px) {
     @content;
   }
 }
-@mixin for-desktop {
-  @media (min-width: $desktop-min) {
+@mixin for-desktop($resolution: $desktop-min) {
+  @media (min-width: $resolution) {
     @content;
   }
 }

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.2/v0.12.2.stories.mdx
@@ -6,12 +6,13 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🚀 Features
 
-- SfHero: new CSS vars for easier customization of SfHeroItem button (`--hero-item-button-width`, `--hero-item-button-height`, 
+- SfHero: new CSS vars for easier customization of SfHeroItem button (--hero-item-button-width`, `--hero-item-button-height`, 
 `--hero-item-button-padding`, `--hero-item-button-color`, `--hero-item-button-transition`, `--hero-item-button-background`, 
 `--hero-item-button-cursor`, `--hero-item-button-wrap`, `--hero-item-button-text-transform`, `--hero-item-button-text-decoration`, 
 `--hero-item-button-border-radius`)
 - feat: change the docs tab to the first place in toolbar
 - SfModal: new CSS var - `--modal-content-height`
+- Media query: allow overrides default breakpoint value - `for-mobile` and `for-desktop` mixins
 
 
 ## 🐛 Fixes
@@ -23,7 +24,6 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfInput: attribute has invalid input in some cases,
 - add timeout options to cypress configuration
 - SfProductCardHorizontal: adjusted position of wishlist icon
-- add timeout options to cypress configuration,
 - SfImage: add internal custom properties `--_image-width` and `--_image-height` to set props height and width properly and allow to overwrite them by custom properties  `--image-width` and `--image-height` when needed, 
 - Nuxt module: exclude core-js from transpiling process
 


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #1260

# Scope of work
Allow overrides default breakpoints value - `for-mobile` and `for-desktop` mixin. 

**Usage examples:**
-  pass value as param directly to mixins:
```
.foo {
   @include for-desktop(1200px) {
    border: 1px solid red;
  }
}
```
- define brekapoints values and pass selected value as param directly to mixin:
```
$breakpoints: (
  mobile: 768px,
  laptop: 1240px,
  desktop-lg: 1800px
);

.bar {
   @include for-desktop(map-get($breakpoints, 'laptop')) {
    border: 1px solid red;
  }
}
```
# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
