### PR TITLE
chore: remove isMobile from SfFooter

### DIFF
--- a/packages/shared/styles/components/organisms/SfFooter.scss
+++ b/packages/shared/styles/components/organisms/SfFooter.scss
@@ -3,6 +3,7 @@
   color: var(--c-white);
   box-sizing: border-box;
   &__title {
+    --heading-title-color: var(--c-white);
     color: var(--c-white);
     display: flex;
     justify-content: space-between;

--- a/packages/shared/styles/components/organisms/SfFooter.scss
+++ b/packages/shared/styles/components/organisms/SfFooter.scss
@@ -22,6 +22,16 @@
     );
     cursor: default;
   }
+  &__content {
+    display: var(--footer-column-content-display, block);
+    &--hidden-on-mobile {
+      --footer-column-content-display: none;
+      @include for-desktop {
+      --footer-column-content-display: block;
+    }
+    }
+  }
+
   &__chevron {
     --chevron-color: var(--c-white);  
   }  

--- a/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
+++ b/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
@@ -62,7 +62,6 @@ export default {
   },
   methods: {
     toggle(payload) {
-      if (!this.isMobile) return;
       if (!this.multiple) {
         this.isOpen = [payload];
       } else if (this.isOpen.includes(payload)) {

--- a/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
+++ b/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
@@ -11,11 +11,6 @@
 <script>
 import Vue from "vue";
 import SfFooterColumn from "./_internal/SfFooterColumn.vue";
-import {
-  mapMobileObserver,
-  unMapMobileObserver,
-} from "../../../utilities/mobile-observer";
-
 Vue.component("SfFooterColumn", SfFooterColumn);
 export default {
   name: "SfFooter",
@@ -43,22 +38,6 @@ export default {
       isOpen: [],
       items: [],
     };
-  },
-  computed: {
-    ...mapMobileObserver(),
-  },
-  watch: {
-    isMobile: {
-      handler(mobile) {
-        this.$nextTick(() => {
-          this.isOpen = mobile ? [...this.open] : [...this.items];
-        });
-      },
-      immediate: true,
-    },
-  },
-  beforeDestroy() {
-    unMapMobileObserver();
   },
   methods: {
     toggle(payload) {

--- a/packages/vue/src/components/organisms/SfFooter/_internal/SfFooterColumn.vue
+++ b/packages/vue/src/components/organisms/SfFooter/_internal/SfFooterColumn.vue
@@ -3,7 +3,7 @@
     <SfButton
       v-focus
       type="button"
-      class="sf-button--pure sf-footer-column__title"
+      class="sf-button--pure sf-footer-column__title smartphone-only"
       @click="toggle(title)"
     >
       {{ title }}
@@ -11,6 +11,11 @@
         <SfChevron :class="{ 'sf-chevron--top': isColumnOpen }" />
       </span>
     </SfButton>
+    <SfHeading
+      class="sf-footer-column__title desktop-only"
+      :title="title"
+      :level="5"
+    />
     <transition name="sf-fade">
       <div
         :class="{ 'display-none': !isColumnOpen }"
@@ -24,6 +29,7 @@
 <script>
 import SfChevron from "../../../atoms/SfChevron/SfChevron.vue";
 import SfButton from "../../../atoms/SfButton/SfButton.vue";
+import SfHeading from "../../../atoms/SfHeading/SfHeading.vue";
 import { focus } from "../../../../utilities/directives";
 export default {
   name: "SfFooterColumn",
@@ -31,6 +37,7 @@ export default {
   components: {
     SfChevron,
     SfButton,
+    SfHeading,
   },
   props: {
     title: {

--- a/packages/vue/src/components/organisms/SfFooter/_internal/SfFooterColumn.vue
+++ b/packages/vue/src/components/organisms/SfFooter/_internal/SfFooterColumn.vue
@@ -18,7 +18,9 @@
     />
     <transition name="sf-fade">
       <div
-        :class="{ 'display-none': !isColumnOpen }"
+        :class="{
+          'sf-footer-column__content--hidden-on-mobile': !isColumnOpen,
+        }"
         class="sf-footer-column__content"
       >
         <slot />

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.3/v0.12.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.3/v0.12.3.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Releases/v0.12.x - v0.12.3 - Change log" />
+<Meta title="Releases/v0.12.x - Latest/v0.12.3 - Change log" />
 
 # v0.12.3
 

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.3/v0.12.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.3/v0.12.3.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Releases/v0.12.x - Latest/v0.12.3 - Latest/Change log" />
+<Meta title="Releases/v0.12.x - v0.12.3 - Change log" />
 
 # v0.12.3
 

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.4/v0.12.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.4/v0.12.4.stories.mdx
@@ -1,0 +1,13 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.12.x - Latest/v0.12.4 - Latest/Change log" />
+
+# v0.12.4
+
+## 🚀 Features
+
+
+## 🐛 Fixes
+
+## 🧹 Chores:
+- SfFooter: removed mobile observer


### PR DESCRIPTION
# Related issue
Closes #2315 

# Scope of work
- removed isMobile from SfFooter
- adjusted css classes and html template

# Screenshots of visual changes
no visual changes

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
