### PR TITLE
docs: fix v1 link

### DIFF
--- a/apps/docs/components/index.md
+++ b/apps/docs/components/index.md
@@ -30,7 +30,7 @@ hideBreadcrumbs: true
 :::::: slot vue
 
 ::: read-more
-If you're using Storefront UI 1, you can find that documentation at [https://storefrontui.io/v1](https://storefrontui.io/v1).
+If you're using Storefront UI 1, you can find that documentation at [https://storefrontui.io/v1](https://docs.storefrontui.io/v1).
 :::
 
 ## Base Components

--- a/apps/docs/components/index.md
+++ b/apps/docs/components/index.md
@@ -30,7 +30,7 @@ hideBreadcrumbs: true
 :::::: slot vue
 
 ::: read-more
-If you're using Storefront UI 1, you can find that documentation at [https://storefrontui.io/v1](https://docs.storefrontui.io/v1).
+If you're using Storefront UI 1, you can find that documentation at [https://docs.storefrontui.io/v1](https://docs.storefrontui.io/v1).
 :::
 
 ## Base Components


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1065



# Scope of work
- change `storefront.io/v1` to `docs.vuestorefront.io/v1` 

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
