### PR TITLE
chore: adjusted visited styling

### DIFF
--- a/packages/sfui/frameworks/react/components/SfLink/SfLink.tsx
+++ b/packages/sfui/frameworks/react/components/SfLink/SfLink.tsx
@@ -7,8 +7,8 @@ const defaultLinkTag = 'a';
 const SfLink = polymorphicForwardRef<typeof defaultLinkTag, SfLinkProps>((props, ref) => {
   const variantClasses = {
     [SfLinkVariant.primary]:
-      'text-primary-700 underline hover:text-primary-800 active:text-primary-900 visited:text-primary-900',
-    [SfLinkVariant.secondary]: 'underline hover:text-primary-800 active:text-primary-900 visited:text-primary-900',
+      'text-primary-700 underline hover:text-primary-800 active:text-primary-900',
+    [SfLinkVariant.secondary]: 'underline hover:text-primary-800 active:text-primary-900',
   };
 
   const { as, className, children, variant = SfLinkVariant.primary, ...attributes } = props;

--- a/packages/sfui/frameworks/vue/components/SfLink/SfLink.vue
+++ b/packages/sfui/frameworks/vue/components/SfLink/SfLink.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
 const variantClasses = {
   [SfLinkVariant.primary]:
-    'text-primary-700 underline hover:text-primary-800 active:text-primary-900 visited:text-primary-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm',
+    'text-primary-700 underline hover:text-primary-800 active:text-primary-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm',
   [SfLinkVariant.secondary]:
-    'underline hover:text-primary-800 active:text-primary-900 visited:text-primary-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm',
+    'underline hover:text-primary-800 active:text-primary-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm',
 };
 </script>
 


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-972?atlOrigin=eyJpIjoiNjQ4ZTkyY2NiOGE2NDc1OGI2ZmEzNWZiZjc0MjYyYWIiLCJwIjoiaiJ9


# Scope of work

- removed styling for visited state

# Screenshots of visual changes

<img width="350" alt="Zrzut ekranu 2023-04-7 o 09 35 31" src="https://user-images.githubusercontent.com/41487496/230564216-ba4c3281-7764-4f3a-b947-8218011a43b2.png">


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
