### PR TITLE
ci: fix ci env handling

### DIFF
--- a/.vuestorefrontcloud/test-next/docker/Dockerfile
+++ b/.vuestorefrontcloud/test-next/docker/Dockerfile
@@ -5,12 +5,14 @@ WORKDIR /var/www
 COPY . .
 
 ARG VITE_DOCS_BASEPATH
-ENV VITE_DOCS_BASEPATH = VITE_DOCS_BASEPATH
+ARG VITE_DOCS_EXAMPLES_REACT_PATH
 
-ENV DOCS_EXAMPLES_REACT_PATH=https://docs.storefrontui.io/v2-react
-RUN  yarn install \
-  && yarn build:peer-next \
-  && yarn build:next
+ENV VITE_DOCS_BASEPATH=$VITE_DOCS_BASEPATH
+ENV VITE_DOCS_EXAMPLES_REACT_PATH=$VITE_DOCS_EXAMPLES_REACT_PATH
+
+RUN yarn
+RUN yarn build:peer-next
+RUN yarn build:next
 
 WORKDIR /var/www/apps/preview/next
 

--- a/.vuestorefrontcloud/test-nuxt/docker/Dockerfile
+++ b/.vuestorefrontcloud/test-nuxt/docker/Dockerfile
@@ -4,10 +4,15 @@ WORKDIR /var/www
 
 COPY . .
 
-ENV VITE_DOCS_EXAMPLES_VUE_PATH=https://docs.storefrontui.io/v2-vue
-RUN  yarn install \
-  && yarn build:peer-next \
-  && yarn build:nuxt
+ARG VITE_DOCS_BASEPATH
+ARG VITE_DOCS_EXAMPLES_VUE_PATH
+
+ENV VITE_DOCS_BASEPATH=$VITE_DOCS_BASEPATH
+ENV VITE_DOCS_EXAMPLES_VUE_PATH=$VITE_DOCS_EXAMPLES_VUE_PATH
+
+RUN yarn
+RUN yarn build:peer-next
+RUN yarn build:nuxt
 
 WORKDIR /var/www/apps/preview/nuxt
 

--- a/apps/preview/next/next.config.mjs
+++ b/apps/preview/next/next.config.mjs
@@ -6,10 +6,10 @@ const isProd = process.env.PROD === 'true';
 /** @type {import('next').NextConfig} */
 export default {
   env: {
-    DOCS_EXAMPLES_REACT_PATH: process.env.DOCS_EXAMPLES_REACT_PATH,
+    DOCS_EXAMPLES_REACT_PATH: process.env.VITE_DOCS_EXAMPLES_REACT_PATH,
   },
-  basePath: process.env.DOCS_EXAMPLES_REACT_PATH
-    ? new URL(process.env.DOCS_EXAMPLES_REACT_PATH).pathname
+  basePath: process.env.VITE_DOCS_EXAMPLES_REACT_PATH
+    ? new URL(process.env.VITE_DOCS_EXAMPLES_REACT_PATH).pathname
     : '',
   reactStrictMode: true,
   swcMinify: true,

--- a/apps/preview/next/pages/showcases/IconBase/ListOfIcons.tsx
+++ b/apps/preview/next/pages/showcases/IconBase/ListOfIcons.tsx
@@ -8,7 +8,7 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 export default function IconList() {
   const [copied, setCopied] = useState('');
   const { data: componentsNames = [] } = useSWR<string[]>(
-    `${process.env.VITE_DOCS_EXAMPLES_REACT_PATH || ''}/api/getIcons`,
+    `${process.env.DOCS_EXAMPLES_REACT_PATH || ''}/api/getIcons`,
     fetcher,
   );
 


### PR DESCRIPTION
# Related issue

Closes https://vsf.atlassian.net/browse/SFUI2-1076

# Scope of work

it seems that env arg handling was missing in next/nuxt dockerfiles
VITE_ prefix was missing when loading env vars in next.config

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
