### PR TITLE
fix: (sfui2-903) initialValue on modal and in docs [hotfix]

### DIFF
--- a/packages/sfui/frameworks/vue/composables/useDisclosure/useDisclosure.ts
+++ b/packages/sfui/frameworks/vue/composables/useDisclosure/useDisclosure.ts
@@ -1,15 +1,20 @@
 import { syncRefs } from '@vueuse/core';
-import { ref, isRef } from 'vue';
+import { ref, isRef, unref, Ref } from 'vue';
 import type { UseDisclosureOptions } from '@storefront-ui/vue';
 
-export function useDisclosure({ initialValue = false }: UseDisclosureOptions = {}) {
-  const isOpen = ref<boolean>();
-  const toggle = (value?: boolean) => (isOpen.value = value ?? !isOpen.value);
+export function useDisclosure({ initialValue = false }: UseDisclosureOptions = {}): {
+  isOpen: Ref<boolean>;
+  open: () => boolean;
+  close: () => boolean;
+  toggle: () => boolean;
+} {
+  const isOpen: Ref<boolean> = ref<boolean>(unref(initialValue));
+  const toggle: (value?: boolean | undefined) => boolean = (value?: boolean) => (isOpen.value = value ?? !isOpen.value);
+  console.log(isOpen.value)
 
-  if (isRef(initialValue)) syncRefs(initialValue, isOpen, { immediate: true });
+  if (isRef(initialValue)) syncRefs(initialValue, isOpen);
 
-  const open = () => toggle(true);
-  const close = () => toggle(false);
-
+  const open: () => boolean = () => toggle(true);
+  const close: () => boolean = () => toggle(false);
   return { isOpen, open, close, toggle };
 }

--- a/packages/sfui/frameworks/vue/composables/useDisclosure/useDisclosure.ts
+++ b/packages/sfui/frameworks/vue/composables/useDisclosure/useDisclosure.ts
@@ -10,7 +10,6 @@ export function useDisclosure({ initialValue = false }: UseDisclosureOptions = {
 } {
   const isOpen: Ref<boolean> = ref<boolean>(unref(initialValue));
   const toggle: (value?: boolean | undefined) => boolean = (value?: boolean) => (isOpen.value = value ?? !isOpen.value);
-  console.log(isOpen.value)
 
   if (isRef(initialValue)) syncRefs(initialValue, isOpen);
 


### PR DESCRIPTION
# Related issue
Closes [#903](https://vsf.atlassian.net/browse/SFUI2-903)

# Scope of work

Added reactive `initialValue` in the modal base component and in docs.

# Screenshots of visual changes
Now it's possible to set `initialValue` to true and has the modal open by default. 

# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
