### PR TITLE
docs: navbar renaming

### DIFF
--- a/apps/docs/components/.vuepress/config.js
+++ b/apps/docs/components/.vuepress/config.js
@@ -133,17 +133,17 @@ module.exports = {
     secondaryNav: {
       '/react/': [
         { text: 'Getting Started', link: '/react/getting-started' },
-        { text: 'Docs', link: '/react/components' },
+        { text: 'Base Components', link: '/react/components' },
         { text: 'Blocks', link: '/react/blocks' },
       ],
       '/vue/': [
         { text: 'Getting Started', link: '/vue/getting-started' },
-        { text: 'Docs', link: '/vue/components' },
+        { text: 'Base Components', link: '/vue/components' },
         { text: 'Blocks', link: '/vue/blocks' },
       ],
       '/': [
         { text: 'Getting Started', link: '/vue/getting-started' },
-        { text: 'Docs', link: '/vue/components' },
+        { text: 'Base Components', link: '/vue/components' },
         { text: 'Blocks', link: '/vue/blocks' },
       ],
     },


### PR DESCRIPTION
# Related issue

# Scope of work
- renames `Docs` to `Base Components` in the navbar

# Screenshots of visual changes
<!-- if visual changes applied -->

# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
