### PR TITLE
fix: checkbox invalid state with indeterminate

### DIFF
--- a/packages/sfui/frameworks/vue/components/SfCheckbox/SfCheckbox.vue
+++ b/packages/sfui/frameworks/vue/components/SfCheckbox/SfCheckbox.vue
@@ -30,7 +30,7 @@ const proxyChecked = computed({
     v-model="proxyChecked"
     class="h-[18px] min-w-[18px] border-2 rounded-sm appearance-none cursor-pointer text-gray-500 hover:indeterminate:text-primary-800 enabled:active:checked:text-primary-900 checked:text-primary-700 checked:bg-checked-checkbox-current border-current indeterminate:bg-indeterminate-checkbox-current indeterminate:text-primary-700 disabled:text-gray-300 hover:text-gray-300 disabled:cursor-not-allowed enabled:hover:border-primary-800 enabled:active:border-primary-900 enabled:hover:checked:text-primary-800 enabled:hover:indeterminate:text-primary-800 enabled:checked:text-primary-700 enabled:indeterminate:text-primary-700 enabled:focus-visible:outline enabled:focus-visible:outline-offset"
     :class="{
-      'border-negative-700 enabled:hover:border-negative-800 enabled:active:border-negative-900': invalid,
+      'border-negative-700 enabled:hover:border-negative-800 enabled:active:border-negative-900 indeterminate:bg-none': invalid,
     }"
     type="checkbox"
     data-testid="checkbox"


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes # https://vsf.atlassian.net/browse/SFUI2-1071

# Scope of work

Checkbox doesn't have background image when invalid and indeterminate states are enabled 

<!-- describe what you did -->

# Screenshots of visual changes
<img width="253" alt="Screenshot 2023-05-10 at 10 01 11" src="https://github.com/vuestorefront/storefront-ui/assets/46591755/39c45f86-b275-4349-88c0-a6f15f85fc3d">



<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
