### PR TITLE
docs: add videos to getting started guides

### DIFF
--- a/apps/docs/components/react/getting-started.md
+++ b/apps/docs/components/react/getting-started.md
@@ -19,6 +19,10 @@ You can try out Storefront UI in your browser with our online playground.
 
 ## Next.js
 
+If you prefer video guides, we have a quick video that can help you set up Storefront UI in your Next.js project.
+
+<iframe src="https://www.youtube-nocookie.com/embed/6xOnCOXU8H4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="allowfullscreen" class="w-full max-w-lg mx-auto rounded aspect-video relative mt-8 custom-block"></iframe>
+
 ### Create Your Next Project
 
 If you don't already have a Next app, you can use the `create-next-app` command from [Create Next App](https://nextjs.org/docs/api-reference/create-next-app) to get started.

--- a/apps/docs/components/vue/getting-started.md
+++ b/apps/docs/components/vue/getting-started.md
@@ -116,6 +116,10 @@ Now, you can import Storefront UI components in your app and all the Tailwind ut
 :::::: slot nuxt
 ## Nuxt 3
 
+If you prefer video guides, we have a quick video that can help you set up Storefront UI in your Nuxt 3 project.
+
+<iframe src="https://www.youtube-nocookie.com/embed/YamdPmZexto" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="allowfullscreen" class="w-full max-w-lg mx-auto rounded aspect-video relative mt-8 custom-block"></iframe>
+
 ### Install all dependencies
 
 With Nuxt 3, the fastest way to get started is to use the `@nuxtjs/tailwindcss` module. The [Nuxt Tailwind module](https://tailwindcss.nuxtjs.org/) will automatically install Tailwind CSS and PostCSS for you.


### PR DESCRIPTION
# Related issue

Getting Started Videos were recently published, so we can add them to the relevant docs!

Closes #

# Scope of work

- adds getting started to next/nuxt getting started guides

# Screenshots of visual changes

<img width="1462" alt="image" src="https://user-images.githubusercontent.com/18535681/229136929-880d754a-1086-4037-8d8c-b78e774bebc3.png">
<img width="1467" alt="image" src="https://user-images.githubusercontent.com/18535681/229136992-6c38e654-8925-4992-ac81-b0ce5f363e2e.png">


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
