### PR TITLE
fix: Dropdown docs interactivity

### DIFF
--- a/packages/vue/src/components/molecules/SfDropdown/SfDropdown.stories.js
+++ b/packages/vue/src/components/molecules/SfDropdown/SfDropdown.stories.js
@@ -54,8 +54,6 @@ export default {
     },
     // end of code generated automatically
     docs: {
-      inlineStories: false,
-      iframeHeight: "25em",
       description: {
         component: "Dropdown component",
       },
@@ -181,22 +179,25 @@ const Template = (args, { argTypes }) => ({
     },
   },
   template: `
-  <SfDropdown
-    :class="classes" 
-    :is-open="isDropdownOpen"  
-    @click:open="openHandler"
-    @click:close="closeHandler"
-    :persistent="persistent" 
-    :title="title"
-  >
-    <template>
-      <SfList>
-        <SfListItem v-for="(action, key) in actionList" :key="key">
-          <SfButton class="sf-button--full-width sf-button--underlined color-primary" @click.stop="isDropdownOpen = false">{{ action }}</SfButton>
-        </SfListItem>
-      </SfList>
-    </template> 
-  </SfDropdown>`,
+  <div style="position: relative; height: 500px;">
+    <SfDropdown
+      :class="classes" 
+      :is-open="isDropdownOpen"  
+      @click:open="openHandler"
+      @click:close="closeHandler"
+      :persistent="persistent" 
+      :title="title"
+      style="position: absolute;"
+    >
+      <template>
+        <SfList>
+          <SfListItem v-for="(action, key) in actionList" :key="key">
+            <SfButton class="sf-button--full-width sf-button--underlined color-primary" @click.stop="isDropdownOpen = false">{{ action }}</SfButton>
+          </SfListItem>
+        </SfList>
+      </template> 
+    </SfDropdown>
+    </div>`,
 });
 
 export const Common = Template.bind({});

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
@@ -13,5 +13,6 @@ import { Meta } from "@storybook/addon-docs/blocks";
 ## 🐛 Fixes
 
 - SfFooter: closing columns on mobile 
+- SfDropdown: change rendering to inline and fix styling
 
 ## 🧹 Chores:


### PR DESCRIPTION
# Related issue
Closes #2464 

# Scope of work
Fix storybook docs Dropdown iframe issue. When settings changed to `inline: false` props in docs are not reactive. After toggling to `true` the layout is broken so there is need to add some extra styling.

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
