### PR TITLE
fix: SfSearchbar change event name in story

### DIFF
--- a/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.stories.js
+++ b/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.stories.js
@@ -245,7 +245,7 @@ export const UseIconSlot = (args, { argTypes }) => ({
   template: `
   <SfSearchBar
     :placeholder="placeholder"
-    @click="click"
+    @click:icon="this['click:icon']"
     @blur="blur"
     @focus="focus"
     @input="input"

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.1/v0.13.1.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.1/v0.13.1.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Releases/v0.13.x - Latest/v0.13.1 - Latest/Change log" />
+<Meta title="Releases/v0.13.x - Latest/v0.13.1/Change log" />
 
 # v0.13.1
 

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.2/v0.13.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.2/v0.13.2.stories.mdx
@@ -1,0 +1,17 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.13.x - Latest/v0.13.2 - Latest/Change log" />
+
+# v0.13.2
+
+## ❗ Breaking Changes
+
+
+## 🚀 Features
+
+
+## 🐛 Fixes
+
+- SfSearchbar: change event name in 'UseIconSlot' story in Storybook
+
+## 🧹 Chores:


### PR DESCRIPTION
# Related issue
Closes #2376 

# Scope of work
Changed `click` event name to proper one in the story. 

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
