### PR TITLE
fix: newsletterbox links color

### DIFF
--- a/apps/preview/next/pages/showcases/NewsletterBox/NewsletterBox.tsx
+++ b/apps/preview/next/pages/showcases/NewsletterBox/NewsletterBox.tsx
@@ -51,8 +51,15 @@ export default function NewsletterBox() {
           </SfButton>
         </form>
         <div className="typography-text-xs text-neutral-600">
-          To learn how we process your data, visit our <SfLink className="text-neutral-600">Privacy Notice</SfLink>. You
-          can <SfLink className="text-neutral-600">unsubscribe</SfLink> at any time without costs.
+          To learn how we process your data, visit our{' '}
+          <SfLink href="#" className="!text-neutral-600">
+            Privacy Notice
+          </SfLink>
+          . You can{' '}
+          <SfLink href="#" className="!text-neutral-600">
+            unsubscribe
+          </SfLink>{' '}
+          at any time without costs.
         </div>
       </div>
       <div className="absolute top-0 right-0 mx-2 mt-2 sm:mr-6">

--- a/apps/preview/nuxt/pages/showcases/NewsletterBox/NewsletterBox.vue
+++ b/apps/preview/nuxt/pages/showcases/NewsletterBox/NewsletterBox.vue
@@ -15,8 +15,8 @@
         <SfButton type="submit" size="lg"> Subscribe to Newsletter </SfButton>
       </form>
       <div class="typography-text-xs text-neutral-600">
-        To learn how we process your data, visit our <SfLink class="text-neutral-600">Privacy Notice</SfLink>. You can
-        <SfLink class="text-neutral-600">unsubscribe</SfLink> at any time without costs.
+        To learn how we process your data, visit our <SfLink href="#" class="!text-neutral-600">Privacy Notice</SfLink>.
+        You can <SfLink href="#" class="!text-neutral-600">unsubscribe</SfLink> at any time without costs.
       </div>
     </div>
     <div class="absolute top-0 right-0 mx-2 mt-2 sm:mr-6">


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes # https://vsf.atlassian.net/jira/software/c/projects/SFUI2/boards/69?modal=detail&selectedIssue=SFUI2-1035&assignee=5fcf86fca1d3f100684db8a5

# Scope of work

Links color changed to gray and added href prop

<!-- describe what you did -->

# Screenshots of visual changes
<img width="947" alt="Screenshot 2023-04-19 at 07 41 06" src="https://user-images.githubusercontent.com/46591755/232977723-a4dce510-1a78-4acb-b484-025d33fb2858.png">
<img width="947" alt="Screenshot 2023-04-19 at 07 41 01" src="https://user-images.githubusercontent.com/46591755/232977731-200a6b15-a951-4974-a22c-53f0985929be.png">



<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
