### PR TITLE
fix: the issue of onClick not defined in button

### DIFF
--- a/packages/vue/src/components/atoms/SfButton/SfButton.stories.js
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.stories.js
@@ -223,7 +223,7 @@ export const WithDefaultSlot = (args, { argTypes }) => ({
   <SfButton
     :class="classes"
     :disabled="disabled"
-    @click="onClick"
+    @click="click"
     :link="link">
     <template>
       <div v-html="content"/>

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.1/v0.13.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.1/v0.13.1.stories.mdx
@@ -13,6 +13,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 ## 🐛 Fixes
 
 - SfAccordion: removed the click event to solve the issue of change not defined
+- SfButton: replaced onClick method with click
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2357 

# Scope of work
<!-- describe what you did -->
Replaced onClick with click method

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [x] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
