### PR TITLE
feat: search block

### DIFF
--- a/apps/docs/components/blocks/Search.md
+++ b/apps/docs/components/blocks/Search.md
@@ -1,0 +1,25 @@
+---
+layout: DefaultLayout
+hideBreadcrumbs: true
+description: Search is a simple yet powerful input that helps users quickly find products in your shop.
+hideToc: true
+---
+
+# Search
+
+{{ $frontmatter.description }}
+
+## Basic search
+
+Simple search with an autocomplete functionality. Give your users hints of what they may look for.
+
+<Showcase showcase-name="Search/SearchBasic" style="min-height: 350px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Search/SearchBasic.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Search/SearchBasic.tsx#source
+<!-- end react -->
+
+</Showcase>

--- a/apps/docs/components/blocks/Search.md
+++ b/apps/docs/components/blocks/Search.md
@@ -11,7 +11,7 @@ hideToc: true
 
 ## Basic search
 
-Simple search with an autocomplete functionality. Give your users hints of what they may look for.
+Simple search with an autocomplete functionality. Give your users hints of what they may look for. In this example we use mock autocomplete example, make sure you provide real data.
 
 <Showcase showcase-name="Search/SearchBasic" style="min-height: 350px">
 

--- a/apps/preview/next/pages/showcases/Search/AutocompleteSearch.tsx
+++ b/apps/preview/next/pages/showcases/Search/AutocompleteSearch.tsx
@@ -1,0 +1,214 @@
+import { ShowcasePageLayout } from '../../showcases';
+// #region source
+import { type ChangeEvent, type FormEvent, useState, useEffect, useRef } from 'react';
+import {
+  SfInput,
+  SfIconSearch,
+  SfIconCancel,
+  SfButton,
+  SfDropdown,
+  useDisclosure,
+  SfListItem,
+  SfLoaderCircular,
+} from '@storefront-ui/react';
+import { useDebounce } from 'react-use';
+
+interface Product {
+  id: string;
+  name: string;
+}
+
+const mockProducts: Product[] = [
+  {
+    id: 'ip-14',
+    name: 'iPhone 14',
+  },
+  {
+    id: 'ip-14-p',
+    name: 'iPhone 14 Pro',
+  },
+  {
+    id: 'ip-14-pm',
+    name: 'iPhone 14 Pro Max',
+  },
+  {
+    id: 'ip-14-p',
+    name: 'iPhone 14 Plus',
+  },
+  {
+    id: 'ip-13',
+    name: 'iPhone 13',
+  },
+  {
+    id: 'ip-13-m',
+    name: 'iPhone 13 mini',
+  },
+  {
+    id: 'ip-12',
+    name: 'iPhone 12',
+  },
+  {
+    id: 'ip-11',
+    name: 'iPhone 11',
+  },
+  {
+    id: 'mb-a',
+    name: 'MacBook Air',
+  },
+  {
+    id: 'mb-p-13',
+    name: 'MacBook Pro 13"',
+  },
+  {
+    id: 'mb-p-14',
+    name: 'MacBook Pro 14"',
+  },
+  {
+    id: 'mb-p-16',
+    name: 'MacBook Pro 16"',
+  },
+];
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const mockSearchRequest = async (phrase: string) => {
+  console.log('SEARCH WITH PHRASE:', phrase);
+  alert(`Searching phrase: ${phrase}`);
+};
+
+const mockAutocompleteRequest = async (phrase: string) => {
+  // Just for presentation purposes. Replace it with the actual API call.
+  await delay(1000);
+  const results = mockProducts
+    .filter((product) => product.name.toLowerCase().startsWith(phrase.toLowerCase()))
+    .map((product) => {
+      const highlight = product.name.substring(0, phrase.length);
+      const rest = product.name.substring(phrase.length);
+      return [highlight, rest, product] as [string, string, Product];
+    });
+  return results;
+};
+
+export default function AutocompleteSearch() {
+  useRef();
+  const [searchValue, setSearchValue] = useState('');
+  const [debouncedSearchValue, setDebouncedSearchValue] = useState('');
+  const [snippets, setSnippets] = useState<[string, string, Product][]>([]);
+  const { isOpen, close, open } = useDisclosure();
+  const [isLoadingSnippets, setIsLoadingSnippets] = useState(false);
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    mockSearchRequest(searchValue);
+    close();
+  };
+
+  const handleReset = () => {
+    setSearchValue('');
+    setDebouncedSearchValue('');
+    close();
+    setSnippets([]);
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const phrase = event.target.value;
+    if (phrase) {
+      setSearchValue(phrase);
+    } else {
+      handleReset();
+    }
+  };
+
+  const handleSelect = (phrase: string) => () => {
+    setSearchValue(phrase);
+    setDebouncedSearchValue(phrase);
+    mockSearchRequest(phrase);
+    close();
+  };
+
+  useDebounce(
+    () => {
+      setDebouncedSearchValue(searchValue);
+    },
+    1000,
+    [searchValue],
+  );
+
+  useEffect(() => {
+    if (debouncedSearchValue) {
+      const getSnippets = async () => {
+        open();
+        setIsLoadingSnippets(true);
+
+        try {
+          const data = await mockAutocompleteRequest(debouncedSearchValue);
+          setSnippets(data);
+        } catch (error) {
+          console.error(error);
+        }
+
+        setIsLoadingSnippets(false);
+      };
+
+      getSnippets();
+    }
+  }, [debouncedSearchValue]);
+
+  return (
+    <>
+      <form onSubmit={handleSubmit}>
+        <SfDropdown
+          open={isOpen}
+          onClose={close}
+          className="!w-full"
+          placement="bottom-start"
+          trigger={
+            <label>
+              <SfInput
+                value={searchValue}
+                onChange={handleChange}
+                onFocus={open}
+                placeholder="Search"
+                slotPrefix={<SfIconSearch />}
+                slotSuffix={
+                  <SfButton onClick={handleReset} square variant="tertiary" aria-label="Reset search">
+                    <SfIconCancel />
+                  </SfButton>
+                }
+              />
+            </label>
+          }
+        >
+          {isLoadingSnippets ? (
+            <div className="w-full h-20 flex justify-center items-center border border-solid border-neutral-100 rounded-md drop-shadow-md bg-white py-2">
+              <SfLoaderCircular />
+            </div>
+          ) : (
+            snippets.length > 0 && (
+              <ul className="border border-solid border-neutral-100 rounded-md drop-shadow-md bg-white py-2">
+                {snippets.map(([highlight, rest, product]) => (
+                  <li key={product.id}>
+                    <SfListItem
+                      as="button"
+                      type="button"
+                      onClick={handleSelect(product.name)}
+                      className="flex justify-start"
+                    >
+                      <p className="text-left">
+                        <span>{highlight}</span>
+                        <span className="font-semibold">{rest}</span>
+                      </p>
+                    </SfListItem>
+                  </li>
+                ))}
+              </ul>
+            )
+          )}
+        </SfDropdown>
+      </form>
+    </>
+  );
+}
+
+// #endregion source
+AutocompleteSearch.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
@@ -115,26 +115,24 @@ export default function SearchBasic() {
 
   return (
     <form role="search" onSubmit={handleSubmit} ref={refs.setReference} className="relative">
-      <label>
-        <SfInput
-          ref={inputRef}
-          value={searchValue}
-          onChange={handleChange}
-          onFocus={open}
-          placeholder="Search 'MacBook' or 'iPhone'..."
-          slotPrefix={<SfIconSearch />}
-          slotSuffix={
-            <button
-              type="button"
-              onClick={handleReset}
-              aria-label="Reset search"
-              className="flex rounded-md focus-visible:outline focus-visible:outline-offset"
-            >
-              <SfIconCancel />
-            </button>
-          }
-        />
-      </label>
+      <SfInput
+        ref={inputRef}
+        value={searchValue}
+        onChange={handleChange}
+        onFocus={open}
+        placeholder="Search 'MacBook' or 'iPhone'..."
+        slotPrefix={<SfIconSearch />}
+        slotSuffix={
+          <button
+            type="button"
+            onClick={handleReset}
+            aria-label="Reset search"
+            className="flex rounded-md focus-visible:outline focus-visible:outline-offset"
+          >
+            <SfIconCancel />
+          </button>
+        }
+      />
       {isOpen && (
         <div ref={refs.setFloating} style={style} className="right-0 left-0">
           {isLoadingSnippets ? (

--- a/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
@@ -48,7 +48,7 @@ const mockAutocompleteRequest = async (phrase: string) => {
   return results;
 };
 
-export default function AutocompleteSearch() {
+export default function SearchBasic() {
   const inputRef = useRef<HTMLInputElement>(null);
   const [searchValue, setSearchValue] = useState('');
   const [isLoadingSnippets, setIsLoadingSnippets] = useState(false);
@@ -165,4 +165,4 @@ export default function AutocompleteSearch() {
 }
 
 // #endregion source
-AutocompleteSearch.getLayout = ShowcasePageLayout;
+SearchBasic.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
@@ -120,6 +120,7 @@ export default function SearchBasic() {
         value={searchValue}
         onChange={handleChange}
         onFocus={open}
+        aria-label="Search"
         placeholder="Search 'MacBook' or 'iPhone'..."
         slotPrefix={<SfIconSearch />}
         slotSuffix={

--- a/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
@@ -35,6 +35,7 @@ const mockProducts: Product[] = [
 ];
 
 // Just for presentation purposes. Replace mock request with the actual API call.
+// eslint-disable-next-line no-promise-executor-return
 const delay = () => new Promise((resolve) => setTimeout(resolve, Math.random() * 1000));
 const mockAutocompleteRequest = async (phrase: string) => {
   await delay();
@@ -113,7 +114,7 @@ export default function SearchBasic() {
   );
 
   return (
-    <form onSubmit={handleSubmit} ref={refs.setReference} className="relative">
+    <form role="search" onSubmit={handleSubmit} ref={refs.setReference} className="relative">
       <label>
         <SfInput
           ref={inputRef}

--- a/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
@@ -54,7 +54,7 @@ export default function SearchBasic() {
   const [isLoadingSnippets, setIsLoadingSnippets] = useState(false);
   const [snippets, setSnippets] = useState<{ highlight: string; rest: string; product: Product }[]>([]);
   const { isOpen, close, open } = useDisclosure();
-  const { refs, style } = useDropdown({ onClose: close, placement: 'bottom-start', middleware: [offset(4)] });
+  const { refs, style } = useDropdown({ isOpen, onClose: close, placement: 'bottom-start', middleware: [offset(4)] });
   useTrapFocus(refs.floating, { arrowKeysOn: true, activeState: isOpen, initialFocus: false });
 
   const handleSubmit = (event: FormEvent) => {

--- a/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
@@ -99,6 +99,7 @@ export default function SearchBasic() {
             const data = await mockAutocompleteRequest(searchValue);
             setSnippets(data);
           } catch (error) {
+            close();
             console.error(error);
           }
           setIsLoadingSnippets(false);
@@ -119,7 +120,7 @@ export default function SearchBasic() {
           value={searchValue}
           onChange={handleChange}
           onFocus={open}
-          placeholder="Search"
+          placeholder="Search 'MacBook' or 'iPhone'..."
           slotPrefix={<SfIconSearch />}
           slotSuffix={
             <button
@@ -139,25 +140,27 @@ export default function SearchBasic() {
             <div className="w-full h-20 flex justify-center items-center border border-solid border-neutral-100 rounded-md drop-shadow-md bg-white py-2">
               <SfLoaderCircular />
             </div>
-          ) : snippets.length > 0 ? (
-            <ul className="border border-solid border-neutral-100 rounded-md drop-shadow-md bg-white py-2">
-              {snippets.map(({ highlight, rest, product }) => (
-                <li key={product.id}>
-                  <SfListItem
-                    as="button"
-                    type="button"
-                    onClick={handleSelect(product.name)}
-                    className="flex justify-start"
-                  >
-                    <p className="text-left">
-                      <span>{highlight}</span>
-                      <span className="font-medium">{rest}</span>
-                    </p>
-                  </SfListItem>
-                </li>
-              ))}
-            </ul>
-          ) : null}
+          ) : (
+            snippets.length > 0 && (
+              <ul className="border border-solid border-neutral-100 rounded-md drop-shadow-md bg-white py-2">
+                {snippets.map(({ highlight, rest, product }) => (
+                  <li key={product.id}>
+                    <SfListItem
+                      as="button"
+                      type="button"
+                      onClick={handleSelect(product.name)}
+                      className="flex justify-start"
+                    >
+                      <p className="text-left">
+                        <span>{highlight}</span>
+                        <span className="font-medium">{rest}</span>
+                      </p>
+                    </SfListItem>
+                  </li>
+                ))}
+              </ul>
+            )
+          )}
         </div>
       )}
     </form>

--- a/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
@@ -1,7 +1,7 @@
 <template>
-  <form @submit.prevent="submit" ref="referenceRef" class="relative">
+  <form role="search" @submit.prevent="submit" ref="referenceRef" class="relative">
     <label>
-      <SfInput ref="inputRef" v-model="inputModel" @focus="open" placeholder="Search">
+      <SfInput ref="inputRef" v-model="inputModel" @focus="open" placeholder="Search 'MacBook' or 'iPhone'...">
         <template #prefix><SfIconSearch /></template>
         <template #suffix>
           <button

--- a/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
@@ -1,0 +1,149 @@
+<template>
+  <form @submit.prevent="submit" ref="referenceRef" class="relative">
+    <label>
+      <SfInput ref="inputRef" v-model="inputModel" @focus="open" placeholder="Search">
+        <template #prefix><SfIconSearch /></template>
+        <template #suffix>
+          <button
+            type="button"
+            @click="reset"
+            aria-label="Reset search"
+            class="flex rounded-md focus-visible:outline focus-visible:outline-offset"
+          >
+            <SfIconCancel /></button
+        ></template>
+      </SfInput>
+    </label>
+    <div v-if="isOpen" ref="floatingRef" :style="style" class="right-0 left-0">
+      <div
+        v-if="isLoadingSnippets"
+        class="w-full h-20 flex justify-center items-center border border-solid border-neutral-100 rounded-md drop-shadow-md bg-white py-2"
+      >
+        <SfLoaderCircular />
+      </div>
+      <ul
+        v-else-if="snippets.length > 0"
+        class="border border-solid border-neutral-100 rounded-md drop-shadow-md bg-white py-2"
+      >
+        <li v-for="{ highlight, rest, product } in snippets" :key="product.id">
+          <SfListItem tag="button" type="button" @click="() => selectValue(product.name)" class="flex justify-start">
+            <p class="text-left">
+              <span>{{ highlight }}</span>
+              <span class="font-medium">{{ rest }}</span>
+            </p>
+          </SfListItem>
+        </li>
+      </ul>
+    </div>
+  </form>
+</template>
+
+<script lang="ts" setup>
+import { ref, nextTick } from 'vue';
+import { offset } from '@floating-ui/vue';
+import {
+  SfIconCancel,
+  SfIconSearch,
+  SfInput,
+  SfListItem,
+  SfLoaderCircular,
+  useDisclosure,
+  useDropdown,
+  useTrapFocus,
+} from '@storefront-ui/vue';
+import { watchDebounced } from '@vueuse/shared';
+
+const inputModel = ref('');
+const inputRef = ref<HTMLInputElement | null>(null);
+const isLoadingSnippets = ref(false);
+const snippets = ref<{ highlight: string; rest: string; product: Product }[]>([]);
+const { isOpen, close, open } = useDisclosure();
+const { referenceRef, floatingRef, style } = useDropdown({
+  isOpen,
+  onClose: close,
+  placement: 'bottom-start',
+  middleware: [offset(4)],
+});
+useTrapFocus(floatingRef, { arrowKeysOn: true, activeState: isOpen, initialFocus: false });
+
+defineExpose({
+  inputRef,
+});
+
+const submit = () => {
+  close();
+  alert(`Search for phrase: ${inputModel.value}`);
+};
+
+const focusInput = () => {
+  inputRef.value?.focus();
+};
+
+const reset = () => {
+  inputModel.value = '';
+  snippets.value = [];
+  close();
+  focusInput();
+};
+
+const selectValue = (phrase: string) => {
+  console.log('SELECT: ', { phrase });
+  inputModel.value = phrase;
+  close();
+  // focusInput();
+};
+
+watchDebounced(
+  inputModel,
+  () => {
+    if (inputModel.value) {
+      const getSnippets = async () => {
+        open();
+        isLoadingSnippets.value = true;
+        try {
+          const data = await mockAutocompleteRequest(inputModel.value);
+          snippets.value = data;
+        } catch (error) {
+          console.error(error);
+        }
+        isLoadingSnippets.value = false;
+      };
+
+      getSnippets();
+    }
+  },
+  { debounce: 500 },
+);
+
+interface Product {
+  id: string;
+  name: string;
+}
+const mockProducts: Product[] = [
+  { id: 'ip-14', name: 'iPhone 14' },
+  { id: 'ip-14-pro', name: 'iPhone 14 Pro' },
+  { id: 'ip-14-pro-max', name: 'iPhone 14 Pro Max' },
+  { id: 'ip-14-plus', name: 'iPhone 14 Plus' },
+  { id: 'ip-13', name: 'iPhone 13' },
+  { id: 'ip-13-mini', name: 'iPhone 13 mini' },
+  { id: 'ip-12', name: 'iPhone 12' },
+  { id: 'ip-11', name: 'iPhone 11' },
+  { id: 'mb-air', name: 'MacBook Air' },
+  { id: 'mb-pro-13', name: 'MacBook Pro 13"' },
+  { id: 'mb-pro-14', name: 'MacBook Pro 14"' },
+  { id: 'mb-pro-16', name: 'MacBook Pro 16"' },
+];
+// Just for presentation purposes. Replace mock request with the actual API call.
+const delay = () => new Promise((resolve) => setTimeout(resolve, Math.random() * 1000));
+const mockAutocompleteRequest = async (phrase: string) => {
+  await delay();
+  const results = mockProducts
+    .filter((product) => product.name.toLowerCase().startsWith(phrase.toLowerCase()))
+    .map((product) => {
+      const highlight = product.name.substring(0, phrase.length);
+      const rest = product.name.substring(phrase.length);
+      return { highlight, rest, product };
+    });
+  return results;
+};
+</script>

--- a/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
@@ -1,19 +1,17 @@
 <template>
   <form role="search" @submit.prevent="submit" ref="referenceRef" class="relative">
-    <label>
-      <SfInput ref="inputRef" v-model="inputModel" @focus="open" placeholder="Search 'MacBook' or 'iPhone'...">
-        <template #prefix><SfIconSearch /></template>
-        <template #suffix>
-          <button
-            type="button"
-            @click="reset"
-            aria-label="Reset search"
-            class="flex rounded-md focus-visible:outline focus-visible:outline-offset"
-          >
-            <SfIconCancel /></button
-        ></template>
-      </SfInput>
-    </label>
+    <SfInput ref="inputRef" v-model="inputModel" @focus="open" placeholder="Search 'MacBook' or 'iPhone'...">
+      <template #prefix><SfIconSearch /></template>
+      <template #suffix>
+        <button
+          type="button"
+          @click="reset"
+          aria-label="Reset search"
+          class="flex rounded-md focus-visible:outline focus-visible:outline-offset"
+        >
+          <SfIconCancel /></button
+      ></template>
+    </SfInput>
     <div v-if="isOpen" ref="floatingRef" :style="style" class="right-0 left-0">
       <div
         v-if="isLoadingSnippets"

--- a/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
@@ -107,6 +107,7 @@ watchDebounced(
           const data = await mockAutocompleteRequest(inputModel.value);
           snippets.value = data;
         } catch (error) {
+          close();
           console.error(error);
         }
         isLoadingSnippets.value = false;

--- a/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
@@ -1,6 +1,12 @@
 <template>
   <form role="search" @submit.prevent="submit" ref="referenceRef" class="relative">
-    <SfInput ref="inputRef" v-model="inputModel" @focus="open" placeholder="Search 'MacBook' or 'iPhone'...">
+    <SfInput
+      ref="inputRef"
+      v-model="inputModel"
+      @focus="open"
+      aria-label="Search"
+      placeholder="Search 'MacBook' or 'iPhone'..."
+    >
       <template #prefix><SfIconSearch /></template>
       <template #suffix>
         <button

--- a/packages/sfui/frameworks/vue/components/SfInput/SfInput.vue
+++ b/packages/sfui/frameworks/vue/components/SfInput/SfInput.vue
@@ -34,7 +34,6 @@ const props = defineProps({
 });
 const emit = defineEmits<{
   (event: 'update:modelValue', value: string): void;
-  (event: 'focus'): void;
 }>();
 const { modelValue, invalid } = toRefs(props);
 const { isFocusVisible } = useFocusVisible({ isTextInput: true });

--- a/packages/sfui/frameworks/vue/components/SfInput/SfInput.vue
+++ b/packages/sfui/frameworks/vue/components/SfInput/SfInput.vue
@@ -33,7 +33,7 @@ const props = defineProps({
   },
 });
 const emit = defineEmits<{
-  (event: 'update:modelValue', value: string): void;
+  (event: 'update:modelValue', value: string | number): void;
 }>();
 const { modelValue, invalid } = toRefs(props);
 const { isFocusVisible } = useFocusVisible({ isTextInput: true });
@@ -43,9 +43,9 @@ Internal state has been implemented due to useFocusVisible and how it works. Mai
 it captures native HTMLElement.prototype.focus method. It makes value disappear under certain circumstances,
 so it's importatnt to keep it here, or to always pass modelValue to the component.
 */
-const internalState = ref();
+const internalState = ref<string | number>();
 const inputValue = computed({
-  get: () => modelValue.value || internalState.value,
+  get: () => modelValue.value ?? internalState.value,
   set: (value) => {
     emit('update:modelValue', value);
     internalState.value = value;


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes [SFUI2-669](https://vsf.atlassian.net/browse/SFUI2-669)

# Scope of work

<!-- describe what you did -->

- Adds Search block. First simple example with autocomplete.
- Small fixes in Input Vue component: remove focus event emit, adjust `??` operator to catch empty string as a value.

# Screenshots of visual changes

<!-- if visual changes applied -->
<img width="1254" alt="Search" src="https://user-images.githubusercontent.com/34419118/234205942-be1bb1df-b234-48d5-85db-6c21992e53ea.png">

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [ ] cypress tests created


[SFUI2-669]: https://vsf.atlassian.net/browse/SFUI2-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ