### PR TITLE
fix: (sfui2-1027) megamenu focus outline improvements

### DIFF
--- a/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
@@ -212,7 +212,6 @@ export default function BaseMegaMenu() {
                                 size="sm"
                                 role="none"
                                 href={item.link}
-                                className="focus-visible:outline focus-visible:rounded-sm"
                               >
                                 {item.title}
                               </SfListItem>

--- a/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
@@ -206,15 +206,17 @@ export default function BaseMegaMenu() {
                         <hr className="mb-3.5" />
                         <ul>
                           {items.map((item) => (
-                            <SfListItem size="sm" role="none">
-                              <a
-                                key={item.title}
-                                className="focus-visible:outline focus-visible:rounded-sm"
+                            <li key={item.title}>
+                              <SfListItem
+                                as="a"
+                                size="sm"
+                                role="none"
                                 href={item.link}
+                                className="focus-visible:outline focus-visible:rounded-sm"
                               >
                                 {item.title}
-                              </a>
-                            </SfListItem>
+                              </SfListItem>
+                            </li>
                           ))}
                         </ul>
                       </div>

--- a/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
@@ -207,12 +207,7 @@ export default function BaseMegaMenu() {
                         <ul>
                           {items.map((item) => (
                             <li key={item.title}>
-                              <SfListItem
-                                as="a"
-                                size="sm"
-                                role="none"
-                                href={item.link}
-                              >
+                              <SfListItem as="a" size="sm" role="none" href={item.link}>
                                 {item.title}
                               </SfListItem>
                             </li>

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
@@ -66,13 +66,7 @@
                     <hr class="mb-3.5" />
                     <ul>
                       <li v-for="item in items" :key="item.title">
-                        <SfListItem
-                          tag="a"
-                          :href="item.link"
-                          size="sm"
-                          role="none"
-                          class="focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
-                        >
+                        <SfListItem tag="a" :href="item.link" size="sm" role="none">
                           {{ item.title }}
                         </SfListItem>
                       </li>

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
@@ -71,7 +71,7 @@
                           :href="item.link"
                           size="sm"
                           role="none"
-                          class="focus-visible:outline focus-visible:outline-offset focus-visible:rounded-md"
+                          class="focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
                         >
                           {{ item.title }}
                         </SfListItem>

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
@@ -65,14 +65,17 @@
                     </h2>
                     <hr class="mb-3.5" />
                     <ul>
-                      <SfListItem v-for="item in items" :key="item.title" size="sm" role="none">
-                        <a
-                          class="focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
+                      <li v-for="item in items" :key="item.title">
+                        <SfListItem
+                          tag="a"
                           :href="item.link"
+                          size="sm"
+                          role="none"
+                          class="focus-visible:outline focus-visible:outline-offset focus-visible:rounded-md"
                         >
                           {{ item.title }}
-                        </a>
-                      </SfListItem>
+                        </SfListItem>
+                      </li>
                     </ul>
                   </div>
                   <div

--- a/packages/sfui/frameworks/vue/components/SfListItem/SfListItem.vue
+++ b/packages/sfui/frameworks/vue/components/SfListItem/SfListItem.vue
@@ -33,9 +33,8 @@ defineProps({
 <template>
   <component
     :is="tag || 'li'"
-    tabindex="0"
     :class="[
-      'inline-flex items-center gap-2 w-full hover:bg-neutral-100 active:bg-neutral-200 cursor-pointer focus-visible:outline focus-visible:outline-offset',
+      'inline-flex items-center gap-2 w-full hover:bg-neutral-100 active:bg-neutral-200 cursor-pointer',
       sizeClasses[size],
       { 'cursor-not-allowed pointer-events-none text-disabled-900': disabled, 'font-medium': selected },
     ]"


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1027?atlOrigin=eyJpIjoiZDIxZTNjYjZmZDhkNDEzMzg5ZjNjOGRjMjlmNGIyYTUiLCJwIjoiaiJ9


# Scope of work

- fixed issue with double-focus outline on megamenu items in vue

# Screenshots of visual changes

-

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
