### PR TITLE
fix: added fix for resolving enums outside component scope

### DIFF
--- a/apps/preview/next/next.config.mjs
+++ b/apps/preview/next/next.config.mjs
@@ -84,7 +84,7 @@ export default {
         },
       });
 
-      const reactPackage = resolve(process.cwd(), '..', '..', '..', 'packages', 'sfui', 'frameworks', 'react', 'index.ts');
+      const reactPackage = resolve(process.cwd(), '..', '..', '..', 'packages', 'sfui', 'frameworks', 'react', 'index.ts', '*.tsx');
       config.resolve.alias = {
         ...config.resolve.alias,
         '@storefront-ui/react': reactPackage,


### PR DESCRIPTION
# Related issue
https://vsf.atlassian.net/browse/SFUI2-859?atlOrigin=eyJpIjoiZTRjZmJmYjZhYjgxNGY1Y2FiYTRhYjUwYTViNjhhN2EiLCJwIjoiaiJ9

# Scope of work

- adjusted alias resolving

# Screenshots of visual changes

Tests success after moving enums outside of component scope:
<img width="1102" alt="Zrzut ekranu 2023-04-26 o 09 56 11" src="https://user-images.githubusercontent.com/41487496/234508586-5a13459a-616c-4151-b354-4c5d94a80904.png">


# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
