### PR TITLE
fix: footer closing on mobile

### DIFF
--- a/packages/shared/styles/components/organisms/SfFooter.scss
+++ b/packages/shared/styles/components/organisms/SfFooter.scss
@@ -25,10 +25,9 @@
   &__content {
     display: var(--footer-column-content-display, block);
     &--hidden-on-mobile {
-      --footer-column-content-display: none;
-      @include for-desktop {
-      --footer-column-content-display: block;
-    }
+      @include for-mobile {
+        --footer-column-content-display: none;
+      }
     }
   }
 

--- a/packages/vue/src/components/organisms/SfFooter/SfFooter.stories.js
+++ b/packages/vue/src/components/organisms/SfFooter/SfFooter.stories.js
@@ -257,7 +257,7 @@ const Template = (args, { argTypes }) => ({
 
 export const Common = Template.bind({});
 Common.args = {
-  open: ["About us", "Help", "Social"],
+  open: ["About us", "Help"],
   title: "Storefront UI",
   logo: "/assets/logo.svg",
 };

--- a/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
+++ b/packages/vue/src/components/organisms/SfFooter/SfFooter.vue
@@ -35,7 +35,7 @@ export default {
   },
   data() {
     return {
-      isOpen: [],
+      isOpen: this.open,
       items: [],
     };
   },

--- a/packages/vue/src/components/organisms/SfFooter/_internal/SfFooterColumn.vue
+++ b/packages/vue/src/components/organisms/SfFooter/_internal/SfFooterColumn.vue
@@ -58,6 +58,7 @@ export default {
       handler(newVal) {
         this.isColumnOpen = newVal.includes(this.title);
       },
+      immediate: true,
     },
   },
   created() {

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
@@ -1,0 +1,17 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Releases/v0.13.x - Latest/v0.13.4 - Latest/Change log" />
+
+# v0.13.4
+
+## ❗ Breaking Changes
+
+
+## 🚀 Features
+
+
+## 🐛 Fixes
+
+- SfFooter: closing columns on mobile 
+
+## 🧹 Chores:


### PR DESCRIPTION
# Related issue
Closes #2465 

# Scope of work
Changed passing `open` prop and styles on mobile to allow closing columns depending on the prop value.

# Screenshots of visual changes
![Screenshot from 2022-07-05 10-40-28](https://user-images.githubusercontent.com/32042425/177287514-da3637ba-658e-4c9b-8391-83a1fe106ac5.png)

# Checklist

- [x] No commented blocks of code left
- [ ] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
