### PR TITLE
fix: SfStorelocator add marker icons

### DIFF
--- a/packages/vue/src/components/organisms/SfStoreLocator/SfStoreLocator.vue
+++ b/packages/vue/src/components/organisms/SfStoreLocator/SfStoreLocator.vue
@@ -69,6 +69,14 @@ import { focus } from "../../../utilities/directives";
 import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
 import SfLoader from "../../atoms/SfLoader/SfLoader.vue";
 import SfStore from "./_internal/SfStore.vue";
+import { Icon } from "leaflet";
+delete Icon.Default.prototype._getIconUrl;
+Icon.Default.mergeOptions({
+  iconRetinaUrl: require("leaflet/dist/images/marker-icon-2x.png"),
+  iconUrl: require("leaflet/dist/images/marker-icon.png"),
+  shadowUrl: require("leaflet/dist/images/marker-shadow.png"),
+});
+
 Vue.component("SfStore", SfStore);
 export default {
   name: "SfStoreLocator",

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.2/v0.13.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.2/v0.13.2.stories.mdx
@@ -16,5 +16,6 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfCheckbox: fix checkbox size in stories
 - SfCheckbox: fix checkbox required message in stories
 - SfRadio: remove required prop from stories
+- SfStoreLocator: lack of marker icons fix
 
 ## 🧹 Chores:


### PR DESCRIPTION
# Related issue

Closes #2393 

# Scope of work
Added script to fix issue with lacking marker icons in SfStoreLocator. Based on solution in VueLeafLet docs:
https://vue2-leaflet.netlify.app/quickstart/#marker-icons-are-missing 
Hard to say if it works properly cause this error doesn't appear locally. 

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
