### PR TITLE
fix: unions for enums in dropdown and tooltip components

### DIFF
--- a/packages/sfui/frameworks/vue/components/SfDropdown/SfDropdown.vue
+++ b/packages/sfui/frameworks/vue/components/SfDropdown/SfDropdown.vue
@@ -9,7 +9,7 @@ const props = defineProps({
     default: false,
   },
   placement: {
-    type: String as PropType<SfPopoverPlacement | undefined>,
+    type: String as PropType<`${SfPopoverPlacement}` | undefined>,
     default: undefined,
   },
   middleware: {
@@ -17,7 +17,7 @@ const props = defineProps({
     default: undefined,
   },
   strategy: {
-    type: String as PropType<SfPopoverStrategy | undefined>,
+    type: String as PropType<`${SfPopoverStrategy}` | undefined>,
     default: undefined,
   },
 });

--- a/packages/sfui/frameworks/vue/components/SfTooltip/SfTooltip.vue
+++ b/packages/sfui/frameworks/vue/components/SfTooltip/SfTooltip.vue
@@ -5,7 +5,7 @@ import { useTooltip, type SfPopoverPlacement, type SfPopoverStrategy } from '@st
 
 const props = defineProps({
   placement: {
-    type: String as PropType<SfPopoverPlacement | undefined>,
+    type: String as PropType<`${SfPopoverPlacement}` | undefined>,
     default: undefined,
   },
   middleware: {
@@ -13,7 +13,7 @@ const props = defineProps({
     default: undefined,
   },
   strategy: {
-    type: String as PropType<SfPopoverStrategy | undefined>,
+    type: String as PropType<`${SfPopoverStrategy}` | undefined>,
     default: undefined,
   },
   showArrow: {


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-973?atlOrigin=eyJpIjoiOTUwZmI4ZjU3YThjNGM3NzhkZjYxNzI2ZTQ1NTMyNGMiLCJwIjoiaiJ9

# Scope of work

- added unions in Dropdown and Tooltip

# Screenshots of visual changes

-

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
