### PR TITLE
fix: accordion closing headers when multiple is used

### DIFF
--- a/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
+++ b/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue
@@ -96,6 +96,11 @@ export default {
           return child._uid === slotId;
         });
         clickedHeader.isOpen = !clickedHeader.isOpen;
+        this.openHeader = this.items.reduce(
+          (openHeaders, item) =>
+            item.isOpen ? [...openHeaders, item.header] : openHeaders,
+          []
+        );
         this.$emit("click:open", clickedHeader.isOpen);
       }
       if (this.headersAreClosed) {


### PR DESCRIPTION
# Related issue
Currently the accordion closes all headers when updating and multiple attribute is passed.

The issue is https://github.com/vuestorefront/storefront-ui/blob/develop/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue#L88 is the only place openHeader is set which is inside a check for !internalMultiple. https://github.com/vuestorefront/storefront-ui/blob/develop/packages/vue/src/components/organisms/SfAccordion/SfAccordion.vue#L76 is called each time the component updates which resets all isOpen properties to those specified in the openHeader.

Below is a simple reproduction of the issue
```
<template>
  <SfAccordion :multiple="true">
    <SfAccordionItem
      key="color"
      header="Color"
    >
      <SfFilter
        key="red"
        label="Red"
        :selected="red"
        @change="red = !red"
      />
      <SfFilter
        key="green"
        label="Green"
        :selected="green"
        @change="green = !green"
      />
    </SfAccordionItem>
    <SfAccordionItem
      key="size"
      header="Size"
    >
      <SfFilter
        key="small"
        label="Small"
        :selected="small"
        @change="small = !small"
      />
      <SfFilter
        key="large"
        label="Large"
        :selected="large"
        @change="large = !large"
      />
    </SfAccordionItem>
  </SfAccordion>
</template>

<script>
import "@storefront-ui/vue/styles.scss";
import { SfAccordion, SfFilter } from "@storefront-ui/vue";

export default {
  components: {
    SfAccordion,
    SfFilter
  },
  data: () => ({
    red: false,
    green: false,

    small: false,
    large: false
  })
}
</script>
```

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [x] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
