### PR TITLE
fix: Storybook Molecules Modal cannot close the modal even with persistent turned off

### DIFF
--- a/packages/vue/src/components/molecules/SfModal/SfModal.stories.js
+++ b/packages/vue/src/components/molecules/SfModal/SfModal.stories.js
@@ -1,4 +1,4 @@
-import { SfModal } from "@storefront-ui/vue";
+import { SfModal, SfButton } from "@storefront-ui/vue";
 export default {
   title: "Components/Molecules/Modal",
   component: SfModal,
@@ -163,16 +163,25 @@ export default {
 };
 
 const Template = (args, { argTypes }) => ({
-  components: { SfModal },
+  components: { SfModal, SfButton },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      modalVisible: true,
+    };
+  },
   template: `
+  <div>
+  <SfButton @click="modalVisible = true">
+    Open modal
+  </SfButton>
   <SfModal
-    :visible="visible"
+    :visible="modalVisible"
     :title="title"
     :overlay="overlay"
     :cross="cross"
     :persistent="persistent"
-    @close="close"
+    @close="modalVisible = false"
   >
     <p>HELLO STOREFRONT UI!</p>
     <form action="">
@@ -180,13 +189,12 @@ const Template = (args, { argTypes }) => ({
       <input type="text">
       <button type="button">hello</button>
     </form>
-  </SfModal>`,
+  </SfModal></div>`,
 });
 
 export const Common = Template.bind({});
 Common.args = {
   title: "My title",
-  visible: true,
 };
 
 export const WithoutOverlay = Template.bind({});
@@ -208,22 +216,32 @@ Cross.args = {
 };
 
 export const UseCloseSlot = (args, { argTypes }) => ({
-  components: { SfModal },
+  components: { SfModal, SfButton },
   props: Object.keys(argTypes),
+  data() {
+    return {
+      modalVisible: true,
+    };
+  },
   template: `
+  <div>
+  <SfButton @click="modalVisible = true">
+    Open modal
+  </SfButton>
   <SfModal
-    :visible="visible"
+    :visible="modalVisible"
     :title="title"
     :overlay="overlay"
     :cross="cross"
     :persistent="persistent"
-    @close="close"
+    @close="modalVisible = false"
   >
     HELLO STOREFRONT UI!
     <template #close>
       close
     </template>
-  </SfModal>`,
+  </SfModal>
+  </div>`,
 });
 UseCloseSlot.args = {
   ...Common.args,

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
@@ -12,6 +12,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
+- SfModal story: modal can be closed in stories
 - SfFooter: closing columns on mobile 
 
 ## 🧹 Chores:


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2471

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
