### PR TITLE
fix: Storybook Atoms Input placeholder prop does not work

### DIFF
--- a/packages/vue/src/components/atoms/SfInput/SfInput.stories.js
+++ b/packages/vue/src/components/atoms/SfInput/SfInput.stories.js
@@ -299,6 +299,7 @@ const Template = (args, { argTypes }) => ({
     :required="required"
     :disabled="disabled"
     :icon="icon"
+    :placeholder="placeholder"
     :has-show-password="hasShowPassword"
     @change="change"
     @input="input"
@@ -310,6 +311,7 @@ Common.args = {
   type: "text",
   label: "First name",
   name: "name",
+  placeholder: "",
 };
 
 export const WithError = Template.bind({});

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.4/v0.13.4.stories.mdx
@@ -18,6 +18,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - SfFooter: closing columns on mobile 
 - SfDropdown: change rendering to inline and fix styling
 - SfGallery: scroll for more than 4 thumb images
+- SfInput: changes in placeholder are visible in story
 
 ## 🧹 Chores:
 - docs: update links and logs on welcome page


### PR DESCRIPTION
# Related issue
<!-- paste a link to related issue -->
Closes #

# Scope of work
<!-- describe what you did -->

# Screenshots of visual changes
<!-- if visual changes applied -->

<img width="1196" alt="Screenshot 2022-10-31 at 11 55 21" src="https://user-images.githubusercontent.com/46591755/198992394-9e9c58f4-4d97-424b-b57b-10c2de613082.png">


# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
