### PR TITLE
fix: sfselect chevron rotate

### DIFF
--- a/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
+++ b/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
@@ -24,7 +24,7 @@ export default function SfSelect(props: SfSelectProps) {
 
   const [chevronRotated, setChevronRotated] = useState(false);
 
-  const blurSelect: FocusEventHandler<HTMLSelectElement> = (event) => {
+  const blurHandler: FocusEventHandler<HTMLSelectElement> = (event) => {
     setChevronRotated(false);
     return onBlur ? onBlur(event) : undefined;
   };
@@ -34,12 +34,12 @@ export default function SfSelect(props: SfSelectProps) {
     return onChange ? onChange(event) : undefined;
   };
 
-  const clickSelect: MouseEventHandler<HTMLSelectElement> = (event) => {
+  const clickHandler: MouseEventHandler<HTMLSelectElement> = (event) => {
     setChevronRotated(true);
     return onClick ? onClick(event) : undefined;
   };
 
-  const keyDownSelect: KeyboardEventHandler<HTMLSelectElement> = (event) => {
+  const keydownHandler: KeyboardEventHandler<HTMLSelectElement> = (event) => {
     if (event.code === 'Space') {
       setChevronRotated(true);
     }
@@ -63,10 +63,10 @@ export default function SfSelect(props: SfSelectProps) {
           className,
         )}
         data-testid="select-input"
-        onBlur={blurSelect}
+        onBlur={blurHandler}
         onChange={changedValue}
-        onClick={clickSelect}
-        onKeyDown={keyDownSelect}
+        onClick={clickHandler}
+        onKeyDown={keydownHandler}
         {...attributes}
       >
         {placeholder && (

--- a/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
+++ b/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
@@ -53,7 +53,7 @@ export default function SfSelect(props: SfSelectProps) {
         required={required}
         disabled={disabled}
         className={classNames(
-          'appearance-none disabled:cursor-not-allowed cursor-pointer pl-4 pr-3.5 text-neutral-900 focus:outline-primary-700 bg-transparent rounded-md ring-1 ring-inset ring-neutral-300 hover:ring-primary-700 active:ring-2 active:ring-primary-700 disabled:bg-disabled-100 disabled:text-disabled-900 disabled:ring-disabled-200 peer',
+          'appearance-none disabled:cursor-not-allowed cursor-pointer pl-4 pr-3.5 text-neutral-900 focus:outline-primary-700 bg-transparent rounded-md ring-1 ring-inset ring-neutral-300 hover:ring-primary-700 active:ring-2 active:ring-primary-700 disabled:bg-disabled-100 disabled:text-disabled-900 disabled:ring-disabled-200',
           {
             'py-1.5': size === SfSelectSize.sm,
             'py-2': size === SfSelectSize.base,

--- a/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
+++ b/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
@@ -1,3 +1,4 @@
+import { ChangeEventHandler, FocusEventHandler, KeyboardEventHandler, MouseEventHandler, useState } from 'react';
 import classNames from 'classnames';
 import { SfSelectSize, SfIconExpandMore } from '@storefront-ui/react';
 
@@ -14,8 +15,37 @@ export default function SfSelect(props: SfSelectProps) {
     disabled,
     className,
     placeholder,
+    onBlur,
+    onChange,
+    onClick,
+    onKeyDown,
     ...attributes
   } = props;
+
+  const [chevronRotated, setChevronRotated] = useState(false);
+
+  const blurSelect: FocusEventHandler<HTMLSelectElement> = (value) => {
+    setChevronRotated(false);
+    return onBlur ? onBlur(value) : undefined;
+  };
+
+  const changedValue: ChangeEventHandler<HTMLSelectElement> = (value) => {
+    setChevronRotated(false);
+    return onChange ? onChange(value) : undefined;
+  };
+
+  const clickSelect: MouseEventHandler<HTMLSelectElement> = (value) => {
+    setChevronRotated(true);
+    return onClick ? onClick(value) : undefined;
+  };
+
+  const keyDownSelect: KeyboardEventHandler<HTMLSelectElement> = (value) => {
+    if (value.code === 'Space') {
+      setChevronRotated(true);
+    }
+
+    return onKeyDown ? onKeyDown(value) : undefined;
+  };
 
   return (
     <div className={classNames('relative flex flex-col', wrapperClassName)} data-testid="select">
@@ -33,6 +63,10 @@ export default function SfSelect(props: SfSelectProps) {
           className,
         )}
         data-testid="select-input"
+        onBlur={blurSelect}
+        onChange={changedValue}
+        onClick={clickSelect}
+        onKeyDown={keyDownSelect}
         {...attributes}
       >
         {placeholder && (
@@ -51,8 +85,9 @@ export default function SfSelect(props: SfSelectProps) {
       {slotChevron || (
         <SfIconExpandMore
           className={classNames(
-            'box-border absolute -translate-y-1 pointer-events-none top-1/3 right-4 peer-focus:rotate-180 transition easy-in-out duration-0.5',
+            'box-border absolute -translate-y-1 pointer-events-none top-1/3 right-4 transition easy-in-out duration-0.5',
             disabled ? 'text-disabled-500' : 'text-neutral-500',
+            { 'rotate-180': chevronRotated },
           )}
         />
       )}

--- a/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
+++ b/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
@@ -1,6 +1,6 @@
-import { ChangeEvent, FocusEvent, KeyboardEvent, MouseEvent, useState } from 'react';
+import { KeyboardEvent, useState } from 'react';
 import classNames from 'classnames';
-import { SfSelectSize, SfIconExpandMore } from '@storefront-ui/react';
+import { SfSelectSize, SfIconExpandMore, composeHandlers } from '@storefront-ui/react';
 
 import type { SfSelectProps } from './types';
 
@@ -24,27 +24,14 @@ export default function SfSelect(props: SfSelectProps) {
 
   const [chevronRotated, setChevronRotated] = useState(false);
 
-  const blurHandler = (event: FocusEvent<HTMLSelectElement>) => {
-    setChevronRotated(false);
-    return onBlur ? onBlur(event) : undefined;
-  };
+  const rotateUp = () => setChevronRotated(true);
 
-  const changedValue = (event: ChangeEvent<HTMLSelectElement>) => {
-    setChevronRotated(false);
-    return onChange ? onChange(event) : undefined;
-  };
-
-  const clickHandler = (event: MouseEvent<HTMLSelectElement>) => {
-    setChevronRotated(true);
-    return onClick ? onClick(event) : undefined;
-  };
+  const rotateDown = () => setChevronRotated(false);
 
   const keydownHandler = (event: KeyboardEvent<HTMLSelectElement>) => {
     if (event.code === 'Space') {
-      setChevronRotated(true);
+      rotateUp();
     }
-
-    return onKeyDown ? onKeyDown(event) : undefined;
   };
 
   return (
@@ -63,10 +50,10 @@ export default function SfSelect(props: SfSelectProps) {
           className,
         )}
         data-testid="select-input"
-        onBlur={blurHandler}
-        onChange={changedValue}
-        onClick={clickHandler}
-        onKeyDown={keydownHandler}
+        onBlur={composeHandlers(rotateDown, onBlur)}
+        onChange={composeHandlers(rotateDown, onChange)}
+        onClick={composeHandlers(rotateUp, onClick)}
+        onKeyDown={composeHandlers(keydownHandler, onKeyDown)}
         {...attributes}
       >
         {placeholder && (

--- a/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
+++ b/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, FocusEventHandler, KeyboardEventHandler, MouseEventHandler, useState } from 'react';
+import { ChangeEvent, FocusEvent, KeyboardEvent, MouseEvent, useState } from 'react';
 import classNames from 'classnames';
 import { SfSelectSize, SfIconExpandMore } from '@storefront-ui/react';
 
@@ -24,22 +24,22 @@ export default function SfSelect(props: SfSelectProps) {
 
   const [chevronRotated, setChevronRotated] = useState(false);
 
-  const blurHandler: FocusEventHandler<HTMLSelectElement> = (event) => {
+  const blurHandler = (event: FocusEvent<HTMLSelectElement>) => {
     setChevronRotated(false);
     return onBlur ? onBlur(event) : undefined;
   };
 
-  const changedValue: ChangeEventHandler<HTMLSelectElement> = (event) => {
+  const changedValue = (event: ChangeEvent<HTMLSelectElement>) => {
     setChevronRotated(false);
     return onChange ? onChange(event) : undefined;
   };
 
-  const clickHandler: MouseEventHandler<HTMLSelectElement> = (event) => {
+  const clickHandler = (event: MouseEvent<HTMLSelectElement>) => {
     setChevronRotated(true);
     return onClick ? onClick(event) : undefined;
   };
 
-  const keydownHandler: KeyboardEventHandler<HTMLSelectElement> = (event) => {
+  const keydownHandler = (event: KeyboardEvent<HTMLSelectElement>) => {
     if (event.code === 'Space') {
       setChevronRotated(true);
     }

--- a/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
+++ b/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
@@ -24,27 +24,27 @@ export default function SfSelect(props: SfSelectProps) {
 
   const [chevronRotated, setChevronRotated] = useState(false);
 
-  const blurSelect: FocusEventHandler<HTMLSelectElement> = (value) => {
+  const blurSelect: FocusEventHandler<HTMLSelectElement> = (event) => {
     setChevronRotated(false);
-    return onBlur ? onBlur(value) : undefined;
+    return onBlur ? onBlur(event) : undefined;
   };
 
-  const changedValue: ChangeEventHandler<HTMLSelectElement> = (value) => {
+  const changedValue: ChangeEventHandler<HTMLSelectElement> = (event) => {
     setChevronRotated(false);
-    return onChange ? onChange(value) : undefined;
+    return onChange ? onChange(event) : undefined;
   };
 
-  const clickSelect: MouseEventHandler<HTMLSelectElement> = (value) => {
+  const clickSelect: MouseEventHandler<HTMLSelectElement> = (event) => {
     setChevronRotated(true);
-    return onClick ? onClick(value) : undefined;
+    return onClick ? onClick(event) : undefined;
   };
 
-  const keyDownSelect: KeyboardEventHandler<HTMLSelectElement> = (value) => {
-    if (value.code === 'Space') {
+  const keyDownSelect: KeyboardEventHandler<HTMLSelectElement> = (event) => {
+    if (event.code === 'Space') {
       setChevronRotated(true);
     }
 
-    return onKeyDown ? onKeyDown(value) : undefined;
+    return onKeyDown ? onKeyDown(event) : undefined;
   };
 
   return (

--- a/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
+++ b/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
@@ -6,6 +6,7 @@ export default {
 <script lang="ts" setup>
 import { ref, type PropType } from 'vue';
 import { SfSelectSize, SfIconExpandMore } from '@storefront-ui/vue';
+import { onClickOutside } from '@vueuse/core';
 
 const props = defineProps({
   size: {
@@ -39,12 +40,19 @@ const props = defineProps({
 });
 
 const selected = ref(props.value);
+const chevronRotated = ref(false);
+const selectRef = ref();
 const emit = defineEmits<{
   (event: 'update:modelValue', param: string): void;
 }>();
 
+const onClickSelect = () => (chevronRotated.value = true);
+
+onClickOutside(selectRef, () => (chevronRotated.value = false));
+
 const changedValue = (event: Event) => {
   selected.value = (event.target as HTMLSelectElement).value;
+  chevronRotated.value = false;
   emit('update:modelValue', (event.target as HTMLSelectElement).value);
 };
 </script>
@@ -53,6 +61,7 @@ const changedValue = (event: Event) => {
   <div :class="['relative flex flex-col', wrapperClassName]" data-testid="select">
     <select
       v-bind="$attrs"
+      ref="selectRef"
       :value="value"
       :required="required"
       :disabled="disabled"
@@ -66,6 +75,7 @@ const changedValue = (event: Event) => {
         },
       ]"
       data-testid="select-input"
+      @click="onClickSelect"
       @change="changedValue"
     >
       <option
@@ -87,8 +97,9 @@ const changedValue = (event: Event) => {
     <slot name="chevron">
       <SfIconExpandMore
         :class="[
-          'absolute -translate-y-1 pointer-events-none top-1/3 right-4 peer-focus:rotate-180 transition easy-in-out duration-0.5',
+          'absolute -translate-y-1 pointer-events-none top-1/3 right-4 transition easy-in-out duration-0.5',
           disabled ? 'text-disabled-500' : 'text-neutral-500',
+          chevronRotated ? 'rotate-180' : '',
         ]"
       />
     </slot>

--- a/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
+++ b/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
@@ -6,7 +6,6 @@ export default {
 <script lang="ts" setup>
 import { ref, type PropType } from 'vue';
 import { SfSelectSize, SfIconExpandMore } from '@storefront-ui/vue';
-import { onClickOutside } from '@vueuse/core';
 
 const props = defineProps({
   size: {
@@ -41,14 +40,13 @@ const props = defineProps({
 
 const selected = ref(props.value);
 const chevronRotated = ref(false);
-const selectRef = ref();
 const emit = defineEmits<{
   (event: 'update:modelValue', param: string): void;
 }>();
 
 const onClickSelect = () => (chevronRotated.value = true);
 
-onClickOutside(selectRef, () => (chevronRotated.value = false));
+const onBlurSelect = () => (chevronRotated.value = false);
 
 const changedValue = (event: Event) => {
   selected.value = (event.target as HTMLSelectElement).value;
@@ -61,7 +59,6 @@ const changedValue = (event: Event) => {
   <div :class="['relative flex flex-col', wrapperClassName]" data-testid="select">
     <select
       v-bind="$attrs"
-      ref="selectRef"
       :value="value"
       :required="required"
       :disabled="disabled"
@@ -75,6 +72,7 @@ const changedValue = (event: Event) => {
         },
       ]"
       data-testid="select-input"
+      @blur="onBlurSelect"
       @click="onClickSelect"
       @change="changedValue"
     >

--- a/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
+++ b/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
@@ -48,7 +48,7 @@ const onClickSelect = () => (chevronRotated.value = true);
 
 const onBlurSelect = () => (chevronRotated.value = false);
 
-const onKeydownSelect = (payload: KeyboardEvent) => {
+const onKeydownSelect = () => {
   chevronRotated.value = true;
 };
 

--- a/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
+++ b/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
@@ -48,6 +48,12 @@ const onClickSelect = () => (chevronRotated.value = true);
 
 const onBlurSelect = () => (chevronRotated.value = false);
 
+const onKeydownSelect = (payload: KeyboardEvent) => {
+  if (payload.code === 'Space') {
+    chevronRotated.value = true;
+  }
+};
+
 const changedValue = (event: Event) => {
   selected.value = (event.target as HTMLSelectElement).value;
   chevronRotated.value = false;
@@ -75,6 +81,7 @@ const changedValue = (event: Event) => {
       @blur="onBlurSelect"
       @click="onClickSelect"
       @change="changedValue"
+      @keydown="onKeydownSelect"
     >
       <option
         v-if="placeholder"

--- a/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
+++ b/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
@@ -49,9 +49,7 @@ const onClickSelect = () => (chevronRotated.value = true);
 const onBlurSelect = () => (chevronRotated.value = false);
 
 const onKeydownSelect = (payload: KeyboardEvent) => {
-  if (payload.code === 'Space') {
-    chevronRotated.value = true;
-  }
+  chevronRotated.value = true;
 };
 
 const changedValue = (event: Event) => {
@@ -81,7 +79,7 @@ const changedValue = (event: Event) => {
       @blur="onBlurSelect"
       @click="onClickSelect"
       @change="changedValue"
-      @keydown="onKeydownSelect"
+      @keydown.space="onKeydownSelect"
     >
       <option
         v-if="placeholder"

--- a/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
+++ b/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
@@ -44,13 +44,11 @@ const emit = defineEmits<{
   (event: 'update:modelValue', param: string): void;
 }>();
 
-const onClickSelect = () => (chevronRotated.value = true);
+const clickHandler = () => (chevronRotated.value = true);
 
-const onBlurSelect = () => (chevronRotated.value = false);
+const blurHandler = () => (chevronRotated.value = false);
 
-const onKeydownSelect = () => {
-  chevronRotated.value = true;
-};
+const keydownHandler = () => (chevronRotated.value = true);
 
 const changedValue = (event: Event) => {
   selected.value = (event.target as HTMLSelectElement).value;
@@ -76,10 +74,10 @@ const changedValue = (event: Event) => {
         },
       ]"
       data-testid="select-input"
-      @blur="onBlurSelect"
-      @click="onClickSelect"
+      @blur="blurHandler"
+      @click="clickHandler"
       @change="changedValue"
-      @keydown.space="onKeydownSelect"
+      @keydown.space="keydownHandler"
     >
       <option
         v-if="placeholder"

--- a/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
+++ b/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
@@ -69,7 +69,7 @@ const changedValue = (event: Event) => {
       :required="required"
       :disabled="disabled"
       :class="[
-        'appearance-none disabled:cursor-not-allowed cursor-pointer pl-4 pr-3.5 text-neutral-900 bg-transparent focus:outline-primary-700 rounded-md ring-1 ring-inset ring-neutral-300 hover:ring-primary-700 active:ring-2 active:ring-primary-700 disabled:bg-disabled-100 disabled:text-disabled-900 disabled:ring-disabled-200 peer',
+        'appearance-none disabled:cursor-not-allowed cursor-pointer pl-4 pr-3.5 text-neutral-900 bg-transparent focus:outline-primary-700 rounded-md ring-1 ring-inset ring-neutral-300 hover:ring-primary-700 active:ring-2 active:ring-primary-700 disabled:bg-disabled-100 disabled:text-disabled-900 disabled:ring-disabled-200',
         {
           'py-1.5': size === SfSelectSize.sm,
           'py-2': size === SfSelectSize.base,


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #2569 

# Scope of work

Chevron will rotate when select is focused.
So, I implemented `chevronRotated` as a ref variable to handle `rotate-180`.
Then, I add `onClickOutside` to handle `chevronRotated`. When clicking outside of select, the chevron should rotate back.

<!-- describe what you did -->

# Screenshots of visual changes
https://user-images.githubusercontent.com/6861191/230060193-45fd4c9e-fbc2-4115-9142-fd180f16d1cc.mov

<!-- if visual changes applied -->

# Discussion

This problem occurs for React too. Should I update to `SfSelect.tsx` for this PR?

# Checklist

- [X] Self code-reviewed
- [ ] Changes documented
- [X] Semantic HTML
- [X] SSR-friendly
- [X] Caching friendly
- [X] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
