### PR TITLE
fix: search block show reset button only when value

### DIFF
--- a/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
@@ -57,6 +57,7 @@ export default function SearchBasic() {
   const { isOpen, close, open } = useDisclosure();
   const { refs, style } = useDropdown({ isOpen, onClose: close, placement: 'bottom-start', middleware: [offset(4)] });
   useTrapFocus(refs.floating, { arrowKeysOn: true, activeState: isOpen, initialFocus: false });
+  const isResetButton = Boolean(searchValue);
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
@@ -124,14 +125,16 @@ export default function SearchBasic() {
         placeholder="Search 'MacBook' or 'iPhone'..."
         slotPrefix={<SfIconSearch />}
         slotSuffix={
-          <button
-            type="button"
-            onClick={handleReset}
-            aria-label="Reset search"
-            className="flex rounded-md focus-visible:outline focus-visible:outline-offset"
-          >
-            <SfIconCancel />
-          </button>
+          isResetButton && (
+            <button
+              type="button"
+              onClick={handleReset}
+              aria-label="Reset search"
+              className="flex rounded-md focus-visible:outline focus-visible:outline-offset"
+            >
+              <SfIconCancel />
+            </button>
+          )
         }
       />
       {isOpen && (

--- a/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
@@ -1,19 +1,20 @@
 <template>
-  <form role="search" @submit.prevent="submit" ref="referenceRef" class="relative">
+  <form ref="referenceRef" role="search" class="relative" @submit.prevent="submit">
     <SfInput
       ref="inputRef"
       v-model="inputModel"
-      @focus="open"
       aria-label="Search"
       placeholder="Search 'MacBook' or 'iPhone'..."
+      @focus="open"
     >
       <template #prefix><SfIconSearch /></template>
       <template #suffix>
         <button
+          v-if="isResetButton"
           type="button"
-          @click="reset"
           aria-label="Reset search"
           class="flex rounded-md focus-visible:outline focus-visible:outline-offset"
+          @click="reset"
         >
           <SfIconCancel /></button
       ></template>
@@ -30,7 +31,7 @@
         class="border border-solid border-neutral-100 rounded-md drop-shadow-md bg-white py-2"
       >
         <li v-for="{ highlight, rest, product } in snippets" :key="product.id">
-          <SfListItem tag="button" type="button" @click="() => selectValue(product.name)" class="flex justify-start">
+          <SfListItem tag="button" type="button" class="flex justify-start" @click="() => selectValue(product.name)">
             <p class="text-left">
               <span>{{ highlight }}</span>
               <span class="font-medium">{{ rest }}</span>
@@ -43,7 +44,7 @@
 </template>
 
 <script lang="ts" setup>
-import { type Ref, ref, watch } from 'vue';
+import { type Ref, ref, watch, computed } from 'vue';
 import { offset } from '@floating-ui/vue';
 import { watchDebounced } from '@vueuse/shared';
 import { unrefElement } from '@vueuse/core';
@@ -70,6 +71,7 @@ const { referenceRef, floatingRef, style } = useDropdown({
   middleware: [offset(4)],
 });
 useTrapFocus(floatingRef as Ref<HTMLElement>, { arrowKeysOn: true, activeState: isOpen, initialFocus: false });
+const isResetButton = computed(() => Boolean(inputModel.value));
 
 const submit = () => {
   close();

--- a/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
@@ -10,7 +10,7 @@
       <template #prefix><SfIconSearch /></template>
       <template #suffix>
         <button
-          v-if="isResetButton"
+          v-if="inputModel"
           type="button"
           aria-label="Reset search"
           class="flex rounded-md focus-visible:outline focus-visible:outline-offset"
@@ -44,7 +44,7 @@
 </template>
 
 <script lang="ts" setup>
-import { type Ref, ref, watch, computed } from 'vue';
+import { type Ref, ref, watch } from 'vue';
 import { offset } from '@floating-ui/vue';
 import { watchDebounced } from '@vueuse/shared';
 import { unrefElement } from '@vueuse/core';
@@ -71,7 +71,6 @@ const { referenceRef, floatingRef, style } = useDropdown({
   middleware: [offset(4)],
 });
 useTrapFocus(floatingRef as Ref<HTMLElement>, { arrowKeysOn: true, activeState: isOpen, initialFocus: false });
-const isResetButton = computed(() => Boolean(inputModel.value));
 
 const submit = () => {
   close();


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes [SFUI2-669](https://vsf.atlassian.net/browse/SFUI2-669)

# Scope of work

<!-- describe what you did -->

- fix of reset button behaviour

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [ ] cypress tests created


[SFUI2-669]: https://vsf.atlassian.net/browse/SFUI2-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ