### PR TITLE
fix: unified examples for switch component

### DIFF
--- a/apps/preview/nuxt/pages/showcases/Switch/SwitchWithoutLabel.vue
+++ b/apps/preview/nuxt/pages/showcases/Switch/SwitchWithoutLabel.vue
@@ -6,5 +6,5 @@
 import { ref } from 'vue';
 import { SfSwitch } from '@storefront-ui/vue';
 
-const modelCheck = ref(true);
+const modelCheck = ref(false);
 </script>


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1072?atlOrigin=eyJpIjoiMjA0NzIwMzcwNjEwNGUzNjk1ODk3MTUxZTYwOTc1OWEiLCJwIjoiaiJ9

# Scope of work

- unified initial Switch state for vue and react

# Screenshots of visual changes

-

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
