### PR TITLE
fix: update-components-docs regex

### DIFF
--- a/packages/vue/scripts/update-components-docs.js
+++ b/packages/vue/scripts/update-components-docs.js
@@ -223,7 +223,7 @@ function getVarsArray(file) {
     outputStyle: "expanded",
   });
   const text = css.toString();
-  const patterns = [/var\((\S+?(?=\)))(, (.+))?\)/g, / {2}(--.+):( (.+));/g];
+  const patterns = [/var\((\S+?(?=\)|,))(,\s*(var\(.+?\)|.+?(?=\))))?\)/g, / {2}(--.+):( (.+));/g];
   const componentName = /\.sf-([a-z]+-?)+/g.exec(text)[0].trim();
   let variables = [];
   let keys = [];

--- a/packages/vue/scripts/update-components-docs.js
+++ b/packages/vue/scripts/update-components-docs.js
@@ -223,7 +223,7 @@ function getVarsArray(file) {
     outputStyle: "expanded",
   });
   const text = css.toString();
-  const patterns = [/var\((\S+)(, (.+))?\)/g, / {2}(--.+):( (.+));/g];
+  const patterns = [/var\((\S+?(?=\)))(, (.+))?\)/g, / {2}(--.+):( (.+));/g];
   const componentName = /\.sf-([a-z]+-?)+/g.exec(text)[0].trim();
   let variables = [];
   let keys = [];


### PR DESCRIPTION
EDIT: See regex example here https://regex101.com/r/rPY7mx/4

Before this change the following in f.ex `packages/shared/styles/components/atoms/SfArrow.scss`:

```scss
  &__icon {
    width: calc(2rem * var(--arrow-width-multiplier));
    transform: var(--arrow-icon-transform);
  }
```

Would result in:

```js
[
  [
    [ '--arrow-justify-content', '' ],
    [ '--arrow-width-multiplier)', '' ],
    [ '--arrow-icon-transform', '' ]
  ],
  [
    [ '--button-width', '' ],
    [ '--button-height', '' ],
    [ '--button-padding', '0 0.625rem' ],
    [ '--button-background', '' ],
    [ '--button-transition', '' ],
    [ '--icon-color', '' ],
    [ '--button-box-shadow', '' ],
    [ '--box-shadow-transition-opacity-duration', '150ms' ],
    [ '--button-box-shadow-opacity', '0.25' ],
    [ '--button-border-radius', '' ]
  ]
]
```

When the `yarn run update-components-docs` script runs. Notice the `[ '--arrow-width-multiplier)', '' ]`.

After this change, the output generated by `yarn run update-components-docs` is:

```js
[
  [
    [ '--arrow-width-multiplier', '' ],
    [ '--arrow-icon-transform', '' ]
  ],
  [
    [ '--button-width', '' ],
    [ '--button-height', '' ],
    [ '--button-padding', '0 0.625rem' ],
    [ '--button-background', '' ],
    [ '--button-transition', '' ],
    [ '--icon-color', '' ],
    [ '--button-box-shadow', '' ],
    [ '--box-shadow-transition-opacity-duration', '150ms' ],
    [ '--button-box-shadow-opacity', '0.25' ],
    [ '--arrow-justify-content', '' ],
    [ '--button-border-radius', '' ]
  ]
]
```

Notice the `[ '--arrow-width-multiplier', '' ]` no longer has the erroneous `)`.