### PR TITLE
ci: split docs from building step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: yarn lint
 
   build:
-    name: Build Nuxt, Next, Docs
+    name: Build Nuxt, Next
     needs: [cache, lint]
     runs-on: ubuntu-latest
     steps:
@@ -93,6 +93,23 @@ jobs:
         run: yarn --immutable
       - name: Run build
         run: yarn build
+
+  build-docs:
+    name: Build Docs
+    needs: [cache, lint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.node-version'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn --immutable
+      - name: Run build
+        run: yarn build:docs
 
   build-release:
     name: Build packages for release

--- a/apps/docs/components/package.json
+++ b/apps/docs/components/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "dev:docs": "yarn update-files && concurrently \"vuepress dev\" \"yarn watch-base\" \"yarn watch-blocks\" \"yarn watch-hooks\" \"yarn watch-customization\"",
-    "build": "yarn update-files && vuepress build",
-    "build:docs": "yarn build",
+    "build:not-run": "yarn update-files && vuepress build",
+    "build:docs": "yarn build:not-run",
     "watch-base": "chokidar --initial \"./components/**/*.md\" -c \"yarn update-base --event {event} --path {path};\"",
     "watch-blocks": "chokidar --initial \"./blocks/*.md\" -c \"yarn update-blocks --event {event} --path {path};\"",
     "watch-hooks": "chokidar --initial \"./hooks/*.md\" -c \"yarn update-hooks --event {event} --path {path};\"",

--- a/apps/docs/components/package.json
+++ b/apps/docs/components/package.json
@@ -8,8 +8,7 @@
   },
   "scripts": {
     "dev:docs": "yarn update-files && concurrently \"vuepress dev\" \"yarn watch-base\" \"yarn watch-blocks\" \"yarn watch-hooks\" \"yarn watch-customization\"",
-    "build:not-run": "yarn update-files && vuepress build",
-    "build:docs": "yarn build:not-run",
+    "build:docs": "yarn update-files && vuepress build",
     "watch-base": "chokidar --initial \"./components/**/*.md\" -c \"yarn update-base --event {event} --path {path};\"",
     "watch-blocks": "chokidar --initial \"./blocks/*.md\" -c \"yarn update-blocks --event {event} --path {path};\"",
     "watch-hooks": "chokidar --initial \"./hooks/*.md\" -c \"yarn update-hooks --event {event} --path {path};\"",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "yarn build:typography && yarn build:peer-next && yarn build:tailwind-config && turbo run lint",
     "lint:fix": "turbo run lint:fix",
     "lint:fix:sfui": "turbo run lint:fix:sfui",
-    "build:docs": "turbo run build:docs",
+    "build:docs": "yarn build:peer-next && turbo run build:docs",
     "build:next": "turbo run build:next",
     "build:nuxt": "turbo run build:nuxt",
     "build:react": "turbo run build:react",

--- a/turbo.json
+++ b/turbo.json
@@ -9,8 +9,7 @@
         "build:tailwind-config",
         "build:release",
         "build:next",
-        "build:nuxt",
-        "build:docs"
+        "build:nuxt"
       ],
       "outputs": [
         "dist/**"


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

Just because we have slow built step on CI jobs (around 10 minutes) IMHO its good idea to split whatever we can and run it in parallel, building docs can be splitted like that. With this simple change time is cut from 10 minutes to 6 minutes 

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
