### PR TITLE
fix: SfTextarea readonly prop

### DIFF
--- a/packages/vue/src/components/atoms/SfTextarea/SfTextarea.stories.js
+++ b/packages/vue/src/components/atoms/SfTextarea/SfTextarea.stories.js
@@ -254,6 +254,7 @@ const Template = (args, { argTypes }) => ({
     :required="required"
     :disabled="disabled"
     :placeholder="placeholder"
+    :readonly="readonly"
     @change="change"
   />`,
 });

--- a/packages/vue/src/components/atoms/SfTextarea/SfTextarea.vue
+++ b/packages/vue/src/components/atoms/SfTextarea/SfTextarea.vue
@@ -24,6 +24,7 @@
       :required="props.required"
       :maxlength="props.maxlength"
       :minlength="props.minlength"
+      :readonly="props.readonly"
       v-on="$options.handleInput(listeners)"
     />
     <label class="sf-textarea__label" :for="props.name">

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.3/v0.13.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.3/v0.13.3.stories.mdx
@@ -9,10 +9,9 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🚀 Features
 
-- Configurable aria-label attributes
-
 ## 🐛 Fixes
 
 - SfInput: showing password icon fixed
+- SfTextarea: readonly prop fixed
 
 ## 🧹 Chores:


### PR DESCRIPTION
# Related issue
Closes #2436 

# Scope of work
SfTextarea pass readonly prop in component and add to story.

# Screenshots of visual changes

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
