### PR TITLE
fix: radio styling in firefox [SFUI2-902]

### DIFF
--- a/packages/sfui/frameworks/react/components/SfInput/SfInput.tsx
+++ b/packages/sfui/frameworks/react/components/SfInput/SfInput.tsx
@@ -23,11 +23,12 @@ const SfInput = forwardRef<HTMLInputElement, SfInputProps>(
       {slotPrefix && <span className="pr-2">{slotPrefix}</span>}
       <input
         className={classNames([
-          'appearance-none outline-none min-w-[80px] w-full text-base text-neutral-900 disabled:cursor-not-allowed disabled:bg-transparent read-only:bg-transparent',
+          'min-w-[80px] w-full text-base outline-none appearance-none text-neutral-900 disabled:cursor-not-allowed disabled:bg-transparent read-only:bg-transparent',
           className,
         ])}
         type="text"
         data-testid="input-field"
+        size={1}
         ref={ref}
         {...attributes}
       />

--- a/packages/sfui/frameworks/react/components/SfRadio/SfRadio.tsx
+++ b/packages/sfui/frameworks/react/components/SfRadio/SfRadio.tsx
@@ -11,7 +11,7 @@ export default forwardRef<HTMLInputElement, SfRadioProps>((props, ref) => {
       type="radio"
       disabled={disabled}
       className={classNames(
-        'min-w-[20px] h-5 border-2 p-[3px] bg-clip-content rounded-full appearance-none cursor-pointer focus-visible:outline focus-visible:outline-offset disabled:border-disabled-500 disabled:cursor-not-allowed disabled:checked:bg-disabled-500 disabled:checked:border-disabled-500',
+        'h-5 w-5 border-2 p-[3px] bg-clip-content rounded-full appearance-none cursor-pointer focus-visible:outline focus-visible:outline-offset disabled:border-disabled-500 disabled:cursor-not-allowed disabled:checked:bg-disabled-500 disabled:checked:border-disabled-500',
         invalid && !disabled
           ? 'border-negative-700 checked:bg-negative-700 hover:border-negative-800 hover:checked:bg-negative-800 active:border-negative-900 active:checked:bg-negative-900'
           : 'border-neutral-500 active:border-primary-900 hover:border-primary-700 checked:bg-primary-700 checked:border-primary-700 hover:checked:bg-primary-800 hover:checked:border-primary-800 active:checked:bg-primary-900 active:checked:border-primary-900',

--- a/packages/sfui/frameworks/vue/components/SfInput/SfInput.vue
+++ b/packages/sfui/frameworks/vue/components/SfInput/SfInput.vue
@@ -60,7 +60,7 @@ const inputValue = useVModel(props, 'modelValue', emit);
       v-bind="$attrs"
       class="min-w-[80px] w-full text-base outline-none appearance-none text-neutral-900 disabled:cursor-not-allowed disabled:bg-transparent read-only:bg-transparent"
       data-testid="input-field"
-      :size="1"
+      size="1"
     />
     <span v-if="$slots.suffix" class="pl-2">
       <slot name="suffix" />

--- a/packages/sfui/frameworks/vue/components/SfRadio/SfRadio.vue
+++ b/packages/sfui/frameworks/vue/components/SfRadio/SfRadio.vue
@@ -42,7 +42,7 @@ const proxyChecked = computed({
     type="radio"
     :value="value"
     :class="[
-      'min-w-[20px] h-5 border-2 p-[3px] bg-clip-content rounded-full appearance-none cursor-pointer focus-visible:outline focus-visible:outline-offset disabled:border-disabled-500 disabled:cursor-not-allowed disabled:checked:bg-disabled-500 disabled:checked:border-disabled-500',
+      'h-5 w-5 border-2 p-[3px] bg-clip-content rounded-full appearance-none cursor-pointer focus-visible:outline focus-visible:outline-offset disabled:border-disabled-500 disabled:cursor-not-allowed disabled:checked:bg-disabled-500 disabled:checked:border-disabled-500',
       invalid && !disabled
         ? 'border-negative-700 checked:bg-negative-700 hover:border-negative-800 hover:checked:bg-negative-800 active:border-negative-900 active:checked:bg-negative-900'
         : 'border-neutral-500 active:border-primary-900 hover:border-primary-700 checked:bg-primary-700 checked:border-primary-700 hover:checked:bg-primary-800 hover:checked:border-primary-800 active:checked:bg-primary-900 active:checked:border-primary-900',


### PR DESCRIPTION
# Related issue
Closes https://vsf.atlassian.net/browse/SFUI2-902

# Scope of work
add width due to radio overflowing in firefox

# Screenshots of visual changes
Now it works:
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/10456649/228072374-7243f544-2f2b-4309-9ba3-f8da1b808db9.png">


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x]  a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created