### PR TITLE
docs: add redirect for friendly figma link

### DIFF
--- a/.vuestorefrontcloud/router/docker/default.conf
+++ b/.vuestorefrontcloud/router/docker/default.conf
@@ -10,4 +10,8 @@ server {
   location / {
     return 301 https://docs.storefrontui.io/v2$uri$is_args$args;
   }
+
+  location /v2/figma {
+    return 307 https://www.figma.com/file/7APRfAoRBRwsZeu07wN5Vg/Storefront-UI-%7C-Design-Kit-v2.2-(public)
+  }
 }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ In addition, Storefront UI fits perfectly complex UI setups where one library is
 - **Typography** package simplifying usage of 3rd party fonts
 - **Figma** file with pixel-perfect representation of SFUI components based on tailwind properties
 
-<a href="https://www.figma.com/file/7pRNATsiFwYmveafXzjhSV/SFUI-2-%7C-Design-Kit-(public)"><img src="./_readme/figma_included.png"></a>
+<a href="https://docs.storefrontui.io/v2/figma)"><img src="./_readme/figma_included.png"></a>
 
 ## Contributing
 

--- a/apps/docs/components/.vuepress/config.js
+++ b/apps/docs/components/.vuepress/config.js
@@ -6,7 +6,7 @@ const { generateComponentPath } = require('./utils/path.util');
 
 const DOCS_EXAMPLES_REACT_PATH = process.env.VITE_DOCS_EXAMPLES_REACT_PATH;
 const DOCS_EXAMPLES_VUE_PATH = process.env.VITE_DOCS_EXAMPLES_VUE_PATH;
-const FIGMA_URL = 'https://www.figma.com/file/7pRNATsiFwYmveafXzjhSV/SFUI-2-%7C-Design-Kit-(public)';
+const FIGMA_URL = 'https://docs.storefrontui.io/v2/figma';
 const GTAG = 'G-BL2CYW4NJ5';
 const convertComponentPathsToLinks = (paths, slug, type) =>
   paths.map((c) => [generateComponentPath(slug, c, type), c.replace('Sf', '')]);

--- a/packages/sfui/typography/README.md
+++ b/packages/sfui/typography/README.md
@@ -97,7 +97,7 @@ export default {
 };
 ```
 
-And get ready to use default StorefrontUI typography classes [that are based on SFUI designs](https://www.figma.com/file/7pRNATsiFwYmveafXzjhSV/SFUI-2-%7C-Design-Kit-(public)).
+And get ready to use default StorefrontUI typography classes [that are based on SFUI designs](https://docs.storefrontui.io/v2/figma).
 
 ## How to use it
 


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

https://vsf.atlassian.net/browse/SFUI2-1144

- adds redirect for figma link
- changes instances of the Figma URL to `https://docs.storefrontui.io/v2/figma`

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
