### PR TITLE
#SFUI-123 fix: change style and HeroItem to show mobile images

### DIFF
--- a/packages/shared/styles/components/organisms/SfHero.scss
+++ b/packages/shared/styles/components/organisms/SfHero.scss
@@ -6,7 +6,7 @@
   box-sizing: border-box;
   width: 100%;
   color: var(--c-text);
-  background-image: var(--hero-item-background-image, var(--hero-item-background-image-mobile));
+  background-image: var(--hero-item-background-image-mobile);
   background-repeat: no-repeat;
   background-size: cover;
   img,

--- a/packages/vue/src/components/organisms/SfHero/_internal/SfHeroItem.vue
+++ b/packages/vue/src/components/organisms/SfHero/_internal/SfHeroItem.vue
@@ -99,23 +99,22 @@ export default {
       };
       if (this.imageTag === "nuxt-img" || this.imageTag === "nuxt-picture") {
         return {
-          "--hero-item-background-image": isImageString
+          "--hero-item-background-image-mobile": isImageString
             ? nuxtImgConvert(image)
-            : {
-                "--hero-item-background-image-mobile": nuxtImgConvert(
-                  image.mobile
-                ),
-                "--hero-item-background-image": nuxtImgConvert(image.desktop),
-              },
+            : image.mobile && nuxtImgConvert(image.mobile),
+          "--hero-item-background-image": isImageString
+            ? `url(${image})`
+            : nuxtImgConvert(image.desktop),
           "--_banner-background-color": background,
         };
       } else {
         return {
+          "--hero-item-background-image-mobile": isImageString
+            ? `url(${image})`
+            : image.mobile && `url(${image.mobile})`,
           "--hero-item-background-image": isImageString
             ? `url(${image})`
             : `url(${image.desktop})`,
-          "--hero-item-background-image-mobile":
-            image.mobile && `url(${image.mobile})`,
           "background-color": background,
         };
       }

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.1/v0.13.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.1/v0.13.1.stories.mdx
@@ -16,6 +16,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfButton: replaced onClick method with click
 - Improvement in the release section structure in storybook
 - SfInput: fixed errors in storybook story
+- SfHero: showing mobile images
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue

Closes #2365 

# Scope of work
Fixed passing mobile image to SfHero. 

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
