### PR TITLE
fix(SfSidebar): fixed lazy loaded animation

### DIFF
--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.stories.js
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.stories.js
@@ -285,7 +285,6 @@ export const UseTitleSlot = (args, { argTypes }) => ({
     :heading-level="headingLevel"
     :button="button"
     :overlay="overlay"
-    :class="classes"
     :persistent="persistent"
   >
     <template #title="{title, subtitle, headingLevel}">
@@ -308,7 +307,6 @@ export const UseCircleIconSlot = (args, { argTypes }) => ({
     :heading-level="headingLevel"
     :button="button"
     :overlay="overlay"
-    :class="classes"
     :persistent="persistent"
   >
     <template #circle-icon="{close}">

--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.stories.js
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.stories.js
@@ -95,16 +95,6 @@ export default {
     },
   },
   argTypes: {
-    classes: {
-      control: {
-        type: "select",
-        options: ["sf-sidebar--right", ""],
-      },
-      table: {
-        category: "CSS Modifiers",
-      },
-      description: "CSS classes to modify component styling",
-    },
     title: {
       control: "text",
       table: {
@@ -252,7 +242,6 @@ const Template = (args, { argTypes }) => ({
     :heading-level="headingLevel"
     :button="button"
     :overlay="overlay"
-    :class="classes"
     :persistent="persistent"
     :position="position"
   >
@@ -269,7 +258,6 @@ Common.args = {
 export const OnTheRight = Template.bind({});
 OnTheRight.args = {
   ...Common.args,
-  classes: "sf-sidebar--right",
   position: "right",
 };
 

--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.stories.js
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.stories.js
@@ -165,6 +165,19 @@ export default {
       defaultValue: true,
       description: "The overlay's visibility",
     },
+    position: {
+      control: "text",
+      table: {
+        category: "Props",
+        type: {
+          summary: "string",
+        },
+        defaultValue: {
+          summary: "left",
+        },
+      },
+      description: "Animation class name based on position value",
+    },
     close: {
       action: "close event emitted",
       table: { category: "Events", type: { summary: null } },
@@ -241,6 +254,7 @@ const Template = (args, { argTypes }) => ({
     :overlay="overlay"
     :class="classes"
     :persistent="persistent"
+    :position="position"
   >
     Total items: 0
   </SfSidebar>`,
@@ -256,6 +270,7 @@ export const OnTheRight = Template.bind({});
 OnTheRight.args = {
   ...Common.args,
   classes: "sf-sidebar--right",
+  position: "right",
 };
 
 export const NoOverlay = Template.bind({});

--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.vue
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="sf-sidebar">
+  <div
+    class="sf-sidebar"
+    :class="{ 'sf-sidebar--right': position === 'right' }"
+  >
     <SfOverlay :visible="visibleOverlay" />
     <transition :name="transitionName" appear>
       <aside

--- a/packages/vue/src/components/organisms/SfSidebar/SfSidebar.vue
+++ b/packages/vue/src/components/organisms/SfSidebar/SfSidebar.vue
@@ -109,6 +109,7 @@ export default {
     position: {
       type: String,
       default: "left",
+      validator: (value) => ["left", "right"].includes(value),
     },
   },
   data() {

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.4/v0.12.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.4/v0.12.4.stories.mdx
@@ -13,6 +13,8 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - one footer for nuxt pages,
 - SfHero: image passed as object doesn't appear, 
 - SfCollectedProduct: removed issue of input function in story and removed duplicate props
+- SfFooter: removed mobile observer
+- SfSidebar: add `position` props and fix animation loading for async component
 
 ## 🧹 Chores:
 

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.4/v0.12.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.4/v0.12.4.stories.mdx
@@ -4,6 +4,9 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 # v0.12.4
 
+## ❗ Breaking Changes
+- SfSidebar: new `position` prop is added for positioning sidebar. Available values are `left` and `right`. When prop isn't set, default value is `left`
+
 ## 🚀 Features
 - SfScrollable: replaced plugin with native solution
 
@@ -14,7 +17,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfHero: image passed as object doesn't appear, 
 - SfCollectedProduct: removed issue of input function in story and removed duplicate props
 - SfFooter: removed mobile observer
-- SfSidebar: add `position` props and fix animation loading for async component
+- SfSidebar: add `position` prop and fix animation loading for async component
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes [En511](https://vsf.atlassian.net/browse/EN-511)
# Scope of work
<!-- describe what you did -->
This PR resolve bug  with lazy loaded SfSidebar animation.
New props `position` is added. Default value is `left`.

**Usage examples:**
-  for `Sidebar`, where animation is appeared from `right` side
```
  <SfSidebar
      class="sf-sidebar--right"
      position="right"
  />
```
**How to test on CT:**
- for `CartSidebar` add `setTimeout` inside `toggleCartSidebar` method - file `useUiState`. `setTimeout` allows handling `out` animation in proper way
```
  setTimeout(() => {
      state.isCartSidebarOpen = !state.isCartSidebarOpen;
    },300)
```
# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
