### PR TITLE
fix: SfBullets and SfImage warnings instead of errors

### DIFF
--- a/packages/vue/src/components/atoms/SfBullets/SfBullets.vue
+++ b/packages/vue/src/components/atoms/SfBullets/SfBullets.vue
@@ -89,7 +89,7 @@ export default {
   },
   inactiveRight(total, current) {
     if (current >= total) {
-      console.error(
+      console.warn(
         "Wrong value for the 'current' prop. This prop cannot be greater than or equal the 'total' value prop"
       );
       return total - 1;
@@ -99,7 +99,7 @@ export default {
   },
   inactiveLeft(total, current) {
     if (current >= total) {
-      console.error(
+      console.warn(
         "Wrong value for the 'current' prop. This prop cannot be greater than or equal the 'total' value prop"
       );
       return total - (total - 1) - 1;

--- a/packages/vue/src/components/atoms/SfImage/SfImage.vue
+++ b/packages/vue/src/components/atoms/SfImage/SfImage.vue
@@ -170,14 +170,14 @@ export default {
         !this.srcset &&
         (this.imageTag === "img" || this.imageTag === "")
       ) {
-        console.error(`Missing required prop width.`);
+        console.warn(`Missing required prop width.`);
       }
       if (
         !this.height &&
         !this.srcset &&
         (this.imageTag === "img" || this.imageTag === "")
       ) {
-        console.error(`Missing required prop height.`);
+        console.warn(`Missing required prop height.`);
       }
       const sizeHandler = (size) => {
         return size === null ? null : `${size}px`;

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
@@ -12,6 +12,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
-- SfFooter: closing columns on mobile 
+- SfFooter: closing columns on mobile
+- SfImage, SfBullets: wrong props will cause warning instead of error
 
 ## 🧹 Chores:


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2473 

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
