### PR TITLE
fix: sfselect placeholder hidden

### DIFF
--- a/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
+++ b/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
@@ -37,6 +37,9 @@ export default function SfSelect(props: SfSelectProps) {
       >
         {placeholder && (
           <option
+            disabled
+            selected
+            hidden
             value=""
             className={classNames('bg-neutral-300 text-sm', {
               'text-base': size === SfSelectSize.lg,

--- a/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
+++ b/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
@@ -70,6 +70,9 @@ const changedValue = (event: Event) => {
     >
       <option
         v-if="placeholder"
+        disabled
+        selected
+        hidden
         class="text-sm bg-neutral-300"
         value=""
         :class="[


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #2603

# Scope of work

<!-- describe what you did -->

Add `disabled`,`selected` and `hidden` attributes to the placeholder option to hide from the selection.

# Screenshots of visual changes

https://user-images.githubusercontent.com/6861191/233136222-e1f9cb6c-648b-4cde-bec5-b1a8c37aa53f.mov

<!-- if visual changes applied -->

# Checklist

- [X] Self code-reviewed
- [ ] Changes documented
- [X] Semantic HTML
- [X] SSR-friendly
- [X] Caching friendly
- [X] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
