### PR TITLE
fix: the align-items property to start to make all the colors visible

### DIFF
--- a/packages/shared/styles/components/molecules/SfColorPicker.scss
+++ b/packages/shared/styles/components/molecules/SfColorPicker.scss
@@ -93,7 +93,7 @@
     }
     &--vertical {
       --color-picker-padding: var(--spacer-base);
-      --color-picker-align-items: center;
+      --color-picker-align-items: start;
       --color-picker-width: auto;
       --color-picker-open-padding: var(--spacer-2xl) 0;
       --color-picker-close-margin: var(--spacer-xs) 0 0 0;

--- a/packages/shared/styles/components/molecules/SfColorPicker.scss
+++ b/packages/shared/styles/components/molecules/SfColorPicker.scss
@@ -15,6 +15,7 @@
     transform: var(--color-picker-transform);
   }
   &__colors {
+    position: relative;
     box-sizing: border-box;
     display: flex;
     width: 100%;

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.3/v0.12.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.3/v0.12.3.stories.mdx
@@ -10,6 +10,7 @@ Category and Home page: added `SfColorPicer` to `SfProductCard` components
 
 
 ## 🐛 Fixes
+SfColorPicker: stretch overlay for color picker
 
 
 ## 🧹 Chores:


### PR DESCRIPTION
# Related issue
Closes #2258 

# Scope of work
<!-- describe what you did -->
- Changed the --color-picker-align-items to start

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [ ] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
