### PR TITLE
fix: (sfui2-1044) pagination styling improvements

### DIFF
--- a/apps/preview/next/pages/showcases/Pagination/Pagination.tsx
+++ b/apps/preview/next/pages/showcases/Pagination/Pagination.tsx
@@ -21,6 +21,7 @@ export function Showcase() {
     >
       <SfButton
         type="button"
+        size="lg"
         className="gap-3"
         aria-label="Go to previous page"
         disabled={selectedPage <= 1}
@@ -145,6 +146,7 @@ export function Showcase() {
       </ul>
       <SfButton
         type="button"
+        size="lg"
         aria-label="Go to next page"
         disabled={selectedPage >= totalPages}
         variant="tertiary"

--- a/apps/preview/next/pages/showcases/Pagination/Pagination.tsx
+++ b/apps/preview/next/pages/showcases/Pagination/Pagination.tsx
@@ -14,7 +14,11 @@ export function Showcase() {
   });
 
   return (
-    <nav className="flex justify-between border-t border-neutral-200" role="navigation" aria-label="pagination">
+    <nav
+      className="flex justify-between items-center border-t border-neutral-200"
+      role="navigation"
+      aria-label="pagination"
+    >
       <SfButton
         type="button"
         className="gap-3"
@@ -31,7 +35,7 @@ export function Showcase() {
           <li>
             <div
               className={classNames('flex pt-1 border-t-4 border-transparent', {
-                'font-medium border-t-4 !border-primary-500': selectedPage === 1,
+                'font-medium border-t-4 !border-primary-700': selectedPage === 1,
               })}
             >
               <button

--- a/apps/preview/nuxt/pages/showcases/Pagination/Pagination.vue
+++ b/apps/preview/nuxt/pages/showcases/Pagination/Pagination.vue
@@ -1,7 +1,8 @@
 <template>
-  <nav class="flex justify-between border-t border-neutral-200" role="navigation" aria-label="pagination">
+  <nav class="flex justify-between items-center border-t border-neutral-200" role="navigation" aria-label="pagination">
     <SfButton
       type="button"
+      size="lg"
       aria-label="Go to previous page"
       :disabled="selectedPage <= 1"
       variant="tertiary"
@@ -52,7 +53,7 @@
         <div
           :class="[
             'flex pt-1 border-t-4 border-transparent',
-            { 'font-medium border-t-4 !border-primary-500': selectedPage === page },
+            { 'font-medium border-t-4 !border-primary-700': selectedPage === page },
           ]"
         >
           <button
@@ -106,6 +107,7 @@
     </ul>
     <SfButton
       type="button"
+      size="lg"
       aria-label="Go to next page"
       :disabled="selectedPage >= totalPages"
       variant="tertiary"


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1044?atlOrigin=eyJpIjoiZTBiODM2YTVhZDg5NGYyYzhlYWQ4ZTFhZjcxYjlhMTciLCJwIjoiaiJ9


# Scope of work

- adjusted flex properties of pagination
- changed border color to primary-700
- added missig size prop for button

# Screenshots of visual changes

<img width="1085" alt="Zrzut ekranu 2023-04-19 o 10 33 08" src="https://user-images.githubusercontent.com/41487496/233017379-250713b9-5d01-4706-8ce7-e784842b9620.png">


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
