### PR TITLE
fix: add missing focus visible to list item

### DIFF
--- a/packages/sfui/frameworks/react/components/SfListItem/SfListItem.tsx
+++ b/packages/sfui/frameworks/react/components/SfListItem/SfListItem.tsx
@@ -29,7 +29,7 @@ const SfListItem = polymorphicForwardRef<typeof defaultListItemTag, SfListItemPr
     <Tag
       ref={ref}
       className={classNames(
-        'inline-flex items-center gap-2 w-full hover:bg-neutral-100 active:bg-neutral-200 cursor-pointer',
+        'inline-flex items-center gap-2 w-full hover:bg-neutral-100 active:bg-neutral-200 cursor-pointer focus-visible:outline focus-visible:outline-offset focus-visible:relative focus-visible:z-10',
         {
           'cursor-not-allowed pointer-events-none text-disabled-900': disabled,
           'font-medium': selected,

--- a/packages/sfui/frameworks/vue/components/SfListItem/SfListItem.vue
+++ b/packages/sfui/frameworks/vue/components/SfListItem/SfListItem.vue
@@ -33,9 +33,8 @@ defineProps({
 <template>
   <component
     :is="tag || 'li'"
-    tabindex="0"
     :class="[
-      'inline-flex items-center gap-2 w-full hover:bg-neutral-100 active:bg-neutral-200 cursor-pointer focus-visible:outline focus-visible:outline-offset',
+      'inline-flex items-center gap-2 w-full hover:bg-neutral-100 active:bg-neutral-200 cursor-pointer focus-visible:outline focus-visible:outline-offset focus-visible:relative focus-visible:z-10',
       sizeClasses[size],
       { 'cursor-not-allowed pointer-events-none text-disabled-900': disabled, 'font-medium': selected },
     ]"


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes [SFUI2-1053](https://vsf.atlassian.net/browse/SFUI2-1053)

# Scope of work

<!-- describe what you did -->

Changes applied to SfListItem component:

- add missing focus ring on focus visible,
- remove `tabindex`,
- make focus ring position over another list item with hover (see screenshot).

SfListItem component interactivity depends on the context. General focus ring is a part of the component but it is enabled only when the component is used as an interactive element like `<a>`, e.g. `<SfListItem as="a">` in React, or `<SfListItem tag="a">` in Vue. By default SfListItem renders as `<li>` element, which is non-interactive, so focus ring won't be applied.

# Screenshots of visual changes

<!-- if visual changes applied -->
<img width="188" alt="ListItem focus" src="https://user-images.githubusercontent.com/34419118/233376346-f243ad00-3af0-4c9d-bad3-583da436ad18.png">

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created


[SFUI2-1053]: https://vsf.atlassian.net/browse/SFUI2-1053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ