### PR TITLE
Fix Leaflet SSR bug

### DIFF
--- a/packages/vue/src/components/organisms/SfStoreLocator/SfStoreLocator.vue
+++ b/packages/vue/src/components/organisms/SfStoreLocator/SfStoreLocator.vue
@@ -173,7 +173,7 @@ export default {
   },
   async mounted() {
     // Fix lack of marker icons
-    const { icon } = await import('leaflet');
+    const { Icon } = await import('leaflet');
     delete Icon.Default.prototype._getIconUrl;
     Icon.Default.mergeOptions({
       iconRetinaUrl: require("leaflet/dist/images/marker-icon-2x.png"),

--- a/packages/vue/src/components/organisms/SfStoreLocator/SfStoreLocator.vue
+++ b/packages/vue/src/components/organisms/SfStoreLocator/SfStoreLocator.vue
@@ -69,13 +69,6 @@ import { focus } from "../../../utilities/directives";
 import SfIcon from "../../atoms/SfIcon/SfIcon.vue";
 import SfLoader from "../../atoms/SfLoader/SfLoader.vue";
 import SfStore from "./_internal/SfStore.vue";
-import { Icon } from "leaflet";
-delete Icon.Default.prototype._getIconUrl;
-Icon.Default.mergeOptions({
-  iconRetinaUrl: require("leaflet/dist/images/marker-icon-2x.png"),
-  iconUrl: require("leaflet/dist/images/marker-icon.png"),
-  shadowUrl: require("leaflet/dist/images/marker-shadow.png"),
-});
 
 Vue.component("SfStore", SfStore);
 export default {
@@ -178,7 +171,16 @@ export default {
       },
     },
   },
-  mounted() {
+  async mounted() {
+    // Fix lack of marker icons
+    const { icon } = await import('leaflet');
+    delete Icon.Default.prototype._getIconUrl;
+    Icon.Default.mergeOptions({
+      iconRetinaUrl: require("leaflet/dist/images/marker-icon-2x.png"),
+      iconUrl: require("leaflet/dist/images/marker-icon.png"),
+      shadowUrl: require("leaflet/dist/images/marker-shadow.png"),
+    });
+
     import("leaflet/dist/leaflet.css");
     import("vue2-leaflet").then(
       ({ LMap, LTileLayer, LMarker, LIcon, LControl, LControlZoom }) => {


### PR DESCRIPTION
Importing leaflet will cause `window is not defined` error on SSR.

Move https://github.com/vuestorefront/storefront-ui/pull/2428 fix on mounted lifecycle.

# Related issue
https://github.com/vuestorefront/storefront-ui/pull/2428
https://github.com/vuestorefront/storefront-ui/issues/2499

