### PR TITLE
chore: run SonarCloud pipeline only for collaborators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,33 @@ jobs:
       - name: Install dependencies
         run: NOT_GENERATE_ICON=true && yarn --immutable
 
+  verify-collaborator:
+    name: Verify collaborator
+    needs: [cache]
+    runs-on: ubuntu-latest
+    setps:
+      - name: Authenticate user
+        uses: actions/github-script@v4
+        with:
+        script: |
+          const token = process.env.GITHUB_TOKEN;
+          const octokit = new Octokit({ auth: token });
+          const user = await octokit.users.getByUsername({ username: context.actor });
+      - name: Check if user is a collaborator
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const token = process.env.GITHUB_TOKEN;
+            const octokit = new Octokit({ auth: token });
+            const { data: isCollaborator } = await octokit.repos.checkCollaborator({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: user.login,
+            });
+            if (!isCollaborator) {
+              core.setFailed(`User \${user.login} is not a collaborator in the SFUI repository`)
+            }
+
   commit-lint:
     name: Validate PR Title (conventional-commit)
     needs: [cache]
@@ -116,7 +143,7 @@ jobs:
         with:
           command: yarn test:ci:vue
       - name: SonarCloud Scan
-        if: success() || failure()
+        if: jobs.verify-collaborator.result == 'success' && (success() || failure())
         uses: SonarSource/sonarcloud-github-action@master
         with:
           projectBaseDir: packages/sfui/frameworks/vue
@@ -143,7 +170,7 @@ jobs:
         with:
           command: yarn test:ci:react
       - name: SonarCloud Scan
-        if: success() || failure()
+        if: jobs.verify-collaborator.result == 'success' && (success() || failure())
         uses: SonarSource/sonarcloud-github-action@master
         with:
           projectBaseDir: packages/sfui/frameworks/react

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,28 +30,17 @@ jobs:
     name: Verify collaborator
     needs: [cache]
     runs-on: ubuntu-latest
+    outputs:
+      isCollaborator: ${{ steps.collaborator.outputs.isCollaborator }}
     steps:
-      - name: Authenticate user
-        uses: actions/github-script@v4
-        with:
-          script: |
-            const token = process.env.GITHUB_TOKEN;
-            const octokit = new Octokit({ auth: token });
-            const user = await octokit.users.getByUsername({ username: context.actor });
-      - name: Check if user is a collaborator
-        uses: actions/github-script@v4
-        with:
-          script: |
-            const token = process.env.GITHUB_TOKEN;
-            const octokit = new Octokit({ auth: token });
-            const { data: isCollaborator } = await octokit.repos.checkCollaborator({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: user.login,
-            });
-            if (!isCollaborator) {
-              core.setFailed(`User \${user.login} is not a collaborator in the SFUI repository`)
-            }
+      - id: collaborator
+        name: Check if user is a collaborator
+        run: |
+          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+               "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.actor }}" \
+               | grep -q "Collaborator not found" \
+               && echo "isCollaborator=false" >> $GITHUB_OUTPUT \
+               || echo "isCollaborator=true" >> $GITHUB_OUTPUT
 
   commit-lint:
     name: Validate PR Title (conventional-commit)
@@ -124,7 +113,7 @@ jobs:
 
   cypress-vue:
     name: Run cypress tests(Vue)
-    needs: [cache, lint]
+    needs: [cache, lint, verify-collaborator]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -143,7 +132,7 @@ jobs:
         with:
           command: yarn test:ci:vue
       - name: SonarCloud Scan
-        if: jobs.verify-collaborator.result == 'success' && (success() || failure())
+        if: ${{ needs.verify-collaborator.outputs.isCollaborator == 'true' && (success() || failure()) }}
         uses: SonarSource/sonarcloud-github-action@master
         with:
           projectBaseDir: packages/sfui/frameworks/vue
@@ -153,7 +142,7 @@ jobs:
 
   cypress-react:
     name: Run cypress tests(react)
-    needs: [cache, lint]
+    needs: [cache, lint, verify-collaborator]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -170,7 +159,7 @@ jobs:
         with:
           command: yarn test:ci:react
       - name: SonarCloud Scan
-        if: jobs.verify-collaborator.result == 'success' && (success() || failure())
+        if: ${{ needs.verify-collaborator.outputs.isCollaborator == 'true' && (success() || failure()) }}
         uses: SonarSource/sonarcloud-github-action@master
         with:
           projectBaseDir: packages/sfui/frameworks/react

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
           curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.actor }}" \
                | grep -q "Collaborator not found" \
-               && echo "isCollaborator=false" >> $GITHUB_OUTPUT \
-               || echo "isCollaborator=true" >> $GITHUB_OUTPUT
+               && echo "isCollaborator=true" >> $GITHUB_OUTPUT \
+               || echo "isCollaborator=false" >> $GITHUB_OUTPUT
 
   commit-lint:
     name: Validate PR Title (conventional-commit)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,14 @@ jobs:
     name: Verify collaborator
     needs: [cache]
     runs-on: ubuntu-latest
-    setps:
+    steps:
       - name: Authenticate user
         uses: actions/github-script@v4
         with:
-        script: |
-          const token = process.env.GITHUB_TOKEN;
-          const octokit = new Octokit({ auth: token });
-          const user = await octokit.users.getByUsername({ username: context.actor });
+          script: |
+            const token = process.env.GITHUB_TOKEN;
+            const octokit = new Octokit({ auth: token });
+            const user = await octokit.users.getByUsername({ username: context.actor });
       - name: Check if user is a collaborator
         uses: actions/github-script@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
           curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.actor }}" \
                | grep -q "Collaborator not found" \
-               && echo "isCollaborator=true" >> $GITHUB_OUTPUT \
-               || echo "isCollaborator=false" >> $GITHUB_OUTPUT
+               && echo "isCollaborator=false" >> $GITHUB_OUTPUT \
+               || echo "isCollaborator=true" >> $GITHUB_OUTPUT
 
   commit-lint:
     name: Validate PR Title (conventional-commit)


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes [SFUI2-1020](https://vsf.atlassian.net/browse/SFUI2-1020)

# Scope of work

Collaborator verification job added. When contributor is not a collaborator then skip SonarCloud step.
<img width="861" alt="sonar" src="https://user-images.githubusercontent.com/34419118/232030665-002f6e3f-6ad4-4c18-bcd0-a9db36289361.png">

<!-- describe what you did -->

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created


[SFUI2-1020]: https://vsf.atlassian.net/browse/SFUI2-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ