### PR TITLE
feat: change gh action workflow

### DIFF
--- a/.github/workflows/on-push-pull-tests.yml
+++ b/.github/workflows/on-push-pull-tests.yml
@@ -1,5 +1,13 @@
 name: Run tests
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+      - develop
+  pull_request: 
+    branches:
+      - master
+      - develop
 
 jobs:
   prepare_dependencies:

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.4/v0.12.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.4/v0.12.4.stories.mdx
@@ -12,3 +12,5 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - E2E tests: SfHero on home page fixed
 
 ## 🧹 Chores:
+
+- gh action workflow change to run tests on push/pull to develop and master branches


### PR DESCRIPTION
# Related issue
Closes #2319 

# Scope of work
Change gh action workflow to run tests only on push/pull request to master or develop branches.

# Screenshots of visual changes

# Checklist

- [x] No commented blocks of code left
- [ ] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
