### PR TITLE
fix: scrollable by one item in vue and react

### DIFF
--- a/apps/docs/components/components/scrollable.md
+++ b/apps/docs/components/components/scrollable.md
@@ -83,7 +83,7 @@ By default `SfScrollable` scroll by one page of items, but can be modified that 
 | `activeIndex` | `number`  |  |       |
 | `reduceMotion` | `boolean`  |  |       |
 | `drag` | `{ sensitivity: number; containerWidth: boolean; } | boolean`  |  |       |
-| `previousDisabled` | `boolean`  |  |       |
+| `prevDisabled` | `boolean`  |  |       |
 | `nextDisabled` | `boolean`  |  |       |
 | `isActiveIndexCentered` | `boolean`  |  |       |
 <!-- vue -->

--- a/apps/preview/next/pages/showcases/Gallery/GalleryVertical.tsx
+++ b/apps/preview/next/pages/showcases/Gallery/GalleryVertical.tsx
@@ -74,7 +74,7 @@ export default function GalleryVertical() {
         className="items-center w-full [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
         direction="vertical"
         activeIndex={activeIndex}
-        previousDisabled={activeIndex === 0}
+        prevDisabled={activeIndex === 0}
         nextDisabled={activeIndex === images.length - 1}
         slotPreviousButton={
           <SfButton

--- a/apps/preview/next/pages/showcases/Gallery/GalleryWithBullets.tsx
+++ b/apps/preview/next/pages/showcases/Gallery/GalleryWithBullets.tsx
@@ -31,7 +31,7 @@ export default function GalleryWithBullets() {
         wrapperClassName="group/scrollable h-full"
         activeIndex={activeIndex}
         isActiveIndexCentered
-        previousDisabled={activeIndex === 0}
+        prevDisabled={activeIndex === 0}
         nextDisabled={activeIndex === images.length - 1}
         buttonsPlacement="block"
         onPrev={() => {

--- a/apps/preview/next/pages/showcases/Scrollable/ScrollByOneItem.tsx
+++ b/apps/preview/next/pages/showcases/Scrollable/ScrollByOneItem.tsx
@@ -13,7 +13,7 @@ export default function ScrollableMoveByOne() {
       wrapperClassName="min-w-0"
       className="items-center w-full"
       activeIndex={activeIndex}
-      previousDisabled={activeIndex === 0}
+      prevDisabled={activeIndex === 0}
       nextDisabled={activeIndex === itemsLength - 1}
       isActiveIndexCentered
       onPrev={({ preventDefault }) => {

--- a/apps/preview/nuxt/pages/showcases/Scrollable/ScrollByOneItem.vue
+++ b/apps/preview/nuxt/pages/showcases/Scrollable/ScrollByOneItem.vue
@@ -3,8 +3,9 @@
     class="items-center w-full"
     :active-index="activeIndex"
     wrapper-class="min-w-0"
-    :prev-disabled="activeIndex === 0"
+    :previous-disabled="activeIndex === 0"
     :next-disabled="activeIndex === itemsLength - 1"
+    is-active-index-centered
     @on-prev="
       ({ preventDefault }) => {
         preventDefault();

--- a/apps/preview/nuxt/pages/showcases/Scrollable/ScrollByOneItem.vue
+++ b/apps/preview/nuxt/pages/showcases/Scrollable/ScrollByOneItem.vue
@@ -3,7 +3,7 @@
     class="items-center w-full"
     :active-index="activeIndex"
     wrapper-class="min-w-0"
-    :previous-disabled="activeIndex === 0"
+    :prev-disabled="activeIndex === 0"
     :next-disabled="activeIndex === itemsLength - 1"
     is-active-index-centered
     @on-prev="

--- a/packages/sfui/frameworks/react/components/SfScrollable/SfScrollable.tsx
+++ b/packages/sfui/frameworks/react/components/SfScrollable/SfScrollable.tsx
@@ -31,7 +31,7 @@ const SfScrollable = polymorphicForwardRef<typeof defaultScrollableTag, SfScroll
       isActiveIndexCentered,
       className,
       wrapperClassName,
-      previousDisabled,
+      prevDisabled,
       nextDisabled,
       style,
       children,
@@ -77,7 +77,7 @@ const SfScrollable = polymorphicForwardRef<typeof defaultScrollableTag, SfScroll
 
     function PreviousButton({ classNameButton }: { classNameButton?: string }) {
       if (slotPreviousButton) {
-        return cloneElement(slotPreviousButton, getPrevButtonProps({ disabled: previousDisabled, onClick: onPrev }));
+        return cloneElement(slotPreviousButton, getPrevButtonProps({ disabled: prevDisabled, onClick: onPrev }));
       }
       return (
         <SfButton
@@ -85,7 +85,7 @@ const SfScrollable = polymorphicForwardRef<typeof defaultScrollableTag, SfScroll
             square: true,
             variant: 'secondary',
             size: 'lg',
-            disabled: previousDisabled,
+            disabled: prevDisabled,
             slotPrefix: <SfIconChevronLeft />,
             className: classNames(
               'hidden md:block !ring-neutral-500 !text-neutral-500 disabled:!ring-disabled-300 disabled:!text-disabled-500',

--- a/packages/sfui/frameworks/react/components/SfScrollable/types.ts
+++ b/packages/sfui/frameworks/react/components/SfScrollable/types.ts
@@ -6,7 +6,7 @@ export interface SfScrollableProps extends UseScrollableOptions, PropsWithChildr
   wrapperClassName?: string;
   slotPreviousButton?: ReactElement;
   slotNextButton?: ReactElement;
-  previousDisabled?: boolean;
+  prevDisabled?: boolean;
   nextDisabled?: boolean;
   buttonsPlacement?: `${SfScrollableButtonsPlacement}`;
 }

--- a/packages/sfui/frameworks/react/hooks/useScrollable/useScrollable.ts
+++ b/packages/sfui/frameworks/react/hooks/useScrollable/useScrollable.ts
@@ -66,7 +66,7 @@ export function useScrollable<TElement extends HTMLElement>({
     };
     return {
       onClick: composeHandlers(handlePrev, userProps?.onClick),
-      disabled: userProps.disabled || !state.hasPrev,
+      disabled: typeof userProps.disabled !== 'undefined' ? userProps.disabled : !state.hasPrev,
     };
   });
 
@@ -76,7 +76,7 @@ export function useScrollable<TElement extends HTMLElement>({
     };
     return {
       onClick: composeHandlers(handleNext, userProps?.onClick),
-      disabled: userProps.disabled || !state.hasNext,
+      disabled: typeof userProps.disabled !== 'undefined' ? userProps.disabled : !state.hasNext,
     };
   });
 

--- a/packages/sfui/frameworks/vue/components/SfScrollable/SfScrollable.vue
+++ b/packages/sfui/frameworks/vue/components/SfScrollable/SfScrollable.vue
@@ -47,7 +47,7 @@ const props = defineProps({
     type: [Object || Boolean] as PropType<ScrollableOptions['drag']>,
     default: undefined,
   },
-  previousDisabled: {
+  prevDisabled: {
     type: Boolean,
     default: undefined,
   },
@@ -108,10 +108,10 @@ const isHorizontal = computed(() => props.direction === SfScrollableDirection.ho
         buttonsPlacement === SfScrollableButtonsPlacement.block && (isHorizontal ? 'mr-4' : 'mb-4 rotate-90'),
         buttonsPlacement === SfScrollableButtonsPlacement.floating && (isHorizontal ? 'left-4' : 'top-4 rotate-90'),
         { 'absolute z-10': buttonsPlacement === SfScrollableButtonsPlacement.floating },
-        changeDisabledClass(typeof previousDisabled === 'boolean' ? previousDisabled : getPrevButtonProps.disabled),
+        changeDisabledClass(typeof prevDisabled === 'boolean' ? prevDisabled : getPrevButtonProps.disabled),
       ]"
       v-bind="getPrevButtonProps"
-      :disabled="previousDisabled"
+      :disabled="prevDisabled"
     >
       <SfIconChevronLeft />
     </SfButton>
@@ -127,7 +127,7 @@ const isHorizontal = computed(() => props.direction === SfScrollableDirection.ho
         },
       ]"
       v-bind="{ ...$attrs, ...props }"
-      :disabled="previousDisabled"
+      :disabled="prevDisabled"
     >
       <slot />
     </component>


### PR DESCRIPTION
# Related issue
Closes [#1112](https://vsf.atlassian.net/browse/SFUI2-1112)

# Scope of work

- In Vue prop name was corrected, changed to `prevDisabled` in order to keep consistency with other props like `onPrev` (not using entire "previous" word)
- in React disabled props have to take priority over default behavior in order to disable buttons correctly - condition for that was changed in useScrollable hook

# Screenshots of visual changes

![scrollable-vue](https://github.com/vuestorefront/storefront-ui/assets/32042425/0ced9119-db1f-4a1b-a8c4-e6ba078ca9d9)


![scrollable-react](https://github.com/vuestorefront/storefront-ui/assets/32042425/9831eaec-0d79-4a46-834d-bbae459b60bd)


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
