### PR TITLE
fix: sfhero image passed as objects

### DIFF
--- a/packages/vue/src/components/organisms/SfHero/_internal/SfHeroItem.vue
+++ b/packages/vue/src/components/organisms/SfHero/_internal/SfHeroItem.vue
@@ -109,16 +109,16 @@ export default {
               },
           "--_banner-background-color": background,
         };
+      } else {
+        return {
+          "--hero-item-background-image": isImageString
+            ? `url(${image})`
+            : `url(${image.desktop})`,
+          "--hero-item-background-image-mobile":
+            image.mobile && `url(${image.mobile})`,
+          "background-color": background,
+        };
       }
-      return {
-        "--hero-item-background-image": isImageString
-          ? `url(${image})`
-          : {
-              "--hero-item-background-image-mobile": image.mobile,
-              "--hero-item-background-image": image.desktop,
-            },
-        "background-color": background,
-      };
     },
     wrapper() {
       return this.link ? "SfLink" : "SfButton";

--- a/packages/vue/src/stories/releases/v0.12.x/v0.12.4/v0.12.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.12.x/v0.12.4/v0.12.4.stories.mdx
@@ -9,8 +9,9 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
-- E2E tests: SfHero on home page fixed
-- one footer for nuxt pages
+- E2E tests: SfHero on home page fixed,
+- one footer for nuxt pages,
+- SfHero: image passed as object doesn't appear, 
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
Closes #2327 

# Scope of work
Fixed passing images as objects in the SfHero component.  

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
