### PR TITLE
feat: (sfui2-1027) added arrows support for navigating mega menu

### DIFF
--- a/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
@@ -128,7 +128,7 @@ export default function BaseMegaMenu() {
   const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
   const drawerRef = useRef(null);
   const menuRef = useRef(null);
-  useTrapFocus(drawerRef, { activeState: isOpen, arrowKeysOn: true, arrowFocusGroupSelector: '.list-item' });
+  useTrapFocus(drawerRef, { activeState: isOpen, arrowKeysOn: true });
   useClickAway(menuRef, () => {
     close();
   });
@@ -206,7 +206,7 @@ export default function BaseMegaMenu() {
                         <hr className="mb-3.5" />
                         <ul>
                           {items.map((item) => (
-                            <SfListItem size="sm" role="none" className="list-item">
+                            <SfListItem size="sm" role="none">
                               <a
                                 key={item.title}
                                 className="focus-visible:outline focus-visible:rounded-sm"

--- a/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
@@ -11,6 +11,7 @@ import {
   SfDrawer,
   SfListItem,
   useDisclosure,
+  useTrapFocus
 } from '@storefront-ui/react';
 import { useRef } from 'react';
 import { useClickAway } from 'react-use';
@@ -127,6 +128,7 @@ export default function BaseMegaMenu() {
   const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
   const drawerRef = useRef(null);
   const menuRef = useRef(null);
+  useTrapFocus(drawerRef, { activeState: isOpen });
   useClickAway(menuRef, () => {
     close();
   });

--- a/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
@@ -11,7 +11,7 @@ import {
   SfDrawer,
   SfListItem,
   useDisclosure,
-  useTrapFocus
+  useTrapFocus,
 } from '@storefront-ui/react';
 import { useRef } from 'react';
 import { useClickAway } from 'react-use';
@@ -128,7 +128,7 @@ export default function BaseMegaMenu() {
   const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
   const drawerRef = useRef(null);
   const menuRef = useRef(null);
-  useTrapFocus(drawerRef, { activeState: isOpen });
+  useTrapFocus(drawerRef, { activeState: isOpen, arrowKeysOn: true, arrowFocusGroupSelector: '.list-item' });
   useClickAway(menuRef, () => {
     close();
   });
@@ -206,7 +206,7 @@ export default function BaseMegaMenu() {
                         <hr className="mb-3.5" />
                         <ul>
                           {items.map((item) => (
-                            <SfListItem size="sm" role="none">
+                            <SfListItem size="sm" role="none" className="list-item">
                               <a
                                 key={item.title}
                                 className="focus-visible:outline focus-visible:rounded-sm"

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
@@ -38,6 +38,7 @@
                 leave-to-class="-translate-x-full md:translate-x-0 md:opacity-0"
               >
                 <SfDrawer
+                  ref="drawerRef"
                   v-model="isOpen"
                   disable-click-away
                   placement="top"
@@ -126,6 +127,7 @@ import {
   SfIconChevronRight,
   SfListItem,
   useDisclosure,
+  useTrapFocus,
 } from '@storefront-ui/vue';
 import { ref } from 'vue';
 import { onClickOutside } from '@vueuse/core';
@@ -135,10 +137,13 @@ import watch from '@assets/watch.png';
 
 const { isOpen, toggle, close } = useDisclosure();
 const menuRef = ref();
+const drawerRef = ref();
 
 onClickOutside(menuRef, () => {
   close();
 });
+
+useTrapFocus(drawerRef, { activeState: isOpen });
 
 const actionItems = [
   {

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
@@ -65,7 +65,7 @@
                     </h2>
                     <hr class="mb-3.5" />
                     <ul>
-                      <SfListItem v-for="item in items" :key="item.title" size="sm" role="none">
+                      <SfListItem v-for="item in items" :key="item.title" class="list-item" size="sm" role="none">
                         <a
                           class="focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
                           :href="item.link"
@@ -143,7 +143,7 @@ onClickOutside(menuRef, () => {
   close();
 });
 
-useTrapFocus(drawerRef, { activeState: isOpen });
+useTrapFocus(drawerRef, { activeState: isOpen, arrowKeysOn: true, arrowFocusGroupSelector: '.list-item' });
 
 const actionItems = [
   {

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
@@ -65,7 +65,7 @@
                     </h2>
                     <hr class="mb-3.5" />
                     <ul>
-                      <SfListItem v-for="item in items" :key="item.title" class="list-item" size="sm" role="none">
+                      <SfListItem v-for="item in items" :key="item.title" size="sm" role="none">
                         <a
                           class="focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
                           :href="item.link"
@@ -143,7 +143,7 @@ onClickOutside(menuRef, () => {
   close();
 });
 
-useTrapFocus(drawerRef, { activeState: isOpen, arrowKeysOn: true, arrowFocusGroupSelector: '.list-item' });
+useTrapFocus(drawerRef, { activeState: isOpen, arrowKeysOn: true });
 
 const actionItems = [
   {

--- a/packages/sfui/frameworks/react/hooks/useTrapFocus/useTrapFocus.ts
+++ b/packages/sfui/frameworks/react/hooks/useTrapFocus/useTrapFocus.ts
@@ -44,15 +44,14 @@ export const useTrapFocus = (containerElementRef: RefObject<HTMLElement | null>,
   const onKeyDownListener = (event: KeyboardEvent) => {
     const isAnyGroupElement =
       arrowFocusGroupSelector && containerElementRef.current?.querySelector(arrowFocusGroupSelector);
-
     if (arrowKeysOn) {
-      if (event.key === 'ArrowRight') {
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
         focusNext({
           current: currentlyFocused.current,
           focusables: focusableElements.current,
           ...(isAnyGroupElement && { arrowFocusGroupSelector }),
         });
-      } else if (event.key === 'ArrowLeft') {
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
         focusPrev({
           current: currentlyFocused.current,
           focusables: focusableElements.current,

--- a/packages/sfui/frameworks/vue/composables/useTrapFocus/useTrapFocus.ts
+++ b/packages/sfui/frameworks/vue/composables/useTrapFocus/useTrapFocus.ts
@@ -51,7 +51,6 @@ export const useTrapFocus = (containerElementRef: Ref<HTMLElement | undefined>, 
   const onKeyDownListener = (event: KeyboardEvent) => {
     const isAnyGroupElement = arrowFocusGroupSelector && containeHTMLElement?.querySelector(arrowFocusGroupSelector);
     if (arrowKeysOn) {
-      console.log(arrowFocusGroupSelector);
       if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
         focusNext({
           current: currentlyFocused.value,

--- a/packages/sfui/frameworks/vue/composables/useTrapFocus/useTrapFocus.ts
+++ b/packages/sfui/frameworks/vue/composables/useTrapFocus/useTrapFocus.ts
@@ -51,13 +51,14 @@ export const useTrapFocus = (containerElementRef: Ref<HTMLElement | undefined>, 
   const onKeyDownListener = (event: KeyboardEvent) => {
     const isAnyGroupElement = arrowFocusGroupSelector && containeHTMLElement?.querySelector(arrowFocusGroupSelector);
     if (arrowKeysOn) {
-      if (event.key === 'ArrowRight') {
+      console.log(arrowFocusGroupSelector);
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
         focusNext({
           current: currentlyFocused.value,
           focusables: focusableElements.value,
           ...(isAnyGroupElement && { arrowFocusGroupSelector }),
         });
-      } else if (event.key === 'ArrowLeft') {
+      } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
         focusPrev({
           current: currentlyFocused.value,
           focusables: focusableElements.value,


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1027?atlOrigin=eyJpIjoiMTE1ZGVlZjYxYzE5NGI1MGIzY2Q3YmRlOGRmOWIyYWMiLCJwIjoiaiJ9

https://vsf.atlassian.net/browse/SFUI2-689


# Scope of work

- added arrows navigation for megamenu using useTrapFocus composable

# Screenshots of visual changes

- 

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
