### PR TITLE
fix: (sfui2-903) initialvalue in useDisclosure composable 

### DIFF
--- a/packages/sfui/frameworks/vue/composables/useDisclosure/useDisclosure.ts
+++ b/packages/sfui/frameworks/vue/composables/useDisclosure/useDisclosure.ts
@@ -1,9 +1,9 @@
 import { syncRefs } from '@vueuse/core';
-import { ref, isRef } from 'vue';
+import { ref, isRef, unref } from 'vue';
 import type { UseDisclosureOptions } from '@storefront-ui/vue';
 
 export function useDisclosure({ initialValue = false }: UseDisclosureOptions = {}) {
-  const isOpen = ref<boolean>();
+  const isOpen = ref<boolean>(unref(initialValue));
   const toggle = (value?: boolean) => (isOpen.value = value ?? !isOpen.value);
 
   if (isRef(initialValue)) syncRefs(initialValue, isOpen, { immediate: true });


### PR DESCRIPTION
# Related issue

Closes[ #903](https://vsf.atlassian.net/browse/SFUI2-903)

# Scope of work

Passed `initialValue`  to `isOpen` property in `useDisclosure` Vue composable. 
Now when changing to `useDisclosure({ initialValue: true });`  in the Modal component it is opened by default. 

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
