### PR TITLE
fix: SfCallToAction show desktop images in background

### DIFF
--- a/packages/shared/styles/components/molecules/SfCallToAction.scss
+++ b/packages/shared/styles/components/molecules/SfCallToAction.scss
@@ -60,6 +60,7 @@
     --call-to-action-align-items: center;
     --call-to-action-padding: var(--spacer-xl) var(--spacer-2xl);
     --call-to-action-height: 12.625rem;
+    --call-to-action-background: var(--_call-to-action-background-desktop-image);
     --call-to-action-text-container-width: 75%;
   }
 }

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.1/v0.13.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.1/v0.13.1.stories.mdx
@@ -16,6 +16,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfButton: replaced onClick method with click
 - Improvement in the release section structure in storybook
 - SfInput: fixed errors in storybook story
+- SfCallToAction: showing desktop images in background
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2366 

# Scope of work


# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
