### PR TITLE
docs: update footer links via vuepress theme

### DIFF
--- a/apps/docs/components/.vuepress/config.js
+++ b/apps/docs/components/.vuepress/config.js
@@ -128,6 +128,7 @@ module.exports = {
     DOCS_EXAMPLES_REACT_PATH,
     DOCS_EXAMPLES_VUE_PATH,
     FIGMA_URL,
+    coreDocs: false,
     title: 'Storefront UI',
     repo: 'https://github.com/vuestorefront/storefront-ui',
     docsRepoPath: 'https://github.com/vuestorefront/storefront-ui/tree/v2/apps/docs/components/', // used to generate direct edit links on docs pages.

--- a/apps/docs/components/package.json
+++ b/apps/docs/components/package.json
@@ -50,7 +50,7 @@
     "sass-loader": "^13.0.0",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.2.17",
     "vue-multiselect": "^2.1.6",
-    "vuepress-theme-vsf-docs": "^1.2.16"
+    "vuepress-theme-vsf-docs": "^1.2.17"
   },
   "resolutions": {
     "webpack-hot-middleware": "2.25.3"

--- a/apps/docs/components/package.json
+++ b/apps/docs/components/package.json
@@ -50,7 +50,7 @@
     "sass-loader": "^13.0.0",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.2.17",
     "vue-multiselect": "^2.1.6",
-    "vuepress-theme-vsf-docs": "^1.2.17"
+    "vuepress-theme-vsf-docs": "^1.2.19"
   },
   "resolutions": {
     "webpack-hot-middleware": "2.25.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3704,7 +3704,7 @@ __metadata:
     vue-multiselect: ^2.1.6
     vuepress: ^1.9.8
     vuepress-plugin-clean-urls: ^1.1.2
-    vuepress-theme-vsf-docs: ^1.2.16
+    vuepress-theme-vsf-docs: ^1.2.17
   languageName: unknown
   linkType: soft
 
@@ -26193,9 +26193,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vuepress-theme-vsf-docs@npm:^1.2.16":
-  version: 1.2.16
-  resolution: "vuepress-theme-vsf-docs@npm:1.2.16"
+"vuepress-theme-vsf-docs@npm:^1.2.17":
+  version: 1.2.17
+  resolution: "vuepress-theme-vsf-docs@npm:1.2.17"
   dependencies:
     "@vuepress/plugin-active-header-links": 1.9.7
     "@vuepress/plugin-nprogress": 1.9.7
@@ -26203,7 +26203,7 @@ __metadata:
     iconify-icon: ^1.0.1
     markdown-it-anchor: ^8.6.5
     vuepress-plugin-container: ^2.0.2
-  checksum: 980d7123f87185728da010a09d8fd3d26d720da977c842075a3ab468362714859f6b572b92286d4513226d207a25e226354da8e1f6dff6aaa47735579a8dab0b
+  checksum: 9b0a563073c037c6c35af20d60ad06f08f465702c862f307758068beed4d3828368f0199d03c2fb74188cf25226b0aaa0d2516e1718ae559200868a641f5e43a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3704,7 +3704,7 @@ __metadata:
     vue-multiselect: ^2.1.6
     vuepress: ^1.9.8
     vuepress-plugin-clean-urls: ^1.1.2
-    vuepress-theme-vsf-docs: ^1.2.17
+    vuepress-theme-vsf-docs: ^1.2.19
   languageName: unknown
   linkType: soft
 
@@ -26193,9 +26193,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vuepress-theme-vsf-docs@npm:^1.2.17":
-  version: 1.2.17
-  resolution: "vuepress-theme-vsf-docs@npm:1.2.17"
+"vuepress-theme-vsf-docs@npm:^1.2.19":
+  version: 1.2.19
+  resolution: "vuepress-theme-vsf-docs@npm:1.2.19"
   dependencies:
     "@vuepress/plugin-active-header-links": 1.9.7
     "@vuepress/plugin-nprogress": 1.9.7
@@ -26203,7 +26203,7 @@ __metadata:
     iconify-icon: ^1.0.1
     markdown-it-anchor: ^8.6.5
     vuepress-plugin-container: ^2.0.2
-  checksum: 9b0a563073c037c6c35af20d60ad06f08f465702c862f307758068beed4d3828368f0199d03c2fb74188cf25226b0aaa0d2516e1718ae559200868a641f5e43a
+  checksum: 6271785097bba030791c7e9878b6ef840a4f16e6df74340bdb0e535bc6c1d0c7a727f4a5440e87bbfa86349d366aa3e7c4ad25a2fa6ff987e7d31e1ac1a2aae6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Related issue

After the main website rework (vuestorefront.io) - some of the links that were previously in the docs footer now 404. Just found this out with the SFUI release because of the number of new developers exploring the docs site. 

# Scope of work

- updated links in shared theme

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
