### PR TITLE
chore: changing code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aniamusial @AdamPawlinski @justyna-13 @Szymon-dziewonski @frsgit
+* @Szymon-dziewonski @frsgit @dkacper @mattmaribojoc


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

The purpose of this change is to increase security and reduce the amount of code owners to prevent unsafe code injection. 
More you can find here: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-codeowners-to-monitor-changes

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
