### PR TITLE
docs: add app directory callout for next.js docs

### DIFF
--- a/apps/docs/components/react/getting-started.md
+++ b/apps/docs/components/react/getting-started.md
@@ -117,8 +117,30 @@ Finally, you'll need to add CSS directives to add each Tailwind layer to `src/ap
 
 </SourceCode>
 
-::: tip
-In Next.js 13 environments that are not using [App Router](https://beta.nextjs.org/docs/api-reference/next-config#appdir) there is an issue with [Next.js not detecting ESM modules of subdependencies correctly.](https://github.com/vercel/next.js/issues/39375)
+### Next.js 13 Notes
+
+#### With App Directory
+
+Next.js 13 introduces a new [`app/`](https://beta.nextjs.org/docs/api-reference/next-config#appdir) directory. When using the App Directory, your project will default to using Server Components. However, components from Storefront UI need to be used in [client components](https://beta.nextjs.org/docs/rendering/server-and-client-components#client-components).
+
+This means that you'll have to add the [`"use client"`](https://beta.nextjs.org/docs/rendering/server-and-client-components#convention) directive at the top of any file that imports Storefront UI components.
+
+```jsx
+'use client';
+import { SfButton } from '@storefront-ui/react';
+
+export default function ButtonDemo() {
+  return (
+    <>
+      <SfButton>Click me!</SfButton>
+    </>
+  );
+}
+```
+
+#### Without App Directory
+
+In Next.js 13 environments that are not using the [`/app`](https://beta.nextjs.org/docs/api-reference/next-config#appdir) directory, there is an issue with [Next.js not detecting ESM modules of subdependencies correctly.](https://github.com/vercel/next.js/issues/39375)
 
 As a workaround, you can add `transpilePackages: ['@storefront-ui/react']` to your `next.config.js` configuration file:
 
@@ -132,7 +154,6 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
-:::
 ::::::
 
 :::::: slot vite


### PR DESCRIPTION
# Related issue

With the Next.js `/app` directory, Storefront UI components need to be used inside Client Components. This should be called out in our docs. 

# Scope of work

- adds callout in Next.js getting started guide regarding the `"use client"` directive

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
