### PR TITLE
fix: add url property to big image in pictureSelected

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
-    "@vue/cli-plugin-eslint": "^4.3.1",
     "@lhci/cli": "^0.8.0",
+    "@vue/cli-plugin-eslint": "^4.3.1",
     "file-save": "^0.2.0",
     "fse": "^4.0.1",
     "glob": "^7.1.4",

--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.vue
@@ -184,7 +184,9 @@ export default {
       pictureSelected: this.images[0] || {
         alt: "",
         zoom: "",
-        big: "",
+        big: {
+          url: "",
+        },
         desktop: "",
         placeholder: "",
       },

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.3/v0.12.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.3/v0.12.3.stories.mdx
@@ -11,5 +11,6 @@ Category and Home page: added `SfColorPicer` to `SfProductCard` components
 
 ## 🐛 Fixes
 
+- SfGallery: no `alt` and `src` props error appearing when refreshed product page is rendered,
 
 ## 🧹 Chores:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,10 +3956,10 @@
     vue2-leaflet "^2.5.2"
 
 "@storefront-ui/vue@link:packages/vue":
-  version "0.12.0"
+  version "0.12.2"
   dependencies:
     "@glidejs/glide" "^3.3.0"
-    "@storefront-ui/shared" "0.12.0"
+    "@storefront-ui/shared" "0.12.2"
     body-scroll-lock "^3.0.1"
     cloudinary-build-url "^0.1.1"
     core-js "^3.6.5"
@@ -7847,9 +7847,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001254, caniuse-lite@^1.0.30001255:
-  version "1.0.30001257"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz#150aaf649a48bee531104cfeda57f92ce587f6e5"
-  integrity sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==
+  version "1.0.30001313"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz"
+  integrity sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Related issue


# Scope of work
Fixes no `alt` and `src` props error appearing on product page entered after refreshing category page. 
![Screenshot from 2022-03-01 12-09-37](https://user-images.githubusercontent.com/32042425/156159981-4dc290e7-8129-4477-85b3-5c99530f27d2.png)

Added empty url prop in pictureSelected. 

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
