### PR TITLE
fix: mega menu category button color

### DIFF
--- a/apps/preview/next/pages/showcases/MegaMenu/MegaMenuNavigation.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/MegaMenuNavigation.tsx
@@ -442,7 +442,7 @@ export default function MegaMenuNavigation() {
                   variant="tertiary"
                   onMouseEnter={handleOpenMenu([menuNode.key])}
                   onClick={handleOpenMenu([menuNode.key])}
-                  className="group mr-2 !text-neutral-900 hover:bg-neutral-200 hover:!text-neutral-700 active:!bg-neutral-300 active:!text-neutral-900"
+                  className="group mr-2 !text-neutral-900 hover:!bg-neutral-200 hover:!text-neutral-700 active:!bg-neutral-300 active:!text-neutral-900"
                 >
                   <span>{menuNode.value.label}</span>
                   <SfIconChevronRight className="rotate-90 text-neutral-500 group-hover:text-neutral-700 group-active:text-neutral-900" />

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/MegaMenuNavigation.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/MegaMenuNavigation.vue
@@ -56,7 +56,7 @@
           <li v-for="menuNode in content.children" :key="menuNode.key">
             <SfButton
               variant="tertiary"
-              class="group mr-2 !text-neutral-900 hover:bg-neutral-200 hover:!text-neutral-700 active:!bg-neutral-300 active:!text-neutral-900"
+              class="group mr-2 !text-neutral-900 hover:!bg-neutral-200 hover:!text-neutral-700 active:!bg-neutral-300 active:!text-neutral-900"
               @mouseenter="openMenu([menuNode.key])"
               @click="openMenu([menuNode.key])"
             >


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes [SFUI2-1105](https://vsf.atlassian.net/browse/SFUI2-1105)

# Scope of work

Overrides default button hover color.

<!-- describe what you did -->

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [ ] cypress tests created


[SFUI2-1105]: https://vsf.atlassian.net/browse/SFUI2-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ