### PR TITLE
fix: quantitySelector in firefox [SFUI2-902]

### DIFF
--- a/apps/preview/next/pages/showcases/ProductCard/Details.tsx
+++ b/apps/preview/next/pages/showcases/ProductCard/Details.tsx
@@ -79,7 +79,7 @@ export default function ProductDetails() {
                 id={inputId}
                 type="number"
                 role="spinbutton"
-                className="appearance-none grow mx-2 text-center [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
+                className="grow appearance-none mx-2 w-8 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
                 min={min}
                 max={max}
                 value={value}

--- a/apps/preview/next/pages/showcases/ProductCard/ProductCardHorizontal.tsx
+++ b/apps/preview/next/pages/showcases/ProductCard/ProductCardHorizontal.tsx
@@ -53,12 +53,12 @@ export default function ProductCardHorizontal() {
         <div className="items-center sm:mt-auto sm:flex">
           <span className="font-bold sm:ml-auto sm:order-1 typography-text-sm sm:typography-text-lg">$2,345.99</span>
           <div className="flex items-center justify-between mt-4 sm:mt-0">
-            <div className="flex mr-auto sm:mr-4">
+            <div className="flex border border-neutral-300 rounded-md">
               <SfButton
                 type="button"
                 variant="tertiary"
                 square
-                className="border-l rounded-r-none border-y border-neutral-300"
+                className="rounded-r-none"
                 disabled={value <= min}
                 aria-controls={inputId}
                 aria-label="Decrease value"
@@ -70,7 +70,7 @@ export default function ProductCardHorizontal() {
                 id={inputId}
                 type="number"
                 role="spinbutton"
-                className="appearance-none px-2 border-y border-neutral-300 rounded-none text-center [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none"
+                className="appearance-none mx-2 w-8 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
                 min={min}
                 max={max}
                 value={value}
@@ -80,7 +80,7 @@ export default function ProductCardHorizontal() {
                 type="button"
                 variant="tertiary"
                 square
-                className="border-r rounded-l-none border-y border-neutral-300"
+                className="rounded-l-none"
                 disabled={value >= max}
                 aria-controls={inputId}
                 aria-label="Increase value"

--- a/apps/preview/next/pages/showcases/QuantitySelector/OutOfStock.tsx
+++ b/apps/preview/next/pages/showcases/QuantitySelector/OutOfStock.tsx
@@ -9,7 +9,7 @@ export default function OutOfStockDemo() {
   const max = 10;
   return (
     <div className="inline-flex flex-col items-center">
-      <div className="flex rounded-md bg-neutral-100 relative after:content-['-'] after:text-disabled-900 after:absolute after:flex after:justify-center after:items-center after:w-full after:h-full">
+      <div className="flex rounded-md border border-disabled-200 bg-disabled-100">
         <SfButton
           variant="tertiary"
           type="button"
@@ -26,7 +26,7 @@ export default function OutOfStockDemo() {
           type="number"
           role="spinbutton"
           disabled
-          className="appearance-none px-2 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none"
+          className="appearance-none mx-2 w-8 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
           min={min}
           max={max}
         />

--- a/apps/preview/next/pages/showcases/QuantitySelector/QuantitySelector.tsx
+++ b/apps/preview/next/pages/showcases/QuantitySelector/QuantitySelector.tsx
@@ -34,7 +34,7 @@ export default function QuantitySelector() {
           id={inputId}
           type="number"
           role="spinbutton"
-          className="appearance-none mx-2 text-center [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
+          className="appearance-none mx-2 w-8 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
           min={min}
           max={max}
           value={value}

--- a/apps/preview/next/pages/showcases/QuantitySelector/Rounded.tsx
+++ b/apps/preview/next/pages/showcases/QuantitySelector/Rounded.tsx
@@ -33,7 +33,7 @@ export default function QuantitySelector() {
           id={inputId}
           type="number"
           role="spinbutton"
-          className="appearance-none mx-2 text-center [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
+          className="appearance-none px-2 mx-2 w-12 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
           min={min}
           max={max}
           value={value}

--- a/apps/preview/nuxt/pages/showcases/ProductCard/Details.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductCard/Details.vue
@@ -47,7 +47,7 @@
               v-model="count"
               type="number"
               role="spinbutton"
-              class="grow appearance-none mx-2 text-center [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
+              class="grow appearance-none mx-2 w-8 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
               :min="min"
               :max="max"
               @input="handleOnChange"

--- a/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardHorizontal.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardHorizontal.vue
@@ -34,25 +34,25 @@
       <div class="items-center sm:mt-auto sm:flex">
         <span class="font-bold sm:ml-auto sm:order-1 typography-text-sm sm:typography-text-lg">$2,345.99 </span>
         <div class="flex items-center justify-between mt-4 sm:mt-0">
-          <div class="flex mr-auto sm:mr-4">
+          <div class="flex border border-neutral-300 rounded-md">
             <SfButton
               type="button"
               variant="tertiary"
               :disabled="count <= min"
               square
-              class="border-l rounded-r-none border-y border-neutral-300"
-              :aria-controls="useId"
+              class="rounded-r-none"
+              :aria-controls="inputId"
               aria-label="Decrease value"
               @click="dec()"
             >
               <SfIconRemove />
             </SfButton>
             <input
-              :id="useId"
+              :id="inputId"
               v-model="count"
               type="number"
               role="spinbutton"
-              class="appearance-none px-2 border-y border-neutral-300 rounded-none text-center [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none"
+              class="appearance-none mx-2 w-8 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
               :min="min"
               :max="max"
               @input="handleOnChange"
@@ -62,8 +62,8 @@
               variant="tertiary"
               :disabled="count >= max"
               square
-              class="border-r rounded-l-none border-y border-neutral-300"
-              :aria-controls="useId"
+              class="rounded-l-none"
+              :aria-controls="inputId"
               aria-label="Increase value"
               @click="inc()"
             >
@@ -93,6 +93,7 @@ import { useCounter } from '@vueuse/core';
 
 const min = ref(1);
 const max = ref(10);
+const inputId = useId();
 const { count, inc, dec, set } = useCounter(1, { min: min.value, max: max.value });
 function handleOnChange(event: Event) {
   const currentValue = (event.target as HTMLInputElement)?.value;

--- a/apps/preview/nuxt/pages/showcases/QuantitySelector/OutOfStock.vue
+++ b/apps/preview/nuxt/pages/showcases/QuantitySelector/OutOfStock.vue
@@ -1,17 +1,7 @@
 <template>
   <div class="inline-flex flex-col items-center">
-    <div
-      class="flex rounded-md bg-neutral-100 relative after:content-['-'] after:text-disabled-900 after:absolute after:flex after:justify-center after:items-center after:w-full after:h-full"
-    >
-      <SfButton
-        variant="tertiary"
-        type="button"
-        square
-        disabled
-        :aria-controls="inputId"
-        aria-label="Decrease value"
-        class="!bg-neutral-100"
-      >
+    <div class="flex rounded-md border border-disabled-200 bg-disabled-100">
+      <SfButton variant="tertiary" type="button" square disabled :aria-controls="inputId" aria-label="Decrease value">
         <SfIconRemove />
       </SfButton>
       <input
@@ -19,7 +9,8 @@
         type="number"
         role="spinbutton"
         disabled
-        class="appearance-none px-2 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none"
+        class="appearance-none mx-2 w-8 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
+        placeholder="-"
         :min="min"
         :max="max"
       />

--- a/apps/preview/nuxt/pages/showcases/QuantitySelector/QuantitySelector.vue
+++ b/apps/preview/nuxt/pages/showcases/QuantitySelector/QuantitySelector.vue
@@ -18,7 +18,7 @@
         v-model="count"
         type="number"
         role="spinbutton"
-        class="appearance-none mx-2 text-center [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
+        class="appearance-none mx-2 w-8 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
         :min="min"
         :max="max"
         @input="handleOnChange"
@@ -49,7 +49,7 @@ import { useCounter } from '@vueuse/core';
 import { SfButton, SfIconAdd, SfIconRemove, useId } from '@storefront-ui/vue';
 
 const min = ref(1);
-const max = ref(10);
+const max = ref(999);
 const inputId = useId();
 const { count, inc, dec, set } = useCounter(1, { min: min.value, max: max.value });
 

--- a/apps/preview/nuxt/pages/showcases/QuantitySelector/Rounded.vue
+++ b/apps/preview/nuxt/pages/showcases/QuantitySelector/Rounded.vue
@@ -1,40 +1,38 @@
 <template>
-  <div class="inline-flex flex-col items-center">
-    <div class="flex">
-      <SfButton
-        type="button"
-        square
-        class="!rounded-full"
-        :disabled="count <= min"
-        :aria-controls="inputId"
-        aria-label="Decrease value"
-        @click="dec()"
-      >
-        <SfIconRemove />
-      </SfButton>
-      <input
-        :id="inputId"
-        v-model="count"
-        type="number"
-        role="spinbutton"
-        class="appearance-none mx-2 text-center [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
-        :min="min"
-        :max="max"
-        @input="handleOnChange"
-      />
+  <div class="flex">
+    <SfButton
+      type="button"
+      square
+      class="!rounded-full"
+      :disabled="count <= min"
+      :aria-controls="inputId"
+      aria-label="Decrease value"
+      @click="dec()"
+    >
+      <SfIconRemove />
+    </SfButton>
+    <input
+      :id="inputId"
+      v-model="count"
+      type="number"
+      role="spinbutton"
+      class="appearance-none px-2 mx-2 w-12 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
+      :min="min"
+      :max="max"
+      @input="handleOnChange"
+    />
 
-      <SfButton
-        type="button"
-        square
-        class="!rounded-full"
-        :disabled="count >= max"
-        :aria-controls="inputId"
-        aria-label="Increase value"
-        @click="inc()"
-      >
-        <SfIconAdd />
-      </SfButton>
-    </div>
+    <SfButton
+      type="button"
+      square
+      class="!rounded-full"
+      :disabled="count >= max"
+      :aria-controls="inputId"
+      aria-label="Increase value"
+      @click="inc()"
+    >
+      <SfIconAdd />
+    </SfButton>
   </div>
 </template>
 


### PR DESCRIPTION
# Related issue
Closes https://vsf.atlassian.net/browse/SFUI2-902

# Scope of work
Fix quantity selector in firefox

# Screenshots of visual changes
Before:
<img width="839" alt="image" src="https://user-images.githubusercontent.com/10456649/228072679-4a6f59d3-c180-4275-9ad8-541a3af0c8dc.png">

After:
<img width="823" alt="image" src="https://user-images.githubusercontent.com/10456649/228072708-b22fdcba-2e77-43b8-85cb-f2ac2d66f7b8.png">


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x]  a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created