### PR TITLE
fix: gallery horizontal [SFUI2-1126]

### DIFF
--- a/apps/preview/next/pages/showcases/Gallery/GalleryHorizontal.tsx
+++ b/apps/preview/next/pages/showcases/Gallery/GalleryHorizontal.tsx
@@ -54,7 +54,7 @@ export default function GalleryHorizontal() {
   };
 
   return (
-    <div className="relative max-h-[600px] flex flex-col h-full">
+    <div className="relative flex flex-col w-full max-h-[600px] aspect-[4/3]">
       <SfScrollable
         className="w-full h-full snap-x snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
         activeIndex={activeIndex}
@@ -69,7 +69,7 @@ export default function GalleryHorizontal() {
             <img
               aria-label={alt}
               aria-hidden={activeIndex !== index}
-              className="object-cover w-auto h-full"
+              className="w-auto h-full"
               alt={alt}
               src={imageSrc}
             />

--- a/apps/preview/nuxt/pages/showcases/Gallery/GalleryHorizontal.vue
+++ b/apps/preview/nuxt/pages/showcases/Gallery/GalleryHorizontal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative max-h-[600px] flex flex-col h-full">
+  <div class="relative flex flex-col w-full max-h-[600px] aspect-[4/3]">
     <SfScrollable
       class="w-full h-full snap-x snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
       :active-index="activeIndex"
@@ -17,7 +17,7 @@
         <img
           :aria-label="alt"
           :aria-hidden="activeIndex !== index"
-          class="object-cover w-auto h-full"
+          class="w-auto h-full"
           :alt="alt"
           :src="imageSrc"
         />

--- a/apps/preview/nuxt/pages/showcases/Gallery/GalleryHorizontal.vue
+++ b/apps/preview/nuxt/pages/showcases/Gallery/GalleryHorizontal.vue
@@ -14,13 +14,7 @@
         :key="`${alt}-${index}`"
         class="flex justify-center h-full basis-full shrink-0 grow snap-center"
       >
-        <img
-          :aria-label="alt"
-          :aria-hidden="activeIndex !== index"
-          class="w-auto h-full"
-          :alt="alt"
-          :src="imageSrc"
-        />
+        <img :aria-label="alt" :aria-hidden="activeIndex !== index" class="w-auto h-full" :alt="alt" :src="imageSrc" />
       </div>
     </SfScrollable>
     <SfScrollable


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1126

# Screenshots of visual changes

320:
![image](https://github.com/vuestorefront/storefront-ui/assets/10456649/a8e6ec3d-8a8d-4672-a390-d3260cf5f06e)

800:
![image](https://github.com/vuestorefront/storefront-ui/assets/10456649/94e377ca-e6aa-4c19-8c41-64e904d89125)

1440:
![image](https://github.com/vuestorefront/storefront-ui/assets/10456649/8d930019-d8a2-4cb5-8c3d-7ee4607f2a1a)


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
