### PR TITLE
fix: Storybook Molecules component select text is coliding with chevron using android phone

### DIFF
--- a/packages/shared/styles/components/molecules/SfComponentSelect.scss
+++ b/packages/shared/styles/components/molecules/SfComponentSelect.scss
@@ -149,6 +149,9 @@
   }
   &--label-right {
     --component-select-label-left: 85%;
+    @include for-mobile {
+      --component-select-label-left: 70%;
+    }
   }
   &.is-selected {
     --component-select-label-transform: var(--component-select-label-translate3d, translate3d(0, -200%, 0)); 

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.2/v0.13.2.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.2/v0.13.2.stories.mdx
@@ -13,6 +13,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
+- SfComponentSelect: label on right doesn't colide with chevron on mobile view
 - SfSearchbar: change event name in 'UseIconSlot' story in Storybook
 - SfCheckbox: fix checkbox size in stories
 - SfCheckbox: fix checkbox required message in stories


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2415

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
