### PR TITLE
Mayashavin/doc product card

### DIFF
--- a/apps/preview/next/pages/showcases/ProductCard/ProductCardHorizontal.tsx
+++ b/apps/preview/next/pages/showcases/ProductCard/ProductCardHorizontal.tsx
@@ -16,14 +16,32 @@ export default function ProductCardHorizontal() {
     const nextValue = parseFloat(currentValue);
     set(Number(clamp(nextValue, min, max)));
   }
+
+  const product = {
+    title: 'Smartwatch Fitness Tracker',
+    shortDescription: 'Lightweight • Non slip • Flexible outsole • Easy to wear on and off',
+    price: '2345,99',
+    currency_code: '$',
+    image: card,
+    variants: {
+      color: {
+        label: 'Color',
+        value: 'Red',
+      },
+      size: {
+        label: 'Size',
+        value: '6.5',
+      }
+    },
+  }
   return (
     <div className="relative flex border-b-[1px] border-neutral-200 hover:shadow-lg min-w-[320px] max-w-[640px] p-4">
       <div className="relative overflow-hidden rounded-md w-[100px] sm:w-[176px]">
         <SfLink href="#">
           <img
             className="w-full h-auto border rounded-md border-neutral-200"
-            src={card.src}
-            alt="alt"
+            src={product.image.src}
+            alt={product.title}
             width={300}
             height={300}
           />
@@ -35,22 +53,24 @@ export default function ProductCardHorizontal() {
       </div>
       <div className="flex flex-col pl-4 min-w-[180px] flex-1">
         <SfLink href="#" variant="secondary" className="no-underline typography-text-sm sm:typography-text-lg">
-          Smartwatch Fitness Tracker
+          {product.title}
         </SfLink>
         <div className="my-2 sm:mb-0">
           <ul className="text-xs font-normal leading-5 sm:typography-text-sm text-neutral-700">
             <li>
-              <span className="mr-1">Size:</span>
-              <span className="font-medium">6.5</span>
+              <span className="mr-1">{product.variants.size.label}:</span>
+              <span className="font-medium">{product.variants.size.value}</span>
             </li>
             <li>
-              <span className="mr-1">Color:</span>
-              <span className="font-medium">Red</span>
+              <span className="mr-1">{product.variants.color.label}:</span>
+              <span className="font-medium">{product.variants.color.value}</span>
             </li>
           </ul>
         </div>
         <div className="items-center sm:mt-auto sm:flex">
-          <span className="font-bold sm:ml-auto sm:order-1 typography-text-sm sm:typography-text-lg">$2,345.99</span>
+          <span className="font-bold sm:ml-auto sm:order-1 typography-text-sm sm:typography-text-lg">
+            {product.currency_code}{product.price}
+          </span>
           <div className="flex items-center justify-between mt-4 sm:mt-0">
             <div className="flex border border-neutral-300 rounded-md">
               <SfButton

--- a/apps/preview/next/pages/showcases/ProductCard/ProductCardVertical.tsx
+++ b/apps/preview/next/pages/showcases/ProductCard/ProductCardVertical.tsx
@@ -4,13 +4,23 @@ import { SfButton, SfRating, SfCounter, SfLink, SfIconShoppingCart, SfIconFavori
 import productImage from '@assets/sneakers.png';
 
 export default function ProductCardVertical() {
+  const product = {
+    title: 'Athletic mens walking sneakers',
+    ratings: 4,
+    reviews: ['some reviews', 'some reviews', 'some reviews'],
+    shortDescription: 'Lightweight • Non slip • Flexible outsole • Easy to wear on and off',
+    price: '2345,99',
+    currency_code: '$',
+    image: productImage,
+  }
+
   return (
     <div className="border border-neutral-200 rounded-md hover:shadow-lg max-w-[300px]">
       <div className="relative">
         <SfLink href="#">
           <img
-            src={productImage.src}
-            alt="Great product"
+            src={product.image.src}
+            alt={product.title}
             className="object-cover h-auto rounded-md aspect-square"
             width={300}
             height={300}
@@ -29,19 +39,19 @@ export default function ProductCardVertical() {
       </div>
       <div className="p-4 border-t border-neutral-200">
         <SfLink href="#" variant="secondary" className="no-underline">
-          Athletic mens walking sneakers
+          {product.title}
         </SfLink>
         <div className="flex items-center pt-1">
-          <SfRating size="xs" value={5} max={5} />
+          <SfRating size="xs" value={product.ratings} max={5} />
 
           <SfLink href="#" variant="secondary" className="pl-1 no-underline">
-            <SfCounter size="xs">{123}</SfCounter>
+            <SfCounter size="xs">{product.reviews.length}</SfCounter>
           </SfLink>
         </div>
         <p className="block py-2 font-normal typography-text-sm text-neutral-700">
-          Lightweight • Non slip • Flexible outsole • Easy to wear on and off
+          {product.shortDescription}
         </p>
-        <span className="block pb-2 font-bold typography-text-lg">$2345,99</span>
+        <span className="block pb-2 font-bold typography-text-lg">{product.currency_code}{product.price}</span>
         <SfButton type="button" size="sm" slotPrefix={<SfIconShoppingCart size="sm" />}>
           Add to cart
         </SfButton>

--- a/apps/preview/next/pages/showcases/ProductCard/ProductCardVertical.tsx
+++ b/apps/preview/next/pages/showcases/ProductCard/ProductCardVertical.tsx
@@ -15,7 +15,7 @@ export default function ProductCardVertical() {
   }
 
   return (
-    <div className="border border-neutral-200 rounded-md hover:shadow-lg max-w-[300px]">
+    <article className="border border-neutral-200 rounded-md hover:shadow-lg max-w-[300px]">
       <div className="relative">
         <SfLink href="#">
           <img

--- a/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardHorizontal.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardHorizontal.vue
@@ -4,8 +4,8 @@
       <SfLink href="#">
         <img
           class="w-full h-auto border rounded-md border-neutral-200"
-          :src="card"
-          alt="Smartwatch Fitness Tracker"
+          :src="product.image"
+          :alt="product.title"
           :width="176"
           :height="176"
         />
@@ -17,22 +17,24 @@
     </div>
     <div class="flex flex-col pl-4 min-w-[180px] flex-1">
       <SfLink href="#" variant="secondary" class="no-underline typography-text-sm sm:typography-text-lg">
-        Smartwatch Fitness Tracker
+        {{ product.title }}
       </SfLink>
       <div class="my-2 sm:mb-0">
         <ul class="font-normal leading-5 typography-text-xs sm:typography-text-sm text-neutral-700">
           <li>
-            <span class="mr-1">Size:</span>
-            <span class="font-medium">6.5</span>
+            <span class="mr-1">{{ product.variants.size.label }}:</span>
+            <span class="font-medium">{{ product.variants.size.value }}</span>
           </li>
           <li>
-            <span class="mr-1">Color:</span>
-            <span class="font-medium">Red</span>
+            <span class="mr-1">{{ product.variants.color.label }}:</span>
+            <span class="font-medium">{{ product.variants.color.value }}</span>
           </li>
         </ul>
       </div>
       <div class="items-center sm:mt-auto sm:flex">
-        <span class="font-bold sm:ml-auto sm:order-1 typography-text-sm sm:typography-text-lg">$2,345.99 </span>
+        <span class="font-bold sm:ml-auto sm:order-1 typography-text-sm sm:typography-text-lg">
+          {{ product.currency_code }}{{ product.price }}
+        </span>
         <div class="flex items-center justify-between mt-4 sm:mt-0">
           <div class="flex border border-neutral-300 rounded-md">
             <SfButton
@@ -91,6 +93,23 @@ import card from '@assets/smartwatch.png';
 import { clamp } from '@storefront-ui/shared';
 import { useCounter } from '@vueuse/core';
 
+const product = {
+  title: 'Smartwatch Fitness Tracker',
+  shortDescription: 'Lightweight • Non slip • Flexible outsole • Easy to wear on and off',
+  price: '2345,99',
+  currency_code: '$',
+  image: card,
+  variants: {
+    color: {
+      label: 'Color',
+      value: 'Red',
+    },
+    size: {
+      label: 'Size',
+      value: '6.5',
+    },
+  },
+};
 const min = ref(1);
 const max = ref(10);
 const inputId = useId();

--- a/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardVertical.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardVertical.vue
@@ -27,7 +27,7 @@
         <SfRating size="xs" :value="product.ratings" :max="5" />
 
         <SfLink href="#" variant="secondary" class="pl-1 no-underline">
-          <SfCounter size="xs">{{ product.reviews.length}}</SfCounter>
+          <SfCounter size="xs">{{ product.reviews.length }}</SfCounter>
         </SfLink>
       </div>
       <p class="block py-2 font-normal leading-5 typography-text-sm text-neutral-700">
@@ -56,6 +56,5 @@ const product = {
   price: '2345,99',
   currency_code: '$',
   image: productImage,
-}
-
+};
 </script>

--- a/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardVertical.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardVertical.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="border border-neutral-200 rounded-md hover:shadow-lg max-w-[300px]">
+  <article class="border border-neutral-200 rounded-md hover:shadow-lg max-w-[300px]">
     <div class="relative">
       <SfLink href="#">
         <img
-          :src="productImage"
-          alt="Great product"
+          :src="product.image"
+          :alt="product.title"
           class="block object-cover h-auto rounded-md aspect-square"
           :width="300"
           :height="300"
@@ -22,18 +22,18 @@
       </SfButton>
     </div>
     <div class="p-4 border-t border-neutral-200">
-      <SfLink href="#" variant="secondary" class="no-underline"> Athletic mens walking sneakers </SfLink>
+      <SfLink href="#" variant="secondary" class="no-underline"> {{ product.title }} </SfLink>
       <div class="flex items-center pt-1">
-        <SfRating size="xs" :value="5" :max="5" />
+        <SfRating size="xs" :value="product.ratings" :max="5" />
 
         <SfLink href="#" variant="secondary" class="pl-1 no-underline">
-          <SfCounter size="xs">123</SfCounter>
+          <SfCounter size="xs">{{ product.reviews.length}}</SfCounter>
         </SfLink>
       </div>
       <p class="block py-2 font-normal leading-5 typography-text-sm text-neutral-700">
-        Lightweight • Non slip • Flexible outsole • Easy to wear on and off
+        {{ product.shortDescription }}
       </p>
-      <span class="block pb-2 font-bold typography-text-lg">$2345,99</span>
+      <span class="block pb-2 font-bold typography-text-lg">{{ product.currency_code }}{{ product.price }}</span>
       <SfButton type="button" size="sm">
         <template #prefix>
           <SfIconShoppingCart size="sm" />
@@ -41,11 +41,21 @@
         Add to cart
       </SfButton>
     </div>
-  </div>
+  </article>
 </template>
 
 <script lang="ts" setup>
 import { SfRating, SfCounter, SfLink, SfButton, SfIconShoppingCart, SfIconFavorite } from '@storefront-ui/vue';
-
 import productImage from '@assets/sneakers.png';
+
+const product = {
+  title: 'Athletic mens walking sneakers',
+  ratings: 4,
+  reviews: ['some reviews', 'some reviews', 'some reviews'],
+  shortDescription: 'Lightweight • Non slip • Flexible outsole • Easy to wear on and off',
+  price: '2345,99',
+  currency_code: '$',
+  image: productImage,
+}
+
 </script>


### PR DESCRIPTION
# Related issue

#2647 

Closes #2647 

# Scope of work

- Put all the static information about product under variable `product`.
- Change the wrapper component to `article` for better HTML syntax usage (also for accessibility)

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
