### PR TITLE
fix: SfGallery - for more than 4 thumbnails gallery is breaking

### DIFF
--- a/packages/shared/styles/components/molecules/SfGallery.scss
+++ b/packages/shared/styles/components/molecules/SfGallery.scss
@@ -68,5 +68,9 @@
         --gallery-item-margin: 0;
       }
     }
+    &__thumbs {
+      overflow-y: scroll;
+      height: var(--gallery-image-height);
+    }
   }
 }

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
@@ -12,6 +12,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🐛 Fixes
 
-- SfFooter: closing columns on mobile 
+- SfFooter: closing columns on mobile
+- SfGallery: scroll for more than 4 thumb images
 
 ## 🧹 Chores:


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #2472

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
