### PR TITLE
130 fix: SfGallery outside zoom image size and position

### DIFF
--- a/packages/shared/styles/components/molecules/SfGallery.scss
+++ b/packages/shared/styles/components/molecules/SfGallery.scss
@@ -37,13 +37,15 @@
     }
   }
   &__stage {
+    position: relative;
     flex: 1;
     max-width: var(--gallery-stage-width, 26.375rem);
   }
   &__zoom {
     position: absolute;
-    left: 50%;
+    left: 125%;
     top: 0;
+    overflow: hidden;
   }
   .glide {
     &__slide {

--- a/packages/vue/src/components/molecules/SfGallery/SfGallery.stories.js
+++ b/packages/vue/src/components/molecules/SfGallery/SfGallery.stories.js
@@ -278,7 +278,7 @@ export const AutoSlide = Template.bind({});
 AutoSlide.args = {
   ...Common.args,
   sliderOptions: {
-    autoplay: true,
+    autoplay: 3000,
     rewind: true,
     gap: 0,
   },

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.1/v0.13.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.1/v0.13.1.stories.mdx
@@ -19,6 +19,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
     and there is an error message in console about wrong value for `current` prop
 - SfInput: fixed errors in storybook story
 - SfBottomModal: fix story
+- SfGallery: fix size and postion of outside zoom image
 
 ## 🧹 Chores:
 


### PR DESCRIPTION
# Related issue
Closes #2381 

# Scope of work
Changed outside zoom in SfGallery to be in limited size and positioned outside main image (not to overwrite it). 
Also changes time for autoplay option in SfGallery stories to change every 3s. 

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
