### PR TITLE
chore: disable renovate to update swc-plugin-coverage-instrument

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,10 @@
       "groupName": "definitelyTyped",
       "matchPackagePrefixes": ["@types/"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["swc-plugin-coverage-instrument"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

Renovate keep updating `swc` plugin but we can't use it since its buggy, 0.0.14 -> 0.0.15 because of https://github.com/kwonoj/swc-plugin-coverage-instrument/issues/200

blocking: https://github.com/vuestorefront/storefront-ui/pull/2582

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
