### PR TITLE
fix: mega menu improvements

### DIFF
--- a/apps/docs/components/blocks/MegaMenu.md
+++ b/apps/docs/components/blocks/MegaMenu.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: Mega menu is a type of website navigation menu that typically displays a list of links and subcategories in a larger, more complex format than a traditional drop-down or fly-out menu. 
+hideToc: true
 ---
 # MegaMenu
 

--- a/apps/docs/components/blocks/NewsletterBox.md
+++ b/apps/docs/components/blocks/NewsletterBox.md
@@ -2,6 +2,7 @@
 layout: DefaultLayout
 hideBreadcrumbs: true
 description: A NewsletterBox supports a typical e-commerce newsletter subscription process.
+hideToc: true
 ---
 # NewsletterBox
 

--- a/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
@@ -155,7 +155,7 @@ export default function BaseMegaMenu() {
           <a
             href="/"
             aria-label="SF Homepage"
-            className="inline-block mr-2 text-white md:mr-10 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
+            className="flex shrink-0 mr-2 text-white md:mr-10 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
           >
             <picture>
               <source srcSet={brandLogo.src} media="(min-width: 1024px)" />

--- a/apps/preview/next/pages/showcases/MegaMenu/MegaMenuNavigation.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/MegaMenuNavigation.tsx
@@ -442,10 +442,10 @@ export default function MegaMenuNavigation() {
                   variant="tertiary"
                   onMouseEnter={handleOpenMenu([menuNode.key])}
                   onClick={handleOpenMenu([menuNode.key])}
-                  className="mr-2"
+                  className="group mr-2 !text-neutral-900 hover:bg-neutral-200 hover:!text-neutral-700 active:!bg-neutral-300 active:!text-neutral-900"
                 >
                   <span>{menuNode.value.label}</span>
-                  <SfIconChevronRight className="rotate-90" />
+                  <SfIconChevronRight className="rotate-90 text-neutral-500 group-hover:text-neutral-700 group-active:text-neutral-900" />
                 </SfButton>
 
                 {isOpen && activeNode.length === 1 && activeNode[0] === menuNode.key && (

--- a/apps/preview/next/pages/showcases/MegaMenu/MegaMenuNavigation.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/MegaMenuNavigation.tsx
@@ -534,7 +534,7 @@ export default function MegaMenuNavigation() {
                       >
                         <div className="flex items-center">
                           <SfIconArrowBack className="text-neutral-500" />
-                          <p className="ml-5">{activeMenu.value.label}</p>
+                          <p className="ml-5 font-medium">{activeMenu.value.label}</p>
                         </div>
                       </SfListItem>
                     </li>

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
@@ -9,7 +9,7 @@
         <a
           href="/"
           aria-label="SF Homepage"
-          class="inline-block text-white mr-2 md:mr-10 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
+          class="flex shrink-0 text-white mr-2 md:mr-10 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
         >
           <picture>
             <source :srcset="brandLogo" media="(min-width: 1024px)" />

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/MegaMenuNavigation.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/MegaMenuNavigation.vue
@@ -126,7 +126,7 @@
               >
                 <div class="flex items-center">
                   <SfIconArrowBack class="text-neutral-500" />
-                  <p class="ml-5">{{ activeMenu.value.label }}</p>
+                  <p class="ml-5 font-medium">{{ activeMenu.value.label }}</p>
                 </div>
               </SfListItem>
             </li>

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/MegaMenuNavigation.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/MegaMenuNavigation.vue
@@ -56,12 +56,14 @@
           <li v-for="menuNode in content.children" :key="menuNode.key">
             <SfButton
               variant="tertiary"
-              class="mr-2"
+              class="group mr-2 !text-neutral-900 hover:bg-neutral-200 hover:!text-neutral-700 active:!bg-neutral-300 active:!text-neutral-900"
               @mouseenter="openMenu([menuNode.key])"
               @click="openMenu([menuNode.key])"
             >
               <span>{{ menuNode.value.label }}</span>
-              <SfIconChevronRight class="rotate-90" />
+              <SfIconChevronRight
+                class="rotate-90 text-neutral-500 group-hover:text-neutral-700 group-active:text-neutral-900"
+              />
             </SfButton>
 
             <div


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes
- [SFUI2-1105](https://vsf.atlassian.net/browse/SFUI2-1105)
- [SFUI2-1106](https://vsf.atlassian.net/browse/SFUI2-1106)
- [SFUI2-1107](https://vsf.atlassian.net/browse/SFUI2-1107)
- [SFUI2-1108](https://vsf.atlassian.net/browse/SFUI2-1108)

# Scope of work

- Hide ToC in Mega Menu and Newsletter pages in the docs.
- Fix font weight of the title/back button in nested navigation mega menu on mobile devices.
- Fix size of the logo in base mega menu example.
- Fix styles (mostly colors) of the buttons in extended navigation bar.

<!-- describe what you did -->

# Screenshots of visual changes
<img width="409" alt="Screenshot 2023-05-05 at 10 33 35" src="https://user-images.githubusercontent.com/34419118/236418380-f1f8591c-19e6-4a1c-bac6-31a2814788a6.png">
<img width="499" alt="Screenshot 2023-05-05 at 11 05 29" src="https://user-images.githubusercontent.com/34419118/236418385-4f7dad00-cbbb-41db-868c-653c4bf1317d.png">
<img width="340" alt="Screenshot 2023-05-05 at 11 05 50" src="https://user-images.githubusercontent.com/34419118/236418387-470ac51c-29a3-4b58-9634-1d08bdd22020.png">

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [ ] cypress tests created


[SFUI2-1105]: https://vsf.atlassian.net/browse/SFUI2-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFUI2-1106]: https://vsf.atlassian.net/browse/SFUI2-1106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFUI2-1107]: https://vsf.atlassian.net/browse/SFUI2-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFUI2-1108]: https://vsf.atlassian.net/browse/SFUI2-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ