### PR TITLE
docs: add playground link

### DIFF
--- a/apps/docs/components/react/getting-started.md
+++ b/apps/docs/components/react/getting-started.md
@@ -7,6 +7,10 @@ tabOptions: [next.js,vite,astro]
 
 Since Storefront UI is designed to fit seamlessly into your Tailwind CSS workflow, there will be different installation steps depending on your environment.
 
+::: tip
+Try out Storefront UI in your browser with our [Stackblitz playground](http://play-react.vuestorefront.io/)
+:::
+
 :::::: slot next.js
 
 ## Next.js

--- a/apps/docs/components/react/getting-started.md
+++ b/apps/docs/components/react/getting-started.md
@@ -12,7 +12,7 @@ Since Storefront UI is designed to fit seamlessly into your Tailwind CSS workflo
 You can try out Storefront UI in your browser with our online playground.
 
 <div class="custom-block mt-8">
-<a href="http://play-react.vuestorefront.io/" target="_blank" rel="noopener noreferrer" class="custom-block  dark:text-white font-medium px-4 py-2 border-green border-2 rounded-lg hover:bg-green transition-colors hover:text-white">Stackblitz playground</a>
+<a href="http://play-react.vuestorefront.io/" target="_blank" rel="noopener noreferrer" class="custom-block dark:text-white font-medium px-4 py-2 border-green border-2 rounded-lg hover:bg-green transition-colors hover:text-white">Stackblitz playground</a>
 </div>
 
 :::::: slot next.js

--- a/apps/docs/components/react/getting-started.md
+++ b/apps/docs/components/react/getting-started.md
@@ -7,9 +7,13 @@ tabOptions: [next.js,vite,astro]
 
 Since Storefront UI is designed to fit seamlessly into your Tailwind CSS workflow, there will be different installation steps depending on your environment.
 
-::: tip
-Try out Storefront UI in your browser with our [Stackblitz playground](http://play-react.vuestorefront.io/)
-:::
+## Playground
+
+You can try out Storefront UI in your browser with our online playground.
+
+<div class="custom-block mt-8">
+<a href="http://play-react.vuestorefront.io/" target="_blank" rel="noopener noreferrer" class="custom-block  dark:text-white font-medium px-4 py-2 border-green border-2 rounded-lg hover:bg-green transition-colors hover:text-white">Stackblitz playground</a>
+</div>
 
 :::::: slot next.js
 

--- a/apps/docs/components/vue/getting-started.md
+++ b/apps/docs/components/vue/getting-started.md
@@ -7,6 +7,10 @@ tabOptions: [nuxt,vite,astro]
 
 Since Storefront UI is designed to fit seamlessly into your Tailwind CSS workflow, there will be different installation steps depending on your environment.
 
+::: tip
+Try out Storefront UI in your browser with our [Stackblitz playground](http://play-vue.vuestorefront.io/)
+:::
+
 :::::: slot vite
 
 ## Vite + Vue 3

--- a/apps/docs/components/vue/getting-started.md
+++ b/apps/docs/components/vue/getting-started.md
@@ -12,7 +12,7 @@ Since Storefront UI is designed to fit seamlessly into your Tailwind CSS workflo
 You can try out Storefront UI in your browser with our online playground.
 
 <div class="custom-block mt-8">
-<a href="http://play-vue.vuestorefront.io/" target="_blank" rel="noopener noreferrer" class="custom-block  dark:text-white font-medium px-4 py-2 border-green border-2 rounded-lg hover:bg-green transition-colors hover:text-white">Stackblitz playground</a>
+<a href="http://play-vue.vuestorefront.io/" target="_blank" rel="noopener noreferrer" class="custom-block dark:text-white font-medium px-4 py-2 border-green border-2 rounded-lg hover:bg-green transition-colors hover:text-white">Stackblitz playground</a>
 </div>
 
 

--- a/apps/docs/components/vue/getting-started.md
+++ b/apps/docs/components/vue/getting-started.md
@@ -7,9 +7,15 @@ tabOptions: [nuxt,vite,astro]
 
 Since Storefront UI is designed to fit seamlessly into your Tailwind CSS workflow, there will be different installation steps depending on your environment.
 
-::: tip
-Try out Storefront UI in your browser with our [Stackblitz playground](http://play-vue.vuestorefront.io/)
-:::
+## Playground
+
+You can try out Storefront UI in your browser with our online playground.
+
+<div class="custom-block mt-8">
+<a href="http://play-vue.vuestorefront.io/" target="_blank" rel="noopener noreferrer" class="custom-block  dark:text-white font-medium px-4 py-2 border-green border-2 rounded-lg hover:bg-green transition-colors hover:text-white">Stackblitz playground</a>
+</div>
+
+
 
 :::::: slot vite
 


### PR DESCRIPTION
# Related issue

Closes #

# Scope of work
- adds link to the Stackblitz playground for Vue/React to the corresponding introduction page

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/18535681/227993415-c522d05d-0a8e-44c3-8f55-8cfcebebec5a.png)



# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
