### PR TITLE
docs: add no-paddings feature, improve no sidebar in showcases [SFUI2-1136]

### DIFF
--- a/apps/docs/components/.vuepress/components/Generate.vue
+++ b/apps/docs/components/.vuepress/components/Generate.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="custom-block border bg-white mt-4" :class="{ generate: !showcasePath }">
-    <iframe :src="exampleUrl" :allow="allow" class="w-full h-full" />
+    <iframe :src="exampleUrl" :allow="allow" class="w-full h-full" ref="iframeRef"/>
   </div>
 </template>
 
@@ -13,14 +13,36 @@ export default {
       type: String,
       default: undefined,
     },
+    noPaddings: {
+      type: Boolean,
+      default: false
+    },
     allow: {
       type: String,
       default: undefined,
     },
   },
+  data: () => {
+    return {
+      iframeRef: undefined
+    }
+  },
+  mounted: function() {
+    const iframeElement = this.$refs.iframeRef;
+    window.addEventListener('message', (e) => {
+      if(e.data === 'loaded' && this.noPaddings) {
+        iframeElement?.contentWindow?.postMessage('no-paddings', "*")
+      }
+    }, false);
+  },
   computed: {
     frameworkName() {
       return this.$route.path.split('/')[1];
+    },
+    urlBasePath() {
+      return this.frameworkName === 'react'
+          ? this.$themeConfig.DOCS_EXAMPLES_REACT_PATH
+          : this.$themeConfig.DOCS_EXAMPLES_VUE_PATH;
     },
     componentName() {
       return this.$route.path.split('/').pop()?.split('.')[0];
@@ -30,11 +52,7 @@ export default {
         component.toLowerCase().includes('sf' + this.componentName),
       );
 
-      return `${
-        this.frameworkName === 'react'
-          ? this.$themeConfig.DOCS_EXAMPLES_REACT_PATH
-          : this.$themeConfig.DOCS_EXAMPLES_VUE_PATH
-      }/${this.showcasePath ? `showcases/${this.showcasePath}` : `examples/${componentNameFull}`}?docs=true`;
+      return `${this.urlBasePath}/${this.showcasePath ? `showcases/${this.showcasePath}` : `examples/${componentNameFull}`}`;
     },
   },
 };

--- a/apps/docs/components/.vuepress/components/Showcase.vue
+++ b/apps/docs/components/.vuepress/components/Showcase.vue
@@ -24,7 +24,7 @@
         @mousedown="mouseDownListener"
       >
         <div class="absolute inset-0" v-show="isHandlerDragging"></div>
-        <Generate :showcase-path="showcaseName" :allow="allow" class="flex-grow rounded" style="margin-top: 0" />
+        <Generate :showcase-path="showcaseName" :allow="allow" class="flex-grow rounded" style="margin-top: 0" :no-paddings="noPaddings"/>
         <div ref="handlerRef" class="select-none rounded-tr flex items-center" style="cursor: ew-resize">
           <iconify-icon icon="akar-icons:drag-vertical" class="pointer-events-none" />
         </div>
@@ -44,7 +44,10 @@ export default {
     showcaseName: {
       type: String,
       default: undefined,
-      default: undefined,
+    },
+    noPaddings: {
+      type: Boolean,
+      default: false
     },
     allow: {
       type: String,

--- a/apps/docs/components/blocks/Footer.md
+++ b/apps/docs/components/blocks/Footer.md
@@ -1,7 +1,7 @@
 ---
 layout: DefaultLayout
 hideBreadcrumbs: true
-description: The Footer block is used as navigation. Usually it's at the bottom of a page and has elements like links to main information pages, contacts, social media links and links to the privacy policy documents. 
+description: The Footer block is used as navigation. Usually it's at the bottom of a page and has elements like links to main information pages, contacts, social media links and links to the privacy policy documents.
 hideToc: true
 ---
 
@@ -11,11 +11,13 @@ hideToc: true
 
 ## Footer basic block
 
-<Showcase showcase-name="Footer/FooterBasic" style="min-height: 750px;">
+<Showcase showcase-name="Footer/FooterBasic" style="min-height: 701px;" no-paddings>
+
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/Footer/FooterBasic.vue
 <!-- end vue -->
 <!-- react -->
 <<<../../preview/next/pages/showcases/Footer/FooterBasic.tsx#source
 <!-- end react -->
+
 </Showcase>

--- a/apps/docs/components/blocks/MegaMenu.md
+++ b/apps/docs/components/blocks/MegaMenu.md
@@ -18,7 +18,7 @@ MegaMenu complies with the WCAG guidelines for accessibility for menus and menu 
 
  When the user clicks on the trigger element (such as one of the menu items), the mega menu opens. On mobile screens, clicking on hamburger button will trigger a drawer opening from the left side with menu content.
 
-<Showcase showcase-name="MegaMenu/BaseMegaMenu" style="min-height: 500px;">
+<Showcase showcase-name="MegaMenu/BaseMegaMenu" no-paddings style="min-height: 500px;">
 
 <!-- react -->
 <<<../../preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx#source
@@ -33,7 +33,7 @@ MegaMenu complies with the WCAG guidelines for accessibility for menus and menu 
 
 Additional navigation bar under the main header helps to find general categories. User can easily open Mega Menu for each category. When using on mobile devices side drawer provides a nice way of navigating through nested categories.
 
-<Showcase showcase-name="MegaMenu/MegaMenuNavigation" style="min-height: 600px;">
+<Showcase showcase-name="MegaMenu/MegaMenuNavigation" no-paddings style="min-height: 600px;">
 
 <!-- react -->
 <<<../../preview/next/pages/showcases/MegaMenu/MegaMenuNavigation.tsx#source

--- a/apps/docs/components/blocks/NavbarBottom.md
+++ b/apps/docs/components/blocks/NavbarBottom.md
@@ -10,7 +10,7 @@ hideToc: true
 
 ## NavbarBottom with white background
 
-<Showcase showcase-name="NavbarBottom/NavbarBottom" style="min-height:200px">
+<Showcase showcase-name="NavbarBottom/NavbarBottom" no-paddings style="min-height:200px">
 
 <!-- react -->
 <<<../../preview/next/pages/showcases/NavbarBottom/NavbarBottom.tsx#source
@@ -23,7 +23,7 @@ hideToc: true
 
 ## NavbarBottom with filled background
 
-<Showcase showcase-name="NavbarBottom/NavbarBottomFilled" style="min-height:200px">
+<Showcase showcase-name="NavbarBottom/NavbarBottomFilled" no-paddings style="min-height:200px">
 
 <!-- react -->
 <<<../../preview/next/pages/showcases/NavbarBottom/NavbarBottomFilled.tsx#source

--- a/apps/docs/components/blocks/NavbarTop.md
+++ b/apps/docs/components/blocks/NavbarTop.md
@@ -1,7 +1,7 @@
 ---
 layout: DefaultLayout
 hideBreadcrumbs: true
-description: The NavbarTop block is used as navigation. Usually it's at the top of a page and has elements like company logo, links to main categories or a menu button, search input and action buttons that can open a cart, wishlist or login modal. 
+description: The NavbarTop block is used as navigation. Usually it's at the top of a page and has elements like company logo, links to main categories or a menu button, search input and action buttons that can open a cart, wishlist or login modal.
 hideToc: true
 ---
 
@@ -11,22 +11,26 @@ hideToc: true
 
 ## NavbarTop with white background
 
-<Showcase showcase-name="NavbarTop/NavbarTop" style="min-height: 500px;">
+<Showcase showcase-name="NavbarTop/NavbarTop" no-paddings style="min-height: 500px;">
+
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/NavbarTop/NavbarTop.vue
 <!-- end vue -->
 <!-- react -->
 <<<../../preview/next/pages/showcases/NavbarTop/NavbarTop.tsx#source
 <!-- end react -->
+
 </Showcase>
 
 ## NavbarTop with filled background
 
-<Showcase showcase-name="NavbarTop/NavbarTopFilled" style="min-height: 500px;">
+<Showcase showcase-name="NavbarTop/NavbarTopFilled" no-paddings style="min-height: 500px;">
+
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/NavbarTop/NavbarTopFilled.vue
 <!-- end vue -->
 <!-- react -->
 <<<../../preview/next/pages/showcases/NavbarTop/NavbarTopFilled.tsx#source
 <!-- end react -->
+
 </Showcase>

--- a/apps/preview/next/layouts/Showcases.tsx
+++ b/apps/preview/next/layouts/Showcases.tsx
@@ -23,17 +23,11 @@ type GroupsInterface = {
     visible: boolean;
   };
 };
-const inIframe = () => {
-  try {
-    return window.self !== window.top;
-  } catch (e) {
-    return true;
-  }
-};
+
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 export default function ShowcaseLayout({ children }: { children: ReactElement }) {
   const [isOpen, setIsOpen] = useState(true);
-  const [isDocsRoute, setIsDocsRoute] = useState(true);
+  const [isNotIframe, setIsNotIframe] = useState(false);
   const [noPaddings, setNoPaddings] = useState(false);
   const [groups, setGroups] = useState<GroupsInterface>({});
   const [search, setSearch] = useState('');
@@ -96,8 +90,8 @@ export default function ShowcaseLayout({ children }: { children: ReactElement })
   });
 
   useEffect(() => {
-    if (!inIframe()) {
-      setIsDocsRoute(false);
+    if (window.self === window.top) {
+      setIsNotIframe(true);
     } else {
       window.parent.postMessage('loaded', '*');
 
@@ -113,7 +107,7 @@ export default function ShowcaseLayout({ children }: { children: ReactElement })
 
   return (
     <div className="e-page-examples">
-      {!isDocsRoute ? (
+      {isNotIframe ? (
         <div className={`sidebar ${isOpen ? '' : 'sidebar-collapsed'}`}>
           <header className="sidebar-heading">
             <h2>StorefrontUI v2</h2>
@@ -181,7 +175,9 @@ export default function ShowcaseLayout({ children }: { children: ReactElement })
         </div>
       ) : null}
       <div className="e-page">
-        <div className={classNames('e-page-component', noPaddings && 'e-page-component--no-paddings')}>{children}</div>
+        <div className={classNames('e-page-component', { 'e-page-component--no-paddings': noPaddings })}>
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/apps/preview/nuxt/pages/showcases.vue
+++ b/apps/preview/nuxt/pages/showcases.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="e-page-examples">
-    <div v-if="!isDocs" class="sidebar" :class="!isOpen && 'sidebar-collapsed'">
+    <div v-if="isNotIframe" class="sidebar" :class="!isOpen && 'sidebar-collapsed'">
       <header class="sidebar-heading">
         <h2>StorefrontUI v2</h2>
         <h3>Vue Blocks</h3>
@@ -106,7 +106,7 @@ const groups = reactive(
   }, {}),
 );
 const isOpen = ref(true);
-const isDocs = ref(true);
+const isNotIframe = ref(false);
 const arePaddingsDisabled = ref(false);
 const searchModelValue = ref('');
 
@@ -146,16 +146,9 @@ watch(
 );
 useControlsSearchParams(reactive({ s: searchModelValue }));
 
-const inIframe = () => {
-  try {
-    return window.self !== window.top;
-  } catch (e) {
-    return true;
-  }
-};
 onBeforeMount(() => {
-  if (!inIframe()) {
-    isDocs.value = false;
+  if (window.self === window.top) {
+    isNotIframe.value = true;
   } else {
     window.parent.postMessage('loaded', '*');
     window.addEventListener(

--- a/apps/preview/nuxt/pages/showcases.vue
+++ b/apps/preview/nuxt/pages/showcases.vue
@@ -53,7 +53,7 @@
       </ul>
     </div>
     <div class="e-page">
-      <div class="e-page-component">
+      <div class="e-page-component" :class="[arePaddingsDisabled && 'e-page-component--no-paddings']">
         <NuxtPage />
       </div>
     </div>
@@ -72,8 +72,7 @@ import {
   SfInput,
   SfIconCloseSm,
 } from '@storefront-ui/vue';
-import { reactive } from 'vue';
-import { ref, watch } from 'vue';
+import { ref, watch, reactive, onBeforeMount } from 'vue';
 import { useControlsSearchParams } from '~/composables/utils/useControlsSearchParams';
 
 const { currentRoute } = useRouter();
@@ -107,7 +106,8 @@ const groups = reactive(
   }, {}),
 );
 const isOpen = ref(true);
-const isDocs = computed(() => currentRoute.value.query.docs);
+const isDocs = ref(true);
+const arePaddingsDisabled = ref(false);
 const searchModelValue = ref('');
 
 const findGroup = (groups, currentRouteHref) =>
@@ -145,4 +145,26 @@ watch(
   { immediate: true },
 );
 useControlsSearchParams(reactive({ s: searchModelValue }));
+
+const inIframe = () => {
+  try {
+    return window.self !== window.top;
+  } catch (e) {
+    return true;
+  }
+};
+onBeforeMount(() => {
+  if (!inIframe()) {
+    isDocs.value = false;
+  } else {
+    window.parent.postMessage('loaded', '*');
+    window.addEventListener(
+      'message',
+      (e) => {
+        if (e.data === 'no-paddings') arePaddingsDisabled.value = true;
+      },
+      false,
+    );
+  }
+});
 </script>

--- a/apps/preview/nuxt/pages/showcases/Link/NuxtLink.vue
+++ b/apps/preview/nuxt/pages/showcases/Link/NuxtLink.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="space-x-4">
-    <SfLink :tag="NuxtLink" :to="{ path: '#' }"> NuxtLink </SfLink>
+    <SfLink :tag="NuxtLink" href="#"> NuxtLink </SfLink>
   </div>
 </template>
 

--- a/apps/preview/nuxt/pages/showcases/Link/NuxtLink.vue
+++ b/apps/preview/nuxt/pages/showcases/Link/NuxtLink.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="space-x-4">
-    <SfLink :tag="NuxtLink" :to="{ path: '#', query: { docs: true } }"> NuxtLink </SfLink>
+    <SfLink :tag="NuxtLink" :to="{ path: '#' }"> NuxtLink </SfLink>
   </div>
 </template>
 

--- a/packages/config/example-style/index.scss
+++ b/packages/config/example-style/index.scss
@@ -18,6 +18,10 @@
         padding: 20px;
         flex: 1;
         transform: scale(1);
+
+        &--no-paddings {
+            padding: 0;
+        }
     }
 
     &-examples {


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1136

# Scope of work

- add possibility to have showcase without paddings
- fix/improve no sidebar in showcases when run in docs, previously in react there was quick jump from visible sidenav to hidden after initial load

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
