### PR TITLE
fix: props getters in Scrollable

### DIFF
--- a/apps/docs/components/components/scrollable.md
+++ b/apps/docs/components/components/scrollable.md
@@ -91,7 +91,7 @@ By default `SfScrollable` scroll by one page of items, but can be modified that 
 <!-- react -->
 | `as`         | `ReactElement`       | `'div'`        | any tag name                       |
 | `children`   | `ReactNode`          |               | Default slotted content            |
-| `wrapperClassNames`   | `string`      |               |    |
+| `wrapperClassName`   | `string`      |               |    |
 | `slotPreviousButton` | `ReactNode`          |               | Previous button         |
 | `slotNextButton` | `ReactNode`          |               | Next button         |
 | `onDragChange`           | `Function` |    |  |

--- a/apps/preview/next/package.json
+++ b/apps/preview/next/package.json
@@ -24,7 +24,6 @@
     "@storefront-ui/preview-shared": "workspace:^",
     "classnames": "^2.3.2",
     "lodash-es": "^4.17.21",
-    "merge-refs": "^1.1.3",
     "next": "^13.1.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/preview/next/package.json
+++ b/apps/preview/next/package.json
@@ -24,6 +24,7 @@
     "@storefront-ui/preview-shared": "workspace:^",
     "classnames": "^2.3.2",
     "lodash-es": "^4.17.21",
+    "merge-refs": "^1.1.3",
     "next": "^13.1.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/preview/next/pages/showcases/Scrollable/ScrollByOneItem.tsx
+++ b/apps/preview/next/pages/showcases/Scrollable/ScrollByOneItem.tsx
@@ -10,7 +10,7 @@ export default function ScrollableMoveByOne() {
 
   return (
     <SfScrollable
-      wrapperClassNames="min-w-0"
+      wrapperClassName="min-w-0"
       className="items-center w-full"
       activeIndex={activeIndex}
       previousDisabled={activeIndex === 0}

--- a/packages/sfui/frameworks/react/components/SfButton/SfButton.tsx
+++ b/packages/sfui/frameworks/react/components/SfButton/SfButton.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
-import { SfButtonSize, SfButtonVariant, polymorphicForwardRef } from '@storefront-ui/react';
-import type { SfButtonProps } from '@storefront-ui/react';
+import { type SfButtonProps, SfButtonSize, SfButtonVariant, polymorphicForwardRef } from '@storefront-ui/react';
 
 const defaultButtonTag = 'button';
 

--- a/packages/sfui/frameworks/react/components/SfDrawer/SfDrawer.tsx
+++ b/packages/sfui/frameworks/react/components/SfDrawer/SfDrawer.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { useRef } from 'react';
 import { useClickAway } from 'react-use';
-import mergeRefs from 'merge-refs';
+import { mergeRefs } from 'react-merge-refs';
 import { SfDrawerPlacement, polymorphicForwardRef } from '@storefront-ui/react';
 import type { SfDrawerProps } from '@storefront-ui/react';
 
@@ -45,7 +45,7 @@ const SfDrawer = polymorphicForwardRef<typeof defaultDrawerTag, SfDrawerProps>(
 
     return open ? (
       <Tag
-        ref={mergeRefs(drawerRef, ref)}
+        ref={mergeRefs([drawerRef, ref])}
         className={classNames('fixed', placementClasses(placement), className)}
         tabIndex="-1"
         data-testid="drawer"

--- a/packages/sfui/frameworks/react/components/SfModal/SfModal.tsx
+++ b/packages/sfui/frameworks/react/components/SfModal/SfModal.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { useRef } from 'react';
 import { useClickAway } from 'react-use';
-import mergeRefs from 'merge-refs';
+import { mergeRefs } from 'react-merge-refs';
 import { type SfModalProps, polymorphicForwardRef, useTrapFocus, InitialFocusType } from '@storefront-ui/react';
 
 const defaultModalTag = 'div';
@@ -31,7 +31,7 @@ const SfModal = polymorphicForwardRef<typeof defaultModalTag, SfModalProps>(
 
     return open ? (
       <Tag
-        ref={mergeRefs(modalRef, ref)}
+        ref={mergeRefs([modalRef, ref])}
         className={classNames(
           'fixed inset-0 w-fit h-fit m-auto p-6 pt-10 lg:p-10 border border-neutral-100 bg-white shadow-xl rounded-xl outline-none',
           className,

--- a/packages/sfui/frameworks/react/components/SfScrollable/SfScrollable.tsx
+++ b/packages/sfui/frameworks/react/components/SfScrollable/SfScrollable.tsx
@@ -62,7 +62,7 @@ const SfScrollable = polymorphicForwardRef<typeof defaultScrollableTag, SfScroll
 
     function PreviousButton({ classNameButton }: { classNameButton?: string }) {
       if (slotPreviousButton) {
-        return cloneElement(slotPreviousButton, getPrevButtonProps());
+        return cloneElement(slotPreviousButton, getPrevButtonProps({ disabled: previousDisabled, onClick: onPrev }));
       }
       return (
         <SfButton
@@ -83,7 +83,7 @@ const SfScrollable = polymorphicForwardRef<typeof defaultScrollableTag, SfScroll
 
     function NextButton({ classNameButton }: { classNameButton?: string }) {
       if (slotNextButton) {
-        return cloneElement(slotNextButton, getNextButtonProps());
+        return cloneElement(slotNextButton, getNextButtonProps({ disabled: nextDisabled, onClick: onNext }));
       }
       return (
         <SfButton

--- a/packages/sfui/frameworks/react/components/SfScrollable/SfScrollable.tsx
+++ b/packages/sfui/frameworks/react/components/SfScrollable/SfScrollable.tsx
@@ -3,7 +3,7 @@ import { cloneElement, useMemo } from 'react';
 import classNames from 'classnames';
 import {
   polymorphicForwardRef,
-  // SfButton,
+  SfButton,
   SfIconChevronLeft,
   SfIconChevronRight,
   useScrollable,
@@ -11,7 +11,6 @@ import {
   SfScrollableButtonsPlacement,
   type SfScrollableProps,
 } from '@storefront-ui/react';
-import SfButton from '../SfButton/SfButton';
 
 const defaultScrollableTag = 'div';
 

--- a/packages/sfui/frameworks/react/components/SfScrollable/SfScrollable.tsx
+++ b/packages/sfui/frameworks/react/components/SfScrollable/SfScrollable.tsx
@@ -3,7 +3,7 @@ import { cloneElement, useMemo } from 'react';
 import classNames from 'classnames';
 import {
   polymorphicForwardRef,
-  SfButton,
+  // SfButton,
   SfIconChevronLeft,
   SfIconChevronRight,
   useScrollable,
@@ -11,6 +11,7 @@ import {
   SfScrollableButtonsPlacement,
   type SfScrollableProps,
 } from '@storefront-ui/react';
+import SfButton from '../SfButton/SfButton';
 
 const defaultScrollableTag = 'div';
 

--- a/packages/sfui/frameworks/react/components/SfScrollable/SfScrollable.tsx
+++ b/packages/sfui/frameworks/react/components/SfScrollable/SfScrollable.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/require-default-props */
 import { cloneElement, useMemo } from 'react';
 import classNames from 'classnames';
 import {
@@ -27,7 +28,7 @@ const SfScrollable = polymorphicForwardRef<typeof defaultScrollableTag, SfScroll
       onPrev,
       onNext,
       className,
-      wrapperClassNames,
+      wrapperClassName,
       previousDisabled,
       nextDisabled,
       style,
@@ -36,10 +37,12 @@ const SfScrollable = polymorphicForwardRef<typeof defaultScrollableTag, SfScroll
       slotNextButton,
       ...attributes
     },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ref,
   ) => {
     const Tag = as || defaultScrollableTag;
+    const isHorizontal = direction === SfScrollableDirection.horizontal;
+    const isBlock = buttonsPlacement === SfScrollableButtonsPlacement.block;
+    const isFloating = buttonsPlacement === SfScrollableButtonsPlacement.floating;
 
     const sliderOptions = useMemo(
       () => ({
@@ -55,76 +58,103 @@ const SfScrollable = polymorphicForwardRef<typeof defaultScrollableTag, SfScroll
       [direction, activeIndex, reduceMotion, drag, onDragChange, onScroll, onPrev, onNext],
     );
 
-    const { getContainerProps, state, getNextButtonProps, getPrevButtonProps } = useScrollable(sliderOptions);
+    const { state, getContainerProps, getNextButtonProps, getPrevButtonProps } = useScrollable(sliderOptions);
 
-    const changeDisabledClass = (isDisabled: boolean) =>
-      isDisabled ? '!ring-disabled-300 !text-disabled-500' : '!ring-neutral-500 !text-neutral-500';
-    const previousButton = (...buttonClassName: Parameters<typeof classNames>) =>
-      (slotPreviousButton && cloneElement(slotPreviousButton, getPrevButtonProps())) || (
+    function PreviousButton({ classNameButton }: { classNameButton?: string }) {
+      if (slotPreviousButton) {
+        return cloneElement(slotPreviousButton, getPrevButtonProps());
+      }
+      return (
         <SfButton
-          variant="secondary"
-          size="lg"
-          className={classNames(
-            'hidden md:block',
-            buttonClassName,
-            changeDisabledClass(
-              typeof previousDisabled === 'boolean' ? previousDisabled : getPrevButtonProps().disabled,
+          {...getPrevButtonProps({
+            square: true,
+            variant: 'secondary',
+            size: 'lg',
+            disabled: previousDisabled,
+            slotPrefix: <SfIconChevronLeft />,
+            className: classNames(
+              'hidden md:block !ring-neutral-500 !text-neutral-500 disabled:!ring-disabled-300 disabled:!text-disabled-500',
+              classNameButton,
             ),
-          )}
-          square
-          slotPrefix={<SfIconChevronLeft />}
-          {...getPrevButtonProps()}
-          disabled={previousDisabled}
+          })}
         />
       );
+    }
 
-    const nextButton = (...buttonClassName: Parameters<typeof classNames>) =>
-      (slotNextButton && cloneElement(slotNextButton, getNextButtonProps())) || (
+    function NextButton({ classNameButton }: { classNameButton?: string }) {
+      if (slotNextButton) {
+        return cloneElement(slotNextButton, getNextButtonProps());
+      }
+      return (
         <SfButton
-          variant="secondary"
-          size="lg"
-          square
-          className={classNames(
-            'hidden md:block',
-            buttonClassName,
-            changeDisabledClass(typeof nextDisabled === 'boolean' ? nextDisabled : getNextButtonProps().disabled),
-          )}
-          slotPrefix={<SfIconChevronRight />}
-          {...getNextButtonProps()}
-          disabled={nextDisabled}
+          {...getNextButtonProps({
+            square: true,
+            variant: 'secondary',
+            size: 'lg',
+            disabled: nextDisabled,
+            slotPrefix: <SfIconChevronRight />,
+            className: classNames(
+              'hidden md:block !ring-neutral-500 !text-neutral-500 disabled:!ring-disabled-300 disabled:!text-disabled-500',
+              classNameButton,
+            ),
+          })}
         />
       );
-
-    const isHorizontal = direction === SfScrollableDirection.horizontal;
+    }
 
     return (
       <div
         className={classNames(
           'items-center relative',
           isHorizontal ? 'flex' : 'flex-col h-full inline-flex',
-          wrapperClassNames,
+          wrapperClassName,
         )}
       >
-        {buttonsPlacement === SfScrollableButtonsPlacement.block &&
-          previousButton('!rounded-full bg-white', isHorizontal ? 'mr-4' : 'mb-4 rotate-90')}
+        {isBlock && (
+          <PreviousButton
+            classNameButton={classNames('!rounded-full bg-white', {
+              'mr-4': isHorizontal,
+              'mb-4 rotate-90': !isHorizontal,
+            })}
+          />
+        )}
         <Tag
           {...getContainerProps({
-            className: classNames(className, 'motion-safe:scroll-smooth', {
+            className: classNames(className, {
               'overflow-x-auto flex gap-4': isHorizontal,
               'overflow-y-auto flex flex-col gap-4': !isHorizontal,
               'cursor-grab': state.isDragged,
             }),
+            ...attributes,
+            ref,
           })}
-          {...attributes}
         >
-          {buttonsPlacement === SfScrollableButtonsPlacement.floating &&
-            previousButton('absolute !rounded-full bg-white z-10', isHorizontal ? 'left-4' : 'top-4 rotate-90')}
+          {isFloating && (
+            <PreviousButton
+              classNameButton={classNames('absolute !rounded-full bg-white z-10', {
+                'left-4': isHorizontal,
+                'top-4 rotate-90': !isHorizontal,
+              })}
+            />
+          )}
           {children}
-          {buttonsPlacement === SfScrollableButtonsPlacement.floating &&
-            nextButton('absolute !rounded-full bg-white z-10', isHorizontal ? 'right-4' : 'bottom-4 rotate-90')}
+          {isFloating && (
+            <NextButton
+              classNameButton={classNames('absolute !rounded-full bg-white z-10', {
+                'right-4': isHorizontal,
+                'bottom-4 rotate-90': !isHorizontal,
+              })}
+            />
+          )}
         </Tag>
-        {buttonsPlacement === SfScrollableButtonsPlacement.block &&
-          nextButton('!rounded-full bg-white', isHorizontal ? 'ml-4' : 'mt-4 rotate-90')}
+        {isBlock && (
+          <NextButton
+            classNameButton={classNames('!rounded-full bg-white', {
+              'ml-4': isHorizontal,
+              'mt-4 rotate-90': !isHorizontal,
+            })}
+          />
+        )}
       </div>
     );
   },

--- a/packages/sfui/frameworks/react/components/SfScrollable/types.ts
+++ b/packages/sfui/frameworks/react/components/SfScrollable/types.ts
@@ -3,7 +3,7 @@ import type { UseScrollableOptions, PropsWithStyle } from '@storefront-ui/react'
 import { SfScrollableButtonsPlacement } from '@storefront-ui/react';
 
 export interface SfScrollableProps extends UseScrollableOptions, PropsWithChildren, PropsWithStyle {
-  wrapperClassNames?: string;
+  wrapperClassName?: string;
   slotPreviousButton?: ReactElement;
   slotNextButton?: ReactElement;
   previousDisabled?: boolean;

--- a/packages/sfui/frameworks/react/hooks/useScrollable/useScrollable.ts
+++ b/packages/sfui/frameworks/react/hooks/useScrollable/useScrollable.ts
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
-import mergeRefs from 'merge-refs';
+import { Ref, useEffect, useRef, useState } from 'react';
+import { mergeRefs } from 'react-merge-refs';
 import { type UseScrollableOptions, Scrollable, composeHandlers, createPropsGetter } from '@storefront-ui/react';
 
 export function useScrollable<TElement extends HTMLElement>({
@@ -64,7 +64,7 @@ export function useScrollable<TElement extends HTMLElement>({
   });
 
   const getContainerProps = createPropsGetter((userProps) => ({
-    ref: mergeRefs(containerElement, userProps.ref),
+    ref: mergeRefs([containerElement, userProps.ref].filter(Boolean) as Ref<HTMLElement>[]),
   }));
 
   return {

--- a/packages/sfui/frameworks/react/hooks/useScrollable/useScrollable.ts
+++ b/packages/sfui/frameworks/react/hooks/useScrollable/useScrollable.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import mergeRefs from 'merge-refs';
 import { type UseScrollableOptions, Scrollable, composeHandlers, createPropsGetter } from '@storefront-ui/react';
 
 export function useScrollable<TElement extends HTMLElement>({
@@ -62,8 +63,8 @@ export function useScrollable<TElement extends HTMLElement>({
     };
   });
 
-  const getContainerProps = createPropsGetter(() => ({
-    ref: containerElement,
+  const getContainerProps = createPropsGetter((userProps) => ({
+    ref: mergeRefs(containerElement, userProps.ref),
   }));
 
   return {

--- a/packages/sfui/frameworks/react/hooks/useScrollable/useScrollable.ts
+++ b/packages/sfui/frameworks/react/hooks/useScrollable/useScrollable.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import mergeRefs from 'merge-refs';
 import { type UseScrollableOptions, Scrollable, composeHandlers, createPropsGetter } from '@storefront-ui/react';
 
 export function useScrollable<TElement extends HTMLElement>({
@@ -63,8 +62,8 @@ export function useScrollable<TElement extends HTMLElement>({
     };
   });
 
-  const getContainerProps = createPropsGetter((userProps) => ({
-    ref: mergeRefs(containerElement, userProps.ref),
+  const getContainerProps = createPropsGetter(() => ({
+    ref: containerElement,
   }));
 
   return {

--- a/packages/sfui/frameworks/react/hooks/useScrollable/useScrollable.ts
+++ b/packages/sfui/frameworks/react/hooks/useScrollable/useScrollable.ts
@@ -1,4 +1,4 @@
-import { Ref, useEffect, useRef, useState } from 'react';
+import { type Ref, useEffect, useRef, useState } from 'react';
 import { mergeRefs } from 'react-merge-refs';
 import { type UseScrollableOptions, Scrollable, composeHandlers, createPropsGetter } from '@storefront-ui/react';
 

--- a/packages/sfui/frameworks/react/hooks/useScrollable/useScrollable.ts
+++ b/packages/sfui/frameworks/react/hooks/useScrollable/useScrollable.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import mergeRefs from 'merge-refs';
 import { type UseScrollableOptions, Scrollable, composeHandlers, createPropsGetter } from '@storefront-ui/react';
 
 export function useScrollable<TElement extends HTMLElement>({
@@ -42,31 +43,28 @@ export function useScrollable<TElement extends HTMLElement>({
     return unregister;
   }, [containerElement, activeIndex, direction, drag, reduceMotion, onDragChange, onScroll, onPrev, onNext]);
 
-  const getPrevButtonProps = createPropsGetter((props) => {
-    const onClick = () => {
+  const getPrevButtonProps = createPropsGetter((userProps) => {
+    const handlePrev = () => {
       scrollable.current?.prev();
     };
     return {
-      ...props,
-      onClick: composeHandlers(onClick, props?.onClick),
-      disabled: !state.hasPrev,
+      onClick: composeHandlers(handlePrev, userProps?.onClick),
+      disabled: userProps.disabled || !state.hasPrev,
     };
   });
 
-  const getNextButtonProps = createPropsGetter((props) => {
-    const onClick = () => {
+  const getNextButtonProps = createPropsGetter((userProps) => {
+    const handleNext = () => {
       scrollable.current?.next();
     };
     return {
-      ...props,
-      onClick: composeHandlers(onClick, props?.onClick),
-      disabled: !state.hasNext,
+      onClick: composeHandlers(handleNext, userProps?.onClick),
+      disabled: userProps.disabled || !state.hasNext,
     };
   });
 
-  const getContainerProps = createPropsGetter((props) => ({
-    ref: containerElement,
-    ...props,
+  const getContainerProps = createPropsGetter((userProps) => ({
+    ref: mergeRefs(containerElement, userProps.ref),
   }));
 
   return {

--- a/packages/sfui/frameworks/react/hooks/useTooltip/useTooltip.ts
+++ b/packages/sfui/frameworks/react/hooks/useTooltip/useTooltip.ts
@@ -46,7 +46,7 @@ export function useTooltip(options?: UseTooltipOptions) {
           bottom: 'top',
           left: 'right',
         }[basePlacement]]: `calc(${arrowSize} / -2)`,
-      };
+      } as const;
     }
     return {};
   }

--- a/packages/sfui/frameworks/react/package.json
+++ b/packages/sfui/frameworks/react/package.json
@@ -43,7 +43,7 @@
     "@storefront-ui/tailwind-config": "workspace:*",
     "classnames": "^2.3.2",
     "jw-paginate": "^1.0.4",
-    "merge-refs": "^1.1.2",
+    "react-merge-refs": "^2.0.1",
     "react-polymorphed": "^2.1.0",
     "react-transition-group": "^4.4.5",
     "react-use": "^17.4.0",

--- a/packages/sfui/frameworks/react/shared/utils/props.ts
+++ b/packages/sfui/frameworks/react/shared/utils/props.ts
@@ -1,5 +1,5 @@
 import type { AllHTMLAttributes, RefAttributes } from 'react';
-import { Prettify } from '@storefront-ui/shared';
+import type { Prettify } from '@storefront-ui/shared';
 
 export const composeHandlers =
   (...callbacks: (Function | null | undefined)[]) =>

--- a/packages/sfui/frameworks/react/shared/utils/props.ts
+++ b/packages/sfui/frameworks/react/shared/utils/props.ts
@@ -16,7 +16,7 @@ while user can pass anything. Sometimes your props getter might have to make ext
 interface UserProps<T> extends AllHTMLAttributes<T>, RefAttributes<T> {}
 
 export function createPropsGetter<TProps>(resolver: (userProps: UserProps<HTMLElement>) => TProps) {
-  return function resolve<TUserProps = {}>(userProps: TUserProps = {} as TUserProps) {
+  return function resolve<TUserProps = {}>(userProps: TUserProps = {} as TUserProps): Prettify<TProps & TUserProps> {
     return {
       ...userProps,
       ...resolver(userProps || {}),

--- a/packages/sfui/frameworks/react/shared/utils/props.ts
+++ b/packages/sfui/frameworks/react/shared/utils/props.ts
@@ -1,4 +1,5 @@
-import type { HTMLProps } from 'react';
+import type { AllHTMLAttributes, RefAttributes } from 'react';
+import { Prettify } from '@storefront-ui/shared';
 
 export const composeHandlers =
   (...callbacks: (Function | null | undefined)[]) =>
@@ -6,9 +7,19 @@ export const composeHandlers =
     callbacks.forEach((cb) => cb?.(...args));
   };
 
-export const createPropsGetter =
-  <TProps>(resolver: (userProps: HTMLProps<HTMLElement>) => TProps) =>
-  (userProps?: HTMLProps<HTMLElement>): TProps & typeof userProps => ({
-    ...userProps,
-    ...resolver(userProps || {}),
-  });
+/*
+USE WITH CAUTION!
+This type is not perfect. You can access all HTML attributes in the userProps object within the resolver.
+However, it may lead to bugs that TypeScript cannot detect, e.g. you can access `size` attribute of type number,
+while user can pass anything. Sometimes your props getter might have to make extra checks on userProps type.
+*/
+interface UserProps<T> extends AllHTMLAttributes<T>, RefAttributes<T> {}
+
+export function createPropsGetter<TProps>(resolver: (userProps: UserProps<HTMLElement>) => TProps) {
+  return function resolve<TUserProps = {}>(userProps: TUserProps = {} as TUserProps): Prettify<TProps & TUserProps> {
+    return {
+      ...userProps,
+      ...resolver(userProps || {}),
+    };
+  };
+}

--- a/packages/sfui/frameworks/react/shared/utils/props.ts
+++ b/packages/sfui/frameworks/react/shared/utils/props.ts
@@ -16,7 +16,7 @@ while user can pass anything. Sometimes your props getter might have to make ext
 interface UserProps<T> extends AllHTMLAttributes<T>, RefAttributes<T> {}
 
 export function createPropsGetter<TProps>(resolver: (userProps: UserProps<HTMLElement>) => TProps) {
-  return function resolve<TUserProps = {}>(userProps: TUserProps = {} as TUserProps): Prettify<TProps & TUserProps> {
+  return function resolve<TUserProps = {}>(userProps: TUserProps = {} as TUserProps) {
     return {
       ...userProps,
       ...resolver(userProps || {}),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4043,7 +4043,7 @@ __metadata:
     classnames: ^2.3.2
     eslint: ^8.34.0
     jw-paginate: ^1.0.4
-    merge-refs: ^1.1.2
+    react-merge-refs: ^2.0.1
     react-polymorphed: ^2.1.0
     react-transition-group: ^4.4.5
     react-use: ^17.4.0
@@ -16943,15 +16943,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-refs@npm:^1.1.2":
-  version: 1.1.3
-  resolution: "merge-refs@npm:1.1.3"
-  dependencies:
-    "@types/react": "*"
-  checksum: beb413608e307866fb1b44cbb3bc6b2d2b9c117a416f85513716c5ab4701abfa03f2b4ab77c6ce7ece5b724d4b88a440479591be23d06d546cd2ceddc84997af
-  languageName: node
-  linkType: hard
-
 "merge-source-map@npm:^1.1.0":
   version: 1.1.0
   resolution: "merge-source-map@npm:1.1.0"
@@ -20650,6 +20641,13 @@ __metadata:
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
+  languageName: node
+  linkType: hard
+
+"react-merge-refs@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "react-merge-refs@npm:2.0.1"
+  checksum: c0b6fdb384a92e9b2bb7d56128244a2db97b9343c0dcae70f172352c3732312266c078495902707e45f523625afcba78996a22edea3a8e7b2b17fe97347059fe
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3976,7 +3976,6 @@ __metadata:
     cypress: ^12.9.0
     glob-promise: ^6.0.2
     lodash-es: ^4.17.21
-    merge-refs: ^1.1.3
     next: ^13.1.6
     nyc: ^15.1.0
     postcss: ^8.4.21
@@ -16944,7 +16943,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-refs@npm:^1.1.2, merge-refs@npm:^1.1.3":
+"merge-refs@npm:^1.1.2":
   version: 1.1.3
   resolution: "merge-refs@npm:1.1.3"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3976,6 +3976,7 @@ __metadata:
     cypress: ^12.9.0
     glob-promise: ^6.0.2
     lodash-es: ^4.17.21
+    merge-refs: ^1.1.3
     next: ^13.1.6
     nyc: ^15.1.0
     postcss: ^8.4.21
@@ -16943,7 +16944,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-refs@npm:^1.1.2":
+"merge-refs@npm:^1.1.2, merge-refs@npm:^1.1.3":
   version: 1.1.3
   resolution: "merge-refs@npm:1.1.3"
   dependencies:


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes [SFUI2-1024](https://vsf.atlassian.net/browse/SFUI2-1024)

# Scope of work

<!-- describe what you did -->

- Fixed typing of `createPropsGetter` function.
- Refactored `<SfScrollable />` component.
- Changed name of the prop: `wrapperClassNames` -> `wrapperClassName`
- Switched to [`react-merge-refs`](https://www.npmjs.com/package/react-merge-refs) due to issue on Next build with previous package `merge-refs`.

**Important!** Please note that when you use props getter, you must always pass all additional props through function's argument. Passing custom props outside of the props getter may cause issues, due to unexpected props overriding or incorrect props merging.
```
// Correct usage example
// onClick props will get merged
<SfButton {...getNextButtonProps({
  variant: 'secondary',
  size: 'lg',
  onClick: () => console.log('click'),
})}>
  Button label
</SfButton>

// Wrong usage example
// onClick prop will override the one that comes from the props getter
<SfButton
  {...getNextButtonProps()}
  variant="secondary",
  size="lg",
  onClick={() => console.log('click')},
>
  Button label
</SfButton>
```

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created


[SFUI2-1024]: https://vsf.atlassian.net/browse/SFUI2-1024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ