### PR TITLE
docs: add basic tooltip example

### DIFF
--- a/apps/docs/components/components/tooltip.md
+++ b/apps/docs/components/components/tooltip.md
@@ -20,6 +20,20 @@ Learn more about `useTooltip` composable in the [Composables > useTooltip docs](
 <!-- end vue -->
 :::
 
+## Examples
+
+### Basic Usage
+
+<Showcase showcase-name="Tooltip/BasicTooltip">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Tooltip/BasicTooltip.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Tooltip/BasicTooltip.tsx#source
+<!-- end react -->
+</Showcase>
+
 ## Accessibility notes
 
 By default, this component sets `role="tooltip"`.

--- a/apps/preview/next/pages/showcases/Tooltip/BasicTooltip.tsx
+++ b/apps/preview/next/pages/showcases/Tooltip/BasicTooltip.tsx
@@ -1,0 +1,14 @@
+import { ShowcasePageLayout } from '../../showcases';
+// #region source
+import { SfTooltip } from '@storefront-ui/react';
+
+export default function BasicTooltip() {
+  return (
+    <SfTooltip label="This is a tooltip!">
+      <span>Hover me!</span>
+    </SfTooltip>
+  );
+}
+
+// #endregion source
+BasicTooltip.getLayout = ShowcasePageLayout;

--- a/apps/preview/nuxt/pages/showcases/Tooltip/BasicTooltip.vue
+++ b/apps/preview/nuxt/pages/showcases/Tooltip/BasicTooltip.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="mt-12">
+    <SfTooltip label="This is a tooltip!"> Hover me! </SfTooltip>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { SfTooltip } from '@storefront-ui/vue';
+</script>


### PR DESCRIPTION
# Related issue
Currently, `SfTooltip` does not have a copy and paste example of usage.

# Scope of work
- converts the `SfTooltip` playground into a minimal copy and paste example for Next/Nuxt

# Screenshots of visual changes
![image](https://user-images.githubusercontent.com/18535681/228224200-d3cafe51-0b3e-496d-b5dd-7a0fada40103.png)


# Checklist

- [x] No commented blocks of code left
- [x] Run tests and docs
- [x] Self code-reviewed
- [x] Changes documented 

If applicable:

- [ ] I followed [composition rules](https://docs.storefrontui.io/?path=/story/introduction-contributing-guide-code-guidelines--page) for my component
- [ ] I tested the component in most common device sizes (can be tested in Storybook [from viewport addon in top menu](https://github.com/storybooks/storybook/tree/master/addons/viewport))
