### PR TITLE
fix: SfCheckbox size adjusted to the content

### DIFF
--- a/packages/vue/src/components/molecules/SfCheckbox/SfCheckbox.stories.js
+++ b/packages/vue/src/components/molecules/SfCheckbox/SfCheckbox.stories.js
@@ -239,6 +239,7 @@ const Template = (args, { argTypes }) => ({
   template: `
   <SfCheckbox 
     v-model="checked"
+    style="--checkbox-container-width: 15rem;"
     :name="name"      
     :label="label"
     :hintMessage="hintMessage"
@@ -305,6 +306,7 @@ export const UseCheckmarkSlot = (args, { argTypes }) => ({
   template: `
   <SfCheckbox 
     v-model="checked"
+    style="--checkbox-container-width: 15rem;"
     :name="name"
     :label="label"
     :hintMessage="hintMessage"
@@ -335,6 +337,7 @@ export const UseErrorMessageSlot = (args, { argTypes }) => ({
   template: `
   <SfCheckbox 
     v-model="checked"
+    style="--checkbox-container-width: 15rem;"
     :name="name"      
     :label="label"
     :hint-message="hintMessage"

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.2/v0.13.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.2/v0.13.2.stories.mdx
@@ -1,0 +1,17 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.13.x - Latest/v0.13.2 - Latest/Change log" />
+
+# v0.13.2
+
+## ❗ Breaking Changes
+
+
+## 🚀 Features
+
+
+## 🐛 Fixes
+
+- SfCheckbox: fix checbox size in stories
+
+## 🧹 Chores:


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2379 

# Scope of work
Changed size of checkbox in the stories.

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
