### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,22 @@
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "all major dependency bump",
+      "groupSlug": "all-major",
+      "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor"],
+      "groupName": "all minor dependency bump",
+      "groupSlug": "all-minor",
+      "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["patch"],
-      "groupName": "all non-major dependency bump",
+      "groupName": "all patch dependency bump",
       "groupSlug": "all-patch",
       "automerge": true
     },
@@ -31,10 +45,6 @@
       "groupName": "definitelyTyped",
       "matchPackagePrefixes": ["@types/"],
       "automerge": true
-    },
-    {
-      "matchPackageNames": ["swc-plugin-coverage-instrument"],
-      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

I've noticed that renovate does not update majors and minors, seems like all catch has to be defined, and we have catch all for patch only

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
