### PR TITLE
feat: adjust tag defaults handling in vue drawer component

### DIFF
--- a/packages/sfui/frameworks/vue/components/SfDrawer/SfDrawer.vue
+++ b/packages/sfui/frameworks/vue/components/SfDrawer/SfDrawer.vue
@@ -14,7 +14,7 @@ const props = defineProps({
   },
   tag: {
     type: String,
-    default: 'aside',
+    default: '',
   },
   disableClickAway: {
     type: Boolean,
@@ -53,7 +53,7 @@ const placementClasses = computed(() => ({
 
 <template>
   <component
-    :is="tag"
+    :is="tag || 'aside'"
     v-if="modelValue"
     ref="drawerRef"
     class="fixed"


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-926?atlOrigin=eyJpIjoiMThjNGMwOGM0MTFjNDhlZDg3N2JmMzg2MTIxNDkxOTIiLCJwIjoiaiJ9

Closes #

# Scope of work

- adjusted handling of the default tag in SfDrawer, as it was causing the component to break on renders (no default tag provided)

# Screenshots of visual changes

-

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
