### PR TITLE
fix: icon slot in searchbar

### DIFF
--- a/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.vue
+++ b/packages/vue/src/components/molecules/SfSearchBar/SfSearchBar.vue
@@ -11,6 +11,9 @@
     v-on="listeners"
     @keyup.enter="$emit('input', value)"
   >
+    <template #icon>
+      <slot name="icon" v-bind="{ icon }" />
+    </template>
   </SfInput>
 </template>
 <script>

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.3/v0.13.3.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.3/v0.13.3.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Releases/v0.13.x - Latest/v0.13.3 - Latest/Change log" />
+<Meta title="Releases/v0.13.x - Latest/v0.13.3/Change log" />
 
 # v0.13.3
 

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
@@ -1,0 +1,17 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.13.x - Latest/v0.13.4 - Latest/Change log" />
+
+# v0.13.4
+
+## ❗ Breaking Changes
+
+
+## 🚀 Features
+
+
+## 🐛 Fixes
+
+- SfSearchbar: icon slot added
+
+## 🧹 Chores:


### PR DESCRIPTION
# Related issue
Closes #2467

# Scope of work
Icon slot passed from SfSearchbar to SfInput. 

# Screenshots of visual changes


# Checklist

- [x] No commented blocks of code left
- [ ] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
