### PR TITLE
fix: adjusted paddings in sfbutton for rounded

### DIFF
--- a/packages/sfui/frameworks/react/components/SfButton/SfButton.tsx
+++ b/packages/sfui/frameworks/react/components/SfButton/SfButton.tsx
@@ -17,7 +17,7 @@ const getSizeClasses = (size: SfButtonProps['size'], square: SfButtonProps['squa
     case SfButtonSize.sm:
       return [square ? 'p-1.5' : 'leading-5 text-sm py-1.5 px-3', 'gap-1.5'];
     case SfButtonSize.lg:
-      return [square ? 'p-4' : 'py-3 leading-6 px-6', 'gap-3'];
+      return [square ? 'p-3' : 'py-3 leading-6 px-6', 'gap-3'];
     default:
       return [square ? 'p-2' : 'py-2 leading-6 px-4', 'gap-2'];
   }

--- a/packages/sfui/frameworks/vue/components/SfButton/SfButton.vue
+++ b/packages/sfui/frameworks/vue/components/SfButton/SfButton.vue
@@ -43,7 +43,7 @@ const sizeClasses = computed(() => {
     case SfButtonSize.sm:
       return [square.value ? 'p-1.5' : 'leading-5 text-sm py-1.5 px-3', 'gap-1.5'];
     case SfButtonSize.lg:
-      return [square.value ? 'p-4' : 'py-3 leading-6 px-6', 'gap-3'];
+      return [square.value ? 'p-3' : 'py-3 leading-6 px-6', 'gap-3'];
     default:
       return [square.value ? 'p-2' : 'py-2 leading-6 px-4', 'gap-2'];
   }


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1066?atlOrigin=eyJpIjoiMmNkZDU2MDgwMjY4NDVlM2E5MWNkMDRiNDNkMzExYmIiLCJwIjoiaiJ9


# Scope of work

- adjusted paddings from 16px to 12px for large version of button.

# Screenshots of visual changes

<img width="352" alt="Zrzut ekranu 2023-05-4 o 10 18 57" src="https://user-images.githubusercontent.com/41487496/236148788-2c36cd0b-1e52-4510-a330-da9add395ee8.png">


# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
