### PR TITLE
fix: SfRadio - remove required prop from storybook

### DIFF
--- a/packages/vue/src/components/molecules/SfRadio/SfRadio.stories.js
+++ b/packages/vue/src/components/molecules/SfRadio/SfRadio.stories.js
@@ -109,19 +109,6 @@ export default {
       defaultValue: "",
       description: "Indicate if this option is disabled",
     },
-    required: {
-      control: "boolean",
-      table: {
-        category: "Props",
-        type: {
-          summary: "boolean",
-        },
-        defaultValue: {
-          summary: false,
-        },
-      },
-      defaultValue: false,
-    },
     "v-model": {
       control: "text",
       table: {
@@ -202,7 +189,6 @@ const Template = (args, { argTypes }) => ({
     :name="name"
     :value="value"
     :disabled="disabled"
-    :required="required"
     v-model="selectedValue"
     @change="change"
     @input="input"
@@ -244,7 +230,6 @@ export const UseCheckmarkSlot = (args, { argTypes }) => ({
     :name="name"
     :value="value"
     :disabled="disabled"
-    :required="required"
     @change="change"
     @input="input"
   >
@@ -268,7 +253,6 @@ export const UseLabelSlot = (args, { argTypes }) => ({
     :name="name"
     :value="value"
     :disabled="disabled"
-    :required="required"
     @change="change"
     @input="input"
   >
@@ -291,7 +275,6 @@ export const UseDetailsSlot = (args, { argTypes }) => ({
     :name="name"
     :value="value"
     :disabled="disabled"
-    :required="required"
     @change="change"
     @input="input"
   >
@@ -314,7 +297,6 @@ export const UseDescriptionSlot = (args, { argTypes }) => ({
     :name="name"
     :value="value"
     :disabled="disabled"
-    :required="required"
     @change="change"
     @input="input"
   >

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.2/v0.13.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.2/v0.13.2.stories.mdx
@@ -12,6 +12,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
-- SfCheckbox: fix checbox size in stories
+- SfCheckbox: fix checkbox size in stories
+- SfRadio: remove required prop from stories
 
 ## 🧹 Chores:


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2384

# Scope of work
I removed `required` prop from story, because `required` functionality for `SfRadio` is not applied. 

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))

