### PR TITLE
fix: gallery horizontal buttons on vue and resize observer in sfscrollable

### DIFF
--- a/packages/sfui/frameworks/vue/components/SfScrollable/SfScrollable.vue
+++ b/packages/sfui/frameworks/vue/components/SfScrollable/SfScrollable.vue
@@ -94,7 +94,7 @@ const isHorizontal = computed(() => props.direction === SfScrollableDirection.ho
 <template>
   <div :class="['items-center', 'relative', isHorizontal ? 'flex' : 'flex-col h-full inline-flex', wrapperClass]">
     <slot
-      v-if="$slots.previousButton && buttonsPlacement === SfScrollableButtonsPlacement.block"
+      v-if="$slots.previousButton && buttonsPlacement !== SfScrollableButtonsPlacement.none"
       v-bind="getPrevButtonProps"
       name="previousButton"
     />
@@ -132,7 +132,7 @@ const isHorizontal = computed(() => props.direction === SfScrollableDirection.ho
       <slot />
     </component>
     <slot
-      v-if="$slots.nextButton && buttonsPlacement === SfScrollableButtonsPlacement.block"
+      v-if="$slots.nextButton && buttonsPlacement !== SfScrollableButtonsPlacement.none"
       v-bind="getNextButtonProps"
       name="nextButton"
     />

--- a/packages/sfui/shared/scrollable/scrollable.ts
+++ b/packages/sfui/shared/scrollable/scrollable.ts
@@ -56,9 +56,8 @@ export default class Scrollable {
 
   private addListeners() {
     const onScroll = this.onScroll.bind(this);
-    const onResize = this.onResize.bind(this);
     this.container.addEventListener('scroll', onScroll, { passive: !this.options.drag });
-    this.container.addEventListener('resize', onResize, { passive: true });
+    this.resizeObserver.observe(this.container);
 
     if (this.options.drag) {
       const onMouseDown = this.onMouseDown.bind(this);
@@ -73,17 +72,17 @@ export default class Scrollable {
 
       return () => {
         this.container.removeEventListener('scroll', onScroll);
-        this.container.removeEventListener('resize', onResize);
         this.container.removeEventListener('mousedown', onMouseDown);
         this.container.removeEventListener('mouseup', onMouseUp);
         this.container.removeEventListener('mousemove', onMouseMove);
         this.container.removeEventListener('mouseleave', onMouseLeave);
+        this.resizeObserver.unobserve(this.container);
       };
     }
 
     return () => {
       this.container.removeEventListener('scroll', onScroll);
-      this.container.removeEventListener('resize', onResize);
+      this.resizeObserver.unobserve(this.container);
     };
   }
 
@@ -234,12 +233,12 @@ export default class Scrollable {
     this.debounceId = setTimeout(this.onScrollHandler.bind(this), 50);
   }
 
-  private onResize(): void {
+  private resizeObserver = new ResizeObserver(() => {
     const container = this.container;
     if (!container) return;
 
     this.refresh(this.options.onScroll);
-  }
+  });
 
   private onScrollHandler() {
     this.refresh(this.options.onScroll);


### PR DESCRIPTION
# Related issue

Closes[ #1113](https://vsf.atlassian.net/browse/SFUI2-1113)

# Scope of work

- fixed buttons in GalleryHorizontal on Vue. Changed condition in SfScrollable in order to show buttons passed in slots when `floating` position is set. 
- replaced `onResize` method with `resizeObserver` to intercept when SfScrollable element changes its size and refresh it

# Screenshots of visual changes

![Screenshot from 2023-05-09 11-44-00](https://user-images.githubusercontent.com/32042425/237058912-87e24b3f-a79d-4ddc-bc2a-159ec88bb7eb.png)



![gallery2](https://user-images.githubusercontent.com/32042425/237058071-1ad6e49a-5c3e-4166-b730-a96d1795f437.gif)


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
