### PR TITLE
docs: remove table of contents from blocks

### DIFF
--- a/apps/docs/components/blocks/Alert.md
+++ b/apps/docs/components/blocks/Alert.md
@@ -2,7 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: Alert is a notification that keeps people informed of the status of the system and which may or not require the user respond.
-
+hideToc: true
 ---
 # Alert
 

--- a/apps/docs/components/blocks/Banners.md
+++ b/apps/docs/components/blocks/Banners.md
@@ -2,7 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: Banners are components that deliver main image and content in various configurations.
-
+hideToc: true
 ---
 # Banners
 

--- a/apps/docs/components/blocks/Breadcrumbs.md
+++ b/apps/docs/components/blocks/Breadcrumbs.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: A breadcrumb trail consists of a list of links to the parent pages of the current page in hierarchical order. It helps users find their place.
+hideToc: true
 ---
 # Breadcrumbs page
 

--- a/apps/docs/components/blocks/Card.md
+++ b/apps/docs/components/blocks/Card.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: The Card component contains content and actions that inform about a single subject. 
+hideToc: true
 ---
 # Card
 

--- a/apps/docs/components/blocks/Checkout.md
+++ b/apps/docs/components/blocks/Checkout.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: Checkout page in one of the most important pages in e-commerce. Usually it contains information about delivery destination, shipping options and payment methods.
+hideToc: true
 ---
 # Checkout page
 

--- a/apps/docs/components/blocks/Filters.md
+++ b/apps/docs/components/blocks/Filters.md
@@ -1,5 +1,6 @@
 ---
 layout: DefaultLayout
+hideToc: true
 hideBreadcrumbs: true
 description: Product filters are a valuable tool for online shoppers to quickly and easily find the products they are looking for on e-commerce websites.
 ---
@@ -10,7 +11,7 @@ description: Product filters are a valuable tool for online shoppers to quickly 
 ## Colors
 Color filters are a type of product filter that allow online shoppers to narrow down their search results based on the color or colors of the products they are interested in.
 
-<Showcase showcase-name="Filters/Color">
+<Showcase showcase-name="Filters/Color" style="min-height:500px">
 
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/Filters/Color.vue
@@ -23,7 +24,7 @@ Color filters are a type of product filter that allow online shoppers to narrow 
 ## Sizes
 Sizes in category pages are a feature that allows online shoppers to filter their search results based on specific sizes of products they are interested in.
 
-<Showcase showcase-name="Filters/Sizes">
+<Showcase showcase-name="Filters/Sizes" >
 
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/Filters/Sizes.vue

--- a/apps/docs/components/blocks/Filters.md
+++ b/apps/docs/components/blocks/Filters.md
@@ -24,7 +24,7 @@ Color filters are a type of product filter that allow online shoppers to narrow 
 ## Sizes
 Sizes in category pages are a feature that allows online shoppers to filter their search results based on specific sizes of products they are interested in.
 
-<Showcase showcase-name="Filters/Sizes" >
+<Showcase showcase-name="Filters/Sizes">
 
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/Filters/Sizes.vue

--- a/apps/docs/components/blocks/Footer.md
+++ b/apps/docs/components/blocks/Footer.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: The Footer block is used as navigation. Usually it's at the bottom of a page and has elements like links to main information pages, contacts, social media links and links to the privacy policy documents. 
+hideToc: true
 ---
 
 # Footer

--- a/apps/docs/components/blocks/NavbarBottom.md
+++ b/apps/docs/components/blocks/NavbarBottom.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: NavbarBottom block is the navigation element used in mobile view.
+hideToc: true
 ---
 # NavbarBottom
 

--- a/apps/docs/components/blocks/NavbarTop.md
+++ b/apps/docs/components/blocks/NavbarTop.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: The NavbarTop block is used as navigation. Usually it's at the top of a page and has elements like company logo, links to main categories or a menu button, search input and action buttons that can open a cart, wishlist or login modal. 
+hideToc: true
 ---
 
 # NavbarTop

--- a/apps/docs/components/blocks/OrderSummary.md
+++ b/apps/docs/components/blocks/OrderSummary.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: An order summary shows all order details into a consolidated view. Your customers can easily add a promo code to their order and the change will be visible immediately after applying a valid code.
+hideToc: true
 ---
 # Order Summary 
 

--- a/apps/docs/components/blocks/Pagination.md
+++ b/apps/docs/components/blocks/Pagination.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: Pagination component is a common element to navigate through pages containing many items like products in lists.
+hideToc: true
 ---
 # Pagination
 

--- a/apps/docs/components/blocks/ProductCard.md
+++ b/apps/docs/components/blocks/ProductCard.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: Product Card usage blocks.
+hideToc: true
 ---
 # ProductCard
 

--- a/apps/docs/components/blocks/QuantitySelector.md
+++ b/apps/docs/components/blocks/QuantitySelector.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: QuantitySelector allows the selection of a numeric value and the display of any additional information needed.
+hideToc: true
 ---
 # QuantitySelector
 

--- a/apps/docs/components/blocks/Review.md
+++ b/apps/docs/components/blocks/Review.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: Block for displaying user opinion.
+hideToc: true
 ---
 # Review
 

--- a/apps/docs/components/react/blocks.md
+++ b/apps/docs/components/react/blocks.md
@@ -1,5 +1,6 @@
 ---
 layout: DefaultLayout
+hideToc: true
 ---
 
 <FigmaLink />

--- a/apps/docs/components/vue/blocks.md
+++ b/apps/docs/components/vue/blocks.md
@@ -1,5 +1,6 @@
 ---
 layout: DefaultLayout
+hideToc: true
 ---
 
 <FigmaLink />


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-968

# Scope of work

When reviewing ways to better show our blocks at different sizes, I saw that we need to show these at larger widths by default. So I added the `hideToc` option on all the blocks pages. 

- also fixed the height of the Colors Filter block.

# Screenshots of visual changes

![image](https://user-images.githubusercontent.com/18535681/231797392-0f5fc319-2c14-4ca2-ab63-65903e4070c4.png)


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
