### PR TITLE
fix: styling improvement for wrapping icons in megamenu

### DIFF
--- a/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
@@ -237,7 +237,7 @@ export default function BaseMegaMenu() {
                 </CSSTransition>
               </li>
             </ul>
-            <div>
+            <div className="flex flex-nowrap">
               {actionItems.map((actionItem) => (
                 <SfButton
                   className="mr-2 -ml-0.5 text-white bg-transparent hover:bg-primary-800 hover:text-white active:bg-primary-900 active:text-white"

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
@@ -94,7 +94,7 @@
               </transition>
             </li>
           </ul>
-          <div>
+          <div class="flex flex-nowrap">
             <SfButton
               v-for="actionItem in actionItems"
               :key="actionItem.ariaLabel"


### PR DESCRIPTION
# Related issue
https://vsf.atlassian.net/browse/SFUI2-1033?atlOrigin=eyJpIjoiNmVhODZjNmJjNjhmNDdhNmI0YzkwMDE3NzQ4ZjhjMWEiLCJwIjoiaiJ9


# Scope of work

- added flex-nowrap classes for icons container

# Screenshots of visual changes

<img width="232" alt="Zrzut ekranu 2023-04-17 o 10 49 39" src="https://user-images.githubusercontent.com/41487496/232435469-87116636-156d-4ba7-bcd1-2d592fd92e7d.png">


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
