### PR TITLE
docs: add example for dropdown

### DIFF
--- a/apps/docs/components/components/dropdown.md
+++ b/apps/docs/components/components/dropdown.md
@@ -18,6 +18,23 @@ Learn more about `useDropdown` composable in the [Composables > useDropdown docs
 <!-- end vue -->
 :::
 
+## Examples
+
+### Basic Usage
+
+By default, the floating content of `SfDropdown` will be placed below your trigger element.
+
+<Showcase showcase-name="Dropdown/BasicDropdown" style="min-height:400px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Dropdown/BasicDropdown.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Dropdown/BasicDropdown.tsx#source
+<!-- end react -->
+
+</Showcase>
+
 ## Playground
 
 <Generate />

--- a/apps/preview/next/pages/showcases/Dropdown/BasicDropdown.tsx
+++ b/apps/preview/next/pages/showcases/Dropdown/BasicDropdown.tsx
@@ -1,0 +1,20 @@
+import { ShowcasePageLayout } from '../../showcases';
+
+// #region source
+import { SfButton, SfDropdown, useDisclosure } from '@storefront-ui/react';
+
+export default function BasicDropdown() {
+  const { isOpen, toggle, close } = useDisclosure();
+  return (
+    <SfDropdown trigger={<SfButton onClick={toggle}>Toggle</SfButton>} open={isOpen} onClose={close}>
+      <ul className="p-2 rounded bg-gray-100">
+        <li>More</li>
+        <li>About</li>
+        <li>Settings</li>
+      </ul>
+    </SfDropdown>
+  );
+}
+
+// #endregion source
+BasicDropdown.getLayout = ShowcasePageLayout;

--- a/apps/preview/nuxt/pages/showcases/Dropdown/BasicDropdown.vue
+++ b/apps/preview/nuxt/pages/showcases/Dropdown/BasicDropdown.vue
@@ -1,0 +1,18 @@
+<template>
+  <SfDropdown v-model="isOpen">
+    <template #trigger>
+      <SfButton @click="toggle()">Toggle</SfButton>
+    </template>
+    <ul class="p-2 rounded bg-gray-100">
+      <li>More</li>
+      <li>About</li>
+      <li>Settings</li>
+    </ul>
+  </SfDropdown>
+</template>
+
+<script lang="ts" setup>
+import { SfDropdown, useDisclosure, SfButton } from '@storefront-ui/vue';
+
+const { isOpen, toggle } = useDisclosure();
+</script>


### PR DESCRIPTION
# Related issue

`SfDropdown` does not have any example usage currently in the docs.

# Scope of work
- converts the playground example into a copy and paste example in Next and Nuxt

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/18535681/228217855-2e8eff5f-4563-46b2-87a4-e4a79fd7c3c3.png)


# Checklist

- [ ] No commented blocks of code left
- [ ] Run tests and docs
- [ ] Self code-reviewed
- [ ] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
