### PR TITLE
fix: product card image blocks

### DIFF
--- a/apps/preview/next/pages/showcases/ProductCard/ProductCardHorizontal.tsx
+++ b/apps/preview/next/pages/showcases/ProductCard/ProductCardHorizontal.tsx
@@ -2,7 +2,6 @@ import { ShowcasePageLayout } from '../../showcases';
 // #region source
 import { SfButton, SfIconRemove, SfLink, SfIconAdd, SfIconSell, SfIconDelete } from '@storefront-ui/react';
 import card from '@assets/smartwatch.png';
-import Image from 'next/image';
 import { useCounter } from 'react-use';
 import { useId, ChangeEvent } from 'react';
 import { clamp } from '@storefront-ui/shared';
@@ -21,7 +20,7 @@ export default function ProductCardHorizontal() {
     <div className="relative flex border-b-[1px] border-neutral-200 hover:shadow-lg min-w-[320px] max-w-[640px] p-4">
       <div className="relative overflow-hidden rounded-md w-[100px] sm:w-[176px]">
         <SfLink href="#">
-          <Image
+          <img
             className="w-full h-auto border rounded-md border-neutral-200"
             src={card.src}
             alt="alt"

--- a/apps/preview/next/pages/showcases/ProductCard/ProductCardVertical.tsx
+++ b/apps/preview/next/pages/showcases/ProductCard/ProductCardVertical.tsx
@@ -2,14 +2,13 @@ import { ShowcasePageLayout } from '../../showcases';
 // #region source
 import { SfButton, SfRating, SfCounter, SfLink, SfIconShoppingCart, SfIconFavorite } from '@storefront-ui/react';
 import productImage from '@assets/sneakers.png';
-import Image from 'next/image';
 
 export default function ProductCardVertical() {
   return (
     <div className="border border-neutral-200 rounded-md hover:shadow-lg max-w-[300px]">
       <div className="relative">
         <SfLink href="#">
-          <Image
+          <img
             src={productImage.src}
             alt="Great product"
             className="object-cover h-auto rounded-md aspect-square"


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #2573 

# Scope of work

I implemented `img` instead of `Image` from `next/image` on `ProductCardHorizontal` and `ProductCardVertical`.

<!-- describe what you did -->

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [X] Self code-reviewed
- [X] Changes documented
- [X] Semantic HTML
- [X] SSR-friendly
- [X] Caching friendly
- [X] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
