### PR TITLE
fix: link examples

### DIFF
--- a/apps/preview/next/pages/examples/SfLink.tsx
+++ b/apps/preview/next/pages/examples/SfLink.tsx
@@ -1,4 +1,3 @@
-import type { ElementType } from 'react';
 import { SfLink, SfLinkVariant } from '@storefront-ui/react';
 import { prepareControls } from '../../components/utils/Controls';
 import { ExamplePageLayout } from '../examples';
@@ -12,13 +11,6 @@ function Example() {
         modelName: 'href',
         propType: 'string',
         description: 'Only for demonstration purposes. Component href attribute',
-      },
-      {
-        type: 'text',
-        modelName: 'as',
-        propType: 'React.ElementType',
-        description: 'Change element tag',
-        propDefaultValue: 'a',
       },
       {
         type: 'select',
@@ -35,10 +27,9 @@ function Example() {
       },
     ],
     {
-      href: '/examples/SfLink#',
+      href: '#',
       variant: SfLinkVariant.primary,
       children: 'Link',
-      as: '' as ElementType<any>,
     },
   );
 

--- a/apps/preview/next/pages/showcases/Link/LinkVariants.tsx
+++ b/apps/preview/next/pages/showcases/Link/LinkVariants.tsx
@@ -5,8 +5,12 @@ import { SfLink } from '@storefront-ui/react';
 export default function LinkVariants() {
   return (
     <div className="space-x-4">
-      <SfLink variant="primary"> Primary </SfLink>
-      <SfLink variant="secondary"> Secondary </SfLink>
+      <SfLink variant="primary" href="#">
+        Primary
+      </SfLink>
+      <SfLink variant="secondary" href="#">
+        Secondary
+      </SfLink>
     </div>
   );
 }

--- a/apps/preview/next/pages/showcases/Link/NextLink.tsx
+++ b/apps/preview/next/pages/showcases/Link/NextLink.tsx
@@ -8,7 +8,7 @@ export default function NextLinkDemo() {
   return (
     <div className="space-x-4">
       <Link href="#" passHref legacyBehavior>
-        <SfLink> NextLink </SfLink>
+        <SfLink>NextLink</SfLink>
       </Link>
     </div>
   );

--- a/apps/preview/nuxt/pages/examples/SfLink.vue
+++ b/apps/preview/nuxt/pages/examples/SfLink.vue
@@ -23,13 +23,6 @@ const { controlsAttrs, state } = prepareControls(
       description: 'Only for demonstration purposes. Component href attribute',
     },
     {
-      type: 'text',
-      modelName: 'tag',
-      propType: 'string | ConcreteComponent',
-      description: 'Change element tag',
-      propDefaultValue: 'a',
-    },
-    {
       type: 'select',
       modelName: 'variant',
       propType: 'SfLinkVariant',
@@ -44,9 +37,8 @@ const { controlsAttrs, state } = prepareControls(
   ],
   {
     SlotDefault: ref('Link'),
-    href: ref('/examples/SfLink#'),
+    href: ref('#'),
     variant: ref(SfLinkVariant.primary),
-    tag: ref(),
   },
 );
 </script>

--- a/apps/preview/nuxt/pages/showcases/Link/NuxtLink.vue
+++ b/apps/preview/nuxt/pages/showcases/Link/NuxtLink.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="space-x-4">
-    <SfLink :tag="NuxtLink" to="#"> NuxtLink </SfLink>
+    <SfLink :tag="NuxtLink" :to="{ path: '#', query: { docs: true } }"> NuxtLink </SfLink>
   </div>
 </template>
 

--- a/apps/preview/nuxt/pages/showcases/Link/NuxtLink.vue
+++ b/apps/preview/nuxt/pages/showcases/Link/NuxtLink.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="space-x-4">
-    <SfLink :tag="NuxtLink" to=""> NuxtLink </SfLink>
+    <SfLink :tag="NuxtLink" to="#"> NuxtLink </SfLink>
   </div>
 </template>
 

--- a/packages/sfui/frameworks/react/components/SfLink/SfLink.tsx
+++ b/packages/sfui/frameworks/react/components/SfLink/SfLink.tsx
@@ -6,8 +6,7 @@ const defaultLinkTag = 'a';
 
 const SfLink = polymorphicForwardRef<typeof defaultLinkTag, SfLinkProps>((props, ref) => {
   const variantClasses = {
-    [SfLinkVariant.primary]:
-      'text-primary-700 underline hover:text-primary-800 active:text-primary-900',
+    [SfLinkVariant.primary]: 'text-primary-700 underline hover:text-primary-800 active:text-primary-900',
     [SfLinkVariant.secondary]: 'underline hover:text-primary-800 active:text-primary-900',
   };
 


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes [SFUI2-928](https://vsf.atlassian.net/browse/SFUI2-928)

# Scope of work

<!-- describe what you did -->

Fixed SfLink examples mostly by setting neutral `href="#"` that does not redirect to other page.

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created


[SFUI2-928]: https://vsf.atlassian.net/browse/SFUI2-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ