### PR TITLE
docs: github updates

### DIFF
--- a/apps/docs/components/.vuepress/config.js
+++ b/apps/docs/components/.vuepress/config.js
@@ -128,8 +128,8 @@ module.exports = {
     DOCS_EXAMPLES_VUE_PATH,
     FIGMA_URL,
     title: 'Storefront UI',
-    repo: 'https://github.com/vuestorefront/sfui2',
-    docsRepoPath: 'https://github.com/vuestorefront/sfui2/tree/main/apps/docs/components/', // used to generate direct edit links on docs pages.
+    repo: 'https://github.com/vuestorefront/storefront-ui',
+    docsRepoPath: 'https://github.com/vuestorefront/storefront-ui/tree/main/apps/docs/components', // used to generate direct edit links on docs pages.
     secondaryNav: {
       '/react/': [
         { text: 'Getting Started', link: '/react/getting-started' },

--- a/apps/docs/components/.vuepress/theme/layouts/HomeLayout.vue
+++ b/apps/docs/components/.vuepress/theme/layouts/HomeLayout.vue
@@ -38,6 +38,14 @@ export default {
   created() {
     this.loadTabs();
   },
+  mounted() {
+    let githubScript = document.createElement('script');
+    githubScript.setAttribute('src', 'https://buttons.github.io/buttons.js');
+    githubScript.setAttribute('async', 'true');
+    githubScript.setAttribute('defer', 'true');
+
+    document.head.appendChild(githubScript);
+  },
   data() {
     return {
       tabOptions: [],

--- a/apps/docs/components/.vuepress/theme/styles/index.styl
+++ b/apps/docs/components/.vuepress/theme/styles/index.styl
@@ -1,3 +1,8 @@
 /** no @tailwind base because we don't want to override the styles from vsf-docs theme */
 @tailwind components;
 @tailwind utilities;
+
+/* Override default theme for the "Edit this page" link */
+.theme-default-content ~ div a span {
+  display: inline !important;
+}

--- a/apps/docs/components/index.md
+++ b/apps/docs/components/index.md
@@ -7,7 +7,6 @@ hideBreadcrumbs: true
 <div class="grid grid-cols-2 custom-block mt-16 gap-8">
   <div class="col-span-2 lg:col-span-1 flex justify-center flex-col order-2 lg:order-1">
     <div class="flex flex-wrap mb-2">
-        <!-- Place this tag where you want the button to render. -->
         <a class="github-button" href="https://github.com/vuestorefront/storefront-ui" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star buttons/github-buttons on GitHub">Star the Project</a>
     </div>
     <h1 class="text-5xl font-extrabold mt-4">Storefront UI</h1>

--- a/apps/docs/components/index.md
+++ b/apps/docs/components/index.md
@@ -7,14 +7,10 @@ hideBreadcrumbs: true
 <div class="grid grid-cols-2 custom-block mt-16 gap-8">
   <div class="col-span-2 lg:col-span-1 flex justify-center flex-col order-2 lg:order-1">
     <div class="flex flex-wrap mb-2">
-      <p
-        class="flex items-center gap-1 p-2 text-xs font-medium text-green-800 bg-green-500 rounded bg-opacity-20 dark:bg-green-500 dark:bg-opacity-20 dark:text-green-50"
-      >
-        <iconify-icon icon="ri:open-source-fill" height="16" />
-        <span> Open Source </span>
-      </p>
+        <!-- Place this tag where you want the button to render. -->
+        <a class="github-button" href="https://github.com/vuestorefront/storefront-ui" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star buttons/github-buttons on GitHub">Star the Project</a>
     </div>
-    <h1 class="text-5xl font-extrabold">Storefront UI</h1>
+    <h1 class="text-5xl font-extrabold mt-4">Storefront UI</h1>
     <p class="text-xl mt-4">Fast, accessible, and fully customizable components built for e-commerce.</p>
     <div class="mt-8 flex items-center">
       <RouterLink to="/vue/getting-started.html" class=" px-4  py-2 rounded-lg  font-medium bg-green text-white  flex items-center filter hover:brightness-110 transition-all">

--- a/apps/docs/components/utils/utils.js
+++ b/apps/docs/components/utils/utils.js
@@ -1,9 +1,9 @@
 const path = require('path');
 const fs = require('fs');
 
-function addRepoPathToFrontmatter(content, fileName) {
+function addRepoPathToFrontmatter(content, fileName, type) {
   const frontmatterStartIndex = content.indexOf('---') + '---'.length;
-  const link = `/components/${fileName}`;
+  const link = `/${type}/${fileName}`;
 
   return content.slice(0, frontmatterStartIndex) + `\nrepoPath: ${link}` + content.slice(frontmatterStartIndex);
 }
@@ -20,7 +20,7 @@ function addNumberOfBlocksToFrontmatter(content) {
 }
 
 function updateFrontmatter(content, fileName, type) {
-  let docContent = addRepoPathToFrontmatter(content, fileName);
+  let docContent = addRepoPathToFrontmatter(content, fileName, type);
   if (type === 'blocks') {
     docContent = addNumberOfBlocksToFrontmatter(docContent);
   }


### PR DESCRIPTION
# Related issue

# Scope of work
- add github star call to action on the home page
- fix `Edit this page` link for blocks/hooks

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/18535681/227964126-b9ec9dcf-34ea-4d11-ab3b-2ee46c506f87.png)

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
