### PR TITLE
Update component.spec.js

### DIFF
--- a/packages/vue/scripts/component-template/component.spec.js
+++ b/packages/vue/scripts/component-template/component.spec.js
@@ -4,6 +4,6 @@ import ComponentNameCamelCase from "./ComponentNameCamelCase.vue";
 describe("ComponentNameCamelCase.vue", () => {
   it("renders a component", () => {
     const component = shallowMount(ComponentNameCamelCase);
-    expect(component.contains(".ComponentNameKebabCase")).toBe(true);
+    expect(component.find(".ComponentNameKebabCase").exists()).toBe(true);
   });
 });


### PR DESCRIPTION
[vue-test-utils]: contains is deprecated and will be removed in the next major version. Use `wrapper.find`, `wrapper.findComponent` or `wrapper.get` instead.