### PR TITLE
feat: newsletterbox block

### DIFF
--- a/apps/docs/components/blocks/NewsletterBox.md
+++ b/apps/docs/components/blocks/NewsletterBox.md
@@ -1,0 +1,19 @@
+---
+layout: DefaultLayout
+hideBreadcrumbs: true
+description: A NewsletterBox supports a typical e-commerce newsletter subscription process.
+---
+# NewsletterBox
+
+{{ $frontmatter.description }}
+
+<Showcase showcase-name="NewsletterBox/NewsletterBox" style="min-height:340px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/NewsletterBox/NewsletterBox.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/NewsletterBox/NewsletterBox.tsx#source
+<!-- end react -->
+
+</Showcase>

--- a/apps/docs/components/blocks/NewsletterBox.md
+++ b/apps/docs/components/blocks/NewsletterBox.md
@@ -7,6 +7,8 @@ description: A NewsletterBox supports a typical e-commerce newsletter subscripti
 
 {{ $frontmatter.description }}
 
+In this example there are two types of alerts: `positive` and `negative`. The first one is shown when a valid email address is passed to the input and submitted. The second one shows up when there already was submitted exactly the same email address.
+
 <Showcase showcase-name="NewsletterBox/NewsletterBox" style="min-height:340px">
 
 <!-- vue -->

--- a/apps/docs/components/utils/future-blocks.json
+++ b/apps/docs/components/utils/future-blocks.json
@@ -1,1 +1,1 @@
-["MegaMenu", "NewsletterBox"]
+["MegaMenu"]

--- a/apps/preview/next/pages/showcases/NewsletterBox/NewsletterBox.tsx
+++ b/apps/preview/next/pages/showcases/NewsletterBox/NewsletterBox.tsx
@@ -1,0 +1,99 @@
+import { ShowcasePageLayout } from '../../showcases';
+// #region source
+import { useState } from 'react';
+import { SfButton, SfInput, SfLink, SfIconCheckCircle, SfIconClose } from '@storefront-ui/react';
+
+export default function NewsletterBox() {
+  const [inputValue, setInputValue] = useState('');
+  const [positiveAlert, setPositiveAlert] = useState(false);
+  const [errorAlert, setErrorAlert] = useState(false);
+  const [emailDataBase, setEmailDataBase] = useState<string[]>([]);
+
+  const checkEmailDataBase = (email: string) => emailDataBase.find((element) => element === email);
+
+  const subscribeNewsletter = (event: React.FormEvent<HTMLFormElement>, email: string) => {
+    event.preventDefault();
+    if (!email) return;
+    if (checkEmailDataBase(email)) {
+      setErrorAlert(true);
+      setTimeout(() => setErrorAlert(false), 5000);
+    } else {
+      setPositiveAlert(true);
+      setEmailDataBase(() => [...emailDataBase, email]);
+      setTimeout(() => setPositiveAlert(false), 5000);
+    }
+    console.log(email);
+    setInputValue('');
+  };
+
+  return (
+    <div className="relative">
+      <div className="bg-neutral-100 p-4 sm:p-10 text-center">
+        <p className="typography-headline-4 sm:typography-headline-3 font-bold">
+          Subscribe and get discount on your first purchase!
+        </p>
+        <p className="typography-text-sm sm:typography-text-base my-2 mb-4">
+          Be aware of upcoming sales and events. Receive gifts and special offers!
+        </p>
+        <form
+          className="mb-4 flex flex-col sm:flex-row gap-4 max-w-[688px] mx-auto"
+          onSubmit={(event) => subscribeNewsletter(event, inputValue)}
+        >
+          <SfInput
+            value={inputValue}
+            type="email"
+            wrapperClassName="grow"
+            placeholder="Type your email"
+            onChange={(event) => setInputValue(event.target.value)}
+          />
+          <SfButton type="submit" size="lg">
+            Subscribe to Newsletter
+          </SfButton>
+        </form>
+        <div className="typography-text-xs text-neutral-600">
+          To learn how we process your data, visit our <SfLink className="text-neutral-600">Privacy Notice</SfLink>. You
+          can <SfLink className="text-neutral-600">unsubscribe</SfLink> at any time without costs.
+        </div>
+      </div>
+      <div className="absolute top-0 right-0 mx-2 mt-2 sm:mr-6">
+        {positiveAlert && (
+          <div
+            role="alert"
+            className="flex items-start md:items-center shadow-md max-w-[600px] bg-positive-100 pr-2 pl-4 mb-2 ring-1 ring-positive-200 typography-text-sm md:typography-text-base py-1 rounded-md"
+          >
+            <SfIconCheckCircle className="mr-2 my-2 text-positive-700" />
+            <p className="py-2 mr-2">Your email has been added to the newsletter subscription.</p>
+            <button
+              type="button"
+              className="p-1.5 md:p-2 ml-auto rounded-md text-positive-700 hover:bg-positive-200 active:bg-positive-300 hover:text-positive-800 active:text-positive-900"
+              aria-label="Close alert"
+              onClick={() => setPositiveAlert(false)}
+            >
+              <SfIconClose className="hidden md:block" />
+              <SfIconClose size="sm" className="md:hidden block" />
+            </button>
+          </div>
+        )}
+        {errorAlert && (
+          <div
+            role="alert"
+            className="flex items-start md:items-center max-w-[600px] shadow-md bg-negative-100 pr-2 pl-4 ring-1 ring-negative-300 typography-text-sm md:typography-text-base py-1 rounded-md"
+          >
+            <p className="py-2 mr-2">This email is already subscribed for our newsletter.</p>
+            <button
+              type="button"
+              className="p-1.5 md:p-2 ml-auto rounded-md text-negative-700 hover:bg-negative-200 active:bg-negative-300 hover:text-negative-800 active:text-negative-900"
+              aria-label="Close alert"
+              onClick={() => setErrorAlert(false)}
+            >
+              <SfIconClose className="hidden md:block" />
+              <SfIconClose size="sm" className="md:hidden block" />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+// #endregion source
+NewsletterBox.getLayout = ShowcasePageLayout;

--- a/apps/preview/nuxt/pages/showcases/NewsletterBox/NewsletterBox.vue
+++ b/apps/preview/nuxt/pages/showcases/NewsletterBox/NewsletterBox.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="relative">
+    <div class="bg-neutral-100 p-4 sm:p-10 text-center">
+      <p class="typography-headline-4 sm:typography-headline-3 font-bold">
+        Subscribe and get discount on your first purchase!
+      </p>
+      <p class="typography-text-sm sm:typography-text-base my-2 mb-4">
+        Be aware of upcoming sales and events. Receive gifts and special offers!
+      </p>
+      <form
+        class="mb-4 flex flex-col sm:flex-row gap-4 max-w-[688px] mx-auto"
+        @submit.prevent="subscribeNewsletter(inputValue)"
+      >
+        <SfInput v-model="inputValue" type="email" wrapper-class="grow" placeholder="Type your email" />
+        <SfButton type="submit" size="lg"> Subscribe to Newsletter </SfButton>
+      </form>
+      <div class="typography-text-xs text-neutral-600">
+        To learn how we process your data, visit our <SfLink class="text-neutral-600">Privacy Notice</SfLink>. You can
+        <SfLink class="text-neutral-600">unsubscribe</SfLink> at any time without costs.
+      </div>
+    </div>
+    <div class="absolute top-0 right-0 mx-2 mt-2 sm:mr-6">
+      <div
+        v-if="showPositiveAlert"
+        role="alert"
+        class="flex items-start md:items-center shadow-md max-w-[600px] bg-positive-100 pr-2 pl-4 mb-2 ring-1 ring-positive-200 typography-text-sm md:typography-text-base py-1 rounded-md"
+      >
+        <SfIconCheckCircle class="mr-2 my-2 text-positive-700" />
+        <p class="py-2 mr-2">Your email has been added to the newsletter subscription.</p>
+        <button
+          type="button"
+          class="p-1.5 md:p-2 ml-auto rounded-md text-positive-700 hover:bg-positive-200 active:bg-positive-300 hover:text-positive-800 active:text-positive-900"
+          aria-label="Close positive alert"
+          @click="showPositiveAlert = false"
+        >
+          <SfIconClose class="hidden md:block" />
+          <SfIconClose size="sm" class="md:hidden block" />
+        </button>
+      </div>
+      <div
+        v-if="showErrorAlert"
+        role="alert"
+        class="flex items-start md:items-center max-w-[600px] shadow-md bg-negative-100 pr-2 pl-4 ring-1 ring-negative-300 typography-text-sm md:typography-text-base py-1 rounded-md"
+      >
+        <p class="py-2 mr-2">This email is already subscribed for our newsletter.</p>
+        <button
+          type="button"
+          class="p-1.5 md:p-2 ml-auto rounded-md text-negative-700 hover:bg-negative-200 active:bg-negative-300 hover:text-negative-800 active:text-negative-900"
+          aria-label="Close error alert"
+          @click="showErrorAlert = false"
+        >
+          <SfIconClose class="hidden md:block" />
+          <SfIconClose size="sm" class="md:hidden block" />
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, type Ref } from 'vue';
+import { SfButton, SfInput, SfLink, SfIconCheckCircle, SfIconClose } from '@storefront-ui/vue';
+
+const inputValue = ref('');
+const showPositiveAlert = ref(false);
+const showErrorAlert = ref(false);
+const emailDataBase: Ref<string[]> = ref([]);
+
+const checkEmailDataBase = (email: string) => emailDataBase.value.find((element) => element === email);
+
+const subscribeNewsletter = (email: string) => {
+  if (!email) return;
+  if (checkEmailDataBase(email)) {
+    showErrorAlert.value = true;
+    setTimeout(() => (showErrorAlert.value = false), 5000);
+  } else {
+    showPositiveAlert.value = true;
+    emailDataBase.value.push(email);
+    setTimeout(() => (showPositiveAlert.value = false), 5000);
+  }
+  console.log(email);
+  inputValue.value = '';
+};
+</script>


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes # https://vsf.atlassian.net/jira/software/c/projects/SFUI2/boards/69?modal=detail&selectedIssue=SFUI2-664

# Scope of work

NewsletterBox block

In task there's a note that this should be in Banners but as this description was made before and there was already a separate place for NewsletterBox with thumbnail then it was put to this block

Two alerts are added separately (for demo purposes) as we can't do a component and there might be a case where we can see both of them (one after another)

<!-- describe what you did -->

# Screenshots of visual changes
<img width="1150" alt="Screenshot 2023-04-14 at 08 33 32" src="https://user-images.githubusercontent.com/46591755/231966449-3c24d8f9-6d96-4b97-9b0e-e83c1e2d36b9.png">
<img width="1150" alt="Screenshot 2023-04-14 at 08 33 24" src="https://user-images.githubusercontent.com/46591755/231966461-8c70a9f5-122e-4e6f-bc9d-6db51ceea775.png">
<img width="388" alt="Screenshot 2023-04-14 at 08 29 52" src="https://user-images.githubusercontent.com/46591755/231966467-79e0c90e-b80a-4ea0-8406-56585796929b.png">
<img width="823" alt="Screenshot 2023-04-14 at 08 29 01" src="https://user-images.githubusercontent.com/46591755/231966474-892dda3f-cc87-459a-8edd-17277347bc60.png">



<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
