### PR TITLE
chore(deps): unify and update cypress version to 12.9

### DIFF
--- a/apps/preview/next/package.json
+++ b/apps/preview/next/package.json
@@ -53,7 +53,7 @@
     "chokidar-cli": "^3.0.0",
     "concurrently": "^7.6.0",
     "cpy-cli": "^4.2.0",
-    "cypress": "^12.5.1",
+    "cypress": "^12.9.0",
     "glob-promise": "^6.0.2",
     "nyc": "^15.1.0",
     "postcss": "^8.4.21",

--- a/apps/preview/vue/package.json
+++ b/apps/preview/vue/package.json
@@ -46,7 +46,7 @@
     "chokidar-cli": "^3.0.0",
     "concurrently": "^7.6.0",
     "cpy-cli": "^4.2.0",
-    "cypress": "^11.0.1",
+    "cypress": "^12.9.0",
     "eslint": "^8.34.0",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-vue": "^9.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3782,7 +3782,7 @@ __metadata:
     classnames: ^2.3.2
     concurrently: ^7.6.0
     cpy-cli: ^4.2.0
-    cypress: ^12.5.1
+    cypress: ^12.9.0
     glob-promise: ^6.0.2
     lodash-es: ^4.17.21
     next: ^13.1.6
@@ -3976,7 +3976,7 @@ __metadata:
     chokidar-cli: ^3.0.0
     concurrently: ^7.6.0
     cpy-cli: ^4.2.0
-    cypress: ^11.0.1
+    cypress: ^12.9.0
     eslint: ^8.34.0
     eslint-plugin-cypress: ^2.12.1
     eslint-plugin-vue: ^9.9.0
@@ -9908,61 +9908,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:^11.0.1":
-  version: 11.2.0
-  resolution: "cypress@npm:11.2.0"
-  dependencies:
-    "@cypress/request": ^2.88.10
-    "@cypress/xvfb": ^1.2.4
-    "@types/node": ^14.14.31
-    "@types/sinonjs__fake-timers": 8.1.1
-    "@types/sizzle": ^2.3.2
-    arch: ^2.2.0
-    blob-util: ^2.0.2
-    bluebird: ^3.7.2
-    buffer: ^5.6.0
-    cachedir: ^2.3.0
-    chalk: ^4.1.0
-    check-more-types: ^2.24.0
-    cli-cursor: ^3.1.0
-    cli-table3: ~0.6.1
-    commander: ^5.1.0
-    common-tags: ^1.8.0
-    dayjs: ^1.10.4
-    debug: ^4.3.2
-    enquirer: ^2.3.6
-    eventemitter2: 6.4.7
-    execa: 4.1.0
-    executable: ^4.1.1
-    extract-zip: 2.0.1
-    figures: ^3.2.0
-    fs-extra: ^9.1.0
-    getos: ^3.2.1
-    is-ci: ^3.0.0
-    is-installed-globally: ~0.4.0
-    lazy-ass: ^1.6.0
-    listr2: ^3.8.3
-    lodash: ^4.17.21
-    log-symbols: ^4.0.0
-    minimist: ^1.2.6
-    ospath: ^1.2.2
-    pretty-bytes: ^5.6.0
-    proxy-from-env: 1.0.0
-    request-progress: ^3.0.0
-    semver: ^7.3.2
-    supports-color: ^8.1.1
-    tmp: ~0.2.1
-    untildify: ^4.0.0
-    yauzl: ^2.10.0
-  bin:
-    cypress: bin/cypress
-  checksum: e13649fb4b62a3c9dff7cc571f4e01dba009d8179b05c4f885c5ceb4ed76b78a7323fec491d992da35527708b54e596bfc9edb1d702f788317889f794d8c1e76
-  languageName: node
-  linkType: hard
-
-"cypress@npm:^12.5.1":
-  version: 12.6.0
-  resolution: "cypress@npm:12.6.0"
+"cypress@npm:^12.9.0":
+  version: 12.9.0
+  resolution: "cypress@npm:12.9.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -10008,7 +9956,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: 716afdc7bd83d14d9ad31aba9f757a5dfccc1a693c57273a6b2281ddc1b201a432fae5c5ae8f049088384e3bcc3bda530910870ff8604a0233e1b96abc069850
+  checksum: aad2278310fe4897b2c4e1f23e22f28992c83bcac945a6c350d077b1b2fb1805e44d5c58e19e2a9d63ca04aa3f9eabdd3c661cab0ce5dddd75c72702262ac89e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

Right now with new cypress version, we can update vue-preview cypress into 12.9.0. Previous ^12 version affect speed headless tests

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
