### PR TITLE
Add type attribute to button

### DIFF
--- a/packages/vue/src/components/atoms/SfButton/SfButton.vue
+++ b/packages/vue/src/components/atoms/SfButton/SfButton.vue
@@ -20,6 +20,7 @@
     :aria-label="props.ariaLabel"
     v-bind="data.attrs"
     v-on="!props.disabled ? listeners : {}"
+    :type="$options.setType(props.type, props.link)"
   >
     <slot />
   </component>
@@ -55,12 +56,23 @@ export default {
       type: String,
       default: "button",
     },
+    type: {
+      type: String,
+      default: null
+    }
   },
   linkActive(link, disabled) {
     return link && disabled;
   },
   buttonActive(link, disabled) {
     return !link && disabled;
+  },
+  setType(type, link) {
+    if (type === null && !link) {
+      return 'button'
+    } else {
+      return type;
+    }
   },
 };
 </script>


### PR DESCRIPTION
Added the `type` attribute to <button> element in order to pass the  `nuxtjs/html-validator ` .  If it's not a link and the type prop return null then add a default 'button'.

# Related issue
https://github.com/vuestorefront/storefront-ui/issues/2430

# Scope of work
Make sure there is a default `type` attribute to button elements
