### PR TITLE
fix: Vue project no longer compiles with npm

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -16,7 +16,7 @@
     "@babel/core": "^7.14.5",
     "@babel/runtime-corejs3": "^7.14.5",
     "@nuxtjs/pwa": "^3.3.5",
-    "@storefront-ui/vue": "link:../vue",
+    "@storefront-ui/vue": "file:../vue",
     "core-js": "^3.9.1",
     "nuxt": "^2.15.3"
   },

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.3/v0.13.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.3/v0.13.3.stories.mdx
@@ -21,5 +21,6 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - click-outside-directive: event passed to `closeHandler`
 - fixed test on login page
 - SfTextarea: readonly prop fixed
+- npm doesn't suppoer `link` - changed to `file`
 
 ## 🧹 Chores:


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
