### PR TITLE
fix: (sfui2-914) icons list on react docs

### DIFF
--- a/apps/preview/next/pages/showcases/IconBase/ListOfIcons.tsx
+++ b/apps/preview/next/pages/showcases/IconBase/ListOfIcons.tsx
@@ -8,7 +8,7 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 export default function IconList() {
   const [copied, setCopied] = useState('');
   const { data: componentsNames = [] } = useSWR<string[]>(
-    `${process.env.DOCS_EXAMPLES_REACT_PATH || ''}/api/getIcons`,
+    `${process.env.VITE_DOCS_EXAMPLES_REACT_PATH || ''}/api/getIcons`,
     fetcher,
   );
 


### PR DESCRIPTION
# Related issue

Closes [#914](https://vsf.atlassian.net/browse/SFUI2-914)

# Scope of work

The bug was connected to the fact that the path to the `getIcons` script was pointing to the prod env instead of dev env. 
![Screenshot from 2023-03-31 14-27-09](https://user-images.githubusercontent.com/32042425/229120600-38b9c99e-b05b-4bc5-a437-739d9d02d5d4.png)

I suppose this change would help but I couldn't verify it so please check if it should be done differently. 

# Screenshots of visual changes


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
