### PR TITLE
fix: gallery vertical [SFUI2-1126]

### DIFF
--- a/apps/preview/next/pages/showcases/Gallery/GalleryVertical.tsx
+++ b/apps/preview/next/pages/showcases/Gallery/GalleryVertical.tsx
@@ -70,11 +70,10 @@ export default function GalleryVertical() {
   };
 
   return (
-    <div className="relative max-h-[600px] flex h-full">
+    <div className="relative flex w-full max-h-[600px] aspect-[4/3]">
       <SfScrollable
         ref={thumbsRef}
         className="items-center w-full [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
-        wrapperClassName="shrink-0"
         direction="vertical"
         activeIndex={activeIndex}
         prevDisabled={activeIndex === 0}
@@ -120,7 +119,7 @@ export default function GalleryVertical() {
             onMouseOver={() => setActiveIndex(index)}
             onFocus={() => setActiveIndex(index)}
           >
-            <img alt={alt} className="object-contain border border-neutral-200" width="78" height="78" src={imageSrc} />
+            <img alt={alt} className="border border-neutral-200" width="78" height="78" src={imageSrc} />
           </button>
         ))}
       </SfScrollable>
@@ -128,7 +127,7 @@ export default function GalleryVertical() {
         className="w-full h-full snap-x snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
         activeIndex={activeIndex}
         direction="vertical"
-        wrapperClassName="h-full"
+        wrapperClassName="h-full m-auto"
         buttonsPlacement="none"
         isActiveIndexCentered
         drag={{ containerWidth: true }}

--- a/apps/preview/nuxt/pages/showcases/Gallery/GalleryVertical.vue
+++ b/apps/preview/nuxt/pages/showcases/Gallery/GalleryVertical.vue
@@ -1,9 +1,8 @@
 <template>
-  <div class="relative max-h-[600px] flex h-full">
+  <div class="relative flex w-full max-h-[600px] aspect-[4/3]">
     <SfScrollable
       ref="thumbsRef"
       class="items-center w-full [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
-      wrapper-class="shrink-0"
       direction="vertical"
       :active-index="activeIndex"
       :previous-disabled="activeIndex === 0"
@@ -36,7 +35,7 @@
         @mouseover="activeIndex = index"
         @focus="activeIndex = index"
       >
-        <img :alt="alt" class="object-contain border border-neutral-200" width="78" height="78" :src="imageSrc" />
+        <img :alt="alt" class="border border-neutral-200" width="78" height="78" :src="imageSrc" />
       </button>
       <template #nextButton="defaultProps">
         <SfButton
@@ -56,7 +55,7 @@
       class="w-full h-full snap-x snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
       :active-index="activeIndex"
       direction="vertical"
-      wrapper-class="h-full"
+      wrapper-class="h-full m-auto"
       is-active-index-centered
       buttons-placement="none"
       :drag="{ containerWidth: true }"


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1126


# Screenshots of visual changes

screen width 320:
![image](https://github.com/vuestorefront/storefront-ui/assets/10456649/025fe7d1-d86c-4e52-9228-9df0f570b6f5)

screen width 800:
![image](https://github.com/vuestorefront/storefront-ui/assets/10456649/953c5e9f-7398-4e19-ad6b-fb776eb27bad)

screen width 1492:
![image](https://github.com/vuestorefront/storefront-ui/assets/10456649/b07d0ab1-a3fe-4fc7-99ff-7087b5436e40)



# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
