### PR TITLE
fix: last item in breadcrumbs is not a link

### DIFF
--- a/apps/docs/components/blocks/Breadcrumbs.md
+++ b/apps/docs/components/blocks/Breadcrumbs.md
@@ -34,7 +34,7 @@ Breadcrumbs block with icons as a item separator.
 
 ## Breadcrumbs with home icon
 
-Breadrcrumbs block with home icon as the first item.
+Breadcrumbs block with home icon as the first item.
 
 <Showcase showcase-name="Breadcrumbs/BreadcrumbsWithIcon" style="min-height: 300px;">
 <!-- vue -->

--- a/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
@@ -70,16 +70,17 @@ export function Showcase() {
             className="peer hidden sm:flex items-center peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
             key={item.name}
           >
-            {index < breadcrumbs.length - 1 ? <SfLink
+            (
+              {index < breadcrumbs.length - 1 ? <SfLink
                 href={item.link}
                 variant="secondary"
                 className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
               >
                 {item.name}
               </SfLink> : (
-                <span> { item.name } </span>
+                <span> {item.name} </span>
               )
-            }
+            })
           </li>
         ))}
       </ol>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
@@ -70,7 +70,6 @@ export function Showcase() {
             className="peer hidden sm:flex items-center peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
             key={item.name}
           >
-            (
             {index < breadcrumbs.length - 1 ? (
               <SfLink
                 href={item.link}
@@ -82,7 +81,6 @@ export function Showcase() {
             ) : (
               <span> {item.name} </span>
             )}
-            )
           </li>
         ))}
       </ol>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
@@ -70,14 +70,15 @@ export function Showcase() {
             className="peer hidden sm:flex items-center peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
             key={item.name}
           >
-            {
-              (index < breadcrumbs.length - 1 ? <SfLink
+            {index < breadcrumbs.length - 1 ? <SfLink
                 href={item.link}
                 variant="secondary"
                 className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
               >
                 {item.name}
-              </SfLink> : <span> { item.name } </span>)
+              </SfLink> : (
+                <span> { item.name } </span>
+              )
             }
           </li>
         ))}

--- a/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
@@ -76,10 +76,7 @@ export function Showcase() {
               className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
             >
               {item.name}
-            </SfLink> :
-            <span>
-              { item.name }
-            </span>}
+            </SfLink> : <span> { item.name } </span>}
           </li>
         ))}
       </ol>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
@@ -71,16 +71,16 @@ export function Showcase() {
             key={item.name}
           >
             (
-              {index < breadcrumbs.length - 1 ? <SfLink
+          {index < breadcrumbs.length - 1 ? (
+            <SfLink
                 href={item.link}
                 variant="secondary"
                 className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
               >
-                {item.name}
-              </SfLink> : (
+            {item.name}
+              </SfLink>) : (
                 <span> {item.name} </span>
-              )
-            })
+              )})
           </li>
         ))}
       </ol>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
@@ -81,7 +81,7 @@ export function Showcase() {
               </SfLink>
             ) : (
               <span> {item.name} </span>
-          )}
+            )}
             )
           </li>
         ))}

--- a/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
@@ -70,13 +70,15 @@ export function Showcase() {
             className="peer hidden sm:flex items-center peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
             key={item.name}
           >
-            {index < breadcrumbs.length - 1 ? <SfLink
-              href={item.link}
-              variant="secondary"
-              className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
-            >
-              {item.name}
-            </SfLink> : <span> { item.name } </span>}
+            {
+              (index < breadcrumbs.length - 1 ? <SfLink
+                href={item.link}
+                variant="secondary"
+                className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
+              >
+                {item.name}
+              </SfLink> : <span> { item.name } </span>)
+            }
           </li>
         ))}
       </ol>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
@@ -65,18 +65,21 @@ export function Showcase() {
             </div>
           </SfDropdown>
         </li>
-        {breadcrumbs.map((item) => (
+        {breadcrumbs.map((item, index) => (
           <li
-            className="peer hidden sm:flex peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
+            className="peer hidden sm:flex items-center peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
             key={item.name}
           >
-            <SfLink
+            {index < breadcrumbs.length - 1 ? <SfLink
               href={item.link}
               variant="secondary"
               className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
             >
               {item.name}
-            </SfLink>
+            </SfLink> :
+            <span>
+              { item.name }
+            </span>}
           </li>
         ))}
       </ol>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
@@ -71,16 +71,18 @@ export function Showcase() {
             key={item.name}
           >
             (
-          {index < breadcrumbs.length - 1 ? (
-            <SfLink
+            {index < breadcrumbs.length - 1 ? (
+              <SfLink
                 href={item.link}
                 variant="secondary"
                 className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
               >
-            {item.name}
-              </SfLink>) : (
-                <span> {item.name} </span>
-              )})
+                {item.name}
+              </SfLink>
+            ) : (
+              <span> {item.name} </span>
+              )}
+            )
           </li>
         ))}
       </ol>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/Breadcrumbs.tsx
@@ -81,7 +81,7 @@ export function Showcase() {
               </SfLink>
             ) : (
               <span> {item.name} </span>
-              )}
+          )}
             )
           </li>
         ))}

--- a/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsSeparator.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsSeparator.tsx
@@ -72,19 +72,17 @@ export function Showcase() {
             key={item.name}
           >
             {index !== 0 ? <SfIconChevronRight size="sm" className="mx-0.5 text-disabled-500" /> : null}
-            (
-              {index < breadcrumbs.length - 1 ? (
-                <SfLink
-                  href={item.link}
-                  variant="secondary"
-                  className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
-                >
-                  {item.name}
-                </SfLink>
-              ) : (
-                <span> {item.name} </span>
-              )}
-            )
+            {index < breadcrumbs.length - 1 ? (
+              <SfLink
+                href={item.link}
+                variant="secondary"
+                className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
+              >
+                {item.name}
+              </SfLink>
+            ) : (
+              <span> {item.name} </span>
+            )}
           </li>
         ))}
       </ol>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsSeparator.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsSeparator.tsx
@@ -72,19 +72,19 @@ export function Showcase() {
             key={item.name}
           >
             {index !== 0 ? <SfIconChevronRight size="sm" className="mx-0.5 text-disabled-500" /> : null}
-            {
-            (index < breadcrumbs.length - 1 ? (
-            <SfLink
-              href={item.link}
-              variant="secondary"
-              className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
-            >
-              {item.name}
-            </SfLink>
-            ) : (
-              <span> {item.name} </span>
+            (
+              {index < breadcrumbs.length - 1 ? (
+                <SfLink
+                  href={item.link}
+                  variant="secondary"
+                  className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
+                >
+                  {item.name}
+                </SfLink>
+              ) : (
+                <span> {item.name} </span>
+              )}
             )
-            )}
           </li>
         ))}
       </ol>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsSeparator.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsSeparator.tsx
@@ -68,17 +68,20 @@ export function Showcase() {
         {breadcrumbs.map((item, index) => (
           <li
             data-icon="url('@assets/chevron_right.svg')"
-            className="hidden peer sm:flex text-neutral-500 last-of-type:flex last-of-type:text-neutral-900 last-of-type:font-medium"
+            className="hidden peer sm:flex items-center text-neutral-500 last-of-type:flex last-of-type:text-neutral-900 last-of-type:font-medium"
             key={item.name}
           >
             {index !== 0 ? <SfIconChevronRight size="sm" className="mx-0.5 text-disabled-500" /> : null}
-            <SfLink
+            {index < breadcrumbs.length - 1 ? <SfLink
               href={item.link}
               variant="secondary"
               className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
             >
               {item.name}
-            </SfLink>
+            </SfLink> :
+            <span>
+              { item.name }
+            </span>}
           </li>
         ))}
       </ol>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsSeparator.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsSeparator.tsx
@@ -78,10 +78,7 @@ export function Showcase() {
               className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
             >
               {item.name}
-            </SfLink> :
-            <span>
-              { item.name }
-            </span>}
+            </SfLink> : <span> { item.name } </span>}
           </li>
         ))}
       </ol>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsSeparator.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsSeparator.tsx
@@ -72,13 +72,19 @@ export function Showcase() {
             key={item.name}
           >
             {index !== 0 ? <SfIconChevronRight size="sm" className="mx-0.5 text-disabled-500" /> : null}
-            {index < breadcrumbs.length - 1 ? <SfLink
+            {
+            (index < breadcrumbs.length - 1 ? (
+            <SfLink
               href={item.link}
               variant="secondary"
               className="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
             >
               {item.name}
-            </SfLink> : <span> { item.name } </span>}
+            </SfLink>
+            ) : (
+              <span> {item.name} </span>
+            )
+            )}
           </li>
         ))}
       </ol>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.tsx
@@ -87,9 +87,7 @@ export function Showcase() {
                 {item.name}
               </SfLink>
             ) : (
-              <span>
-              {item.name}
-            </span>
+              <span> {item.name} </span>
             )}
           </li>
         ))}

--- a/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.tsx
@@ -68,7 +68,7 @@ export function Showcase() {
         </li>
         {breadcrumbs.map((item, index) => (
           <li
-            className="peer hidden sm:flex peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
+            className="peer hidden sm:flex items-center peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
             key={item.name}
           >
             {index === 0 ? (
@@ -79,7 +79,7 @@ export function Showcase() {
               >
                 <SfIconHome size="sm" />
               </SfLink>
-            ) : index !== breadcrumbs.length ? (
+            ) : index < breadcrumbs.length - 1 ? (
               <SfLink
                 href={item.link}
                 variant="secondary"

--- a/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.tsx
@@ -67,7 +67,7 @@ export function Showcase() {
         </li>
         {breadcrumbs.map((item, index) => (
           <li
-            className="peer hidden sm:flex items-center peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
+            className="peer hidden sm:flex peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
             key={item.name}
           >
             {index === 0 ? (
@@ -78,7 +78,7 @@ export function Showcase() {
               >
                 <SfIconHome size="sm" />
               </SfLink>
-            ) : index < breadcrumbs.length - 1 ? (
+            ) : index !== breadcrumbs.length ? (
               <SfLink
                 href={item.link}
                 variant="secondary"

--- a/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.tsx
@@ -67,7 +67,7 @@ export function Showcase() {
         </li>
         {breadcrumbs.map((item, index) => (
           <li
-            className="peer hidden sm:flex peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
+            className="peer hidden sm:flex items-center peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
             key={item.name}
           >
             {index === 0 ? (
@@ -78,7 +78,7 @@ export function Showcase() {
               >
                 <SfIconHome size="sm" />
               </SfLink>
-            ) : (
+            ) : index < breadcrumbs.length - 1 ? (
               <SfLink
                 href={item.link}
                 variant="secondary"
@@ -86,6 +86,10 @@ export function Showcase() {
               >
                 {item.name}
               </SfLink>
+            ) : (
+              <span>
+              { item.name }
+            </span>
             )}
           </li>
         ))}

--- a/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.tsx
@@ -88,7 +88,7 @@ export function Showcase() {
               </SfLink>
             ) : (
               <span>
-              { item.name }
+              {item.name}
             </span>
             )}
           </li>

--- a/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.tsx
+++ b/apps/preview/next/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import { useState } from 'react';
 import { SfDropdown, SfButton, SfLink, SfIconMoreHoriz, SfIconHome } from '@storefront-ui/react';
 import { ShowcasePageLayout } from '../../showcases';

--- a/apps/preview/nuxt/pages/showcases/Breadcrumbs/Breadcrumbs.vue
+++ b/apps/preview/nuxt/pages/showcases/Breadcrumbs/Breadcrumbs.vue
@@ -34,17 +34,21 @@
         </SfDropdown>
       </li>
       <li
-        v-for="item in breadcrumbs"
+        v-for="(item, index) in breadcrumbs"
         :key="item.name"
-        class="peer hidden sm:flex peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
+        class="peer hidden sm:flex items-center peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
       >
         <SfLink
+          v-if="index < breadcrumbs.length - 1"
           :href="item.link"
           variant="secondary"
           class="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
         >
           {{ item.name }}
         </SfLink>
+        <span v-else>
+          {{ item.name }}
+        </span>
       </li>
     </ol>
   </nav>

--- a/apps/preview/nuxt/pages/showcases/Breadcrumbs/BreadcrumbsSeparator.vue
+++ b/apps/preview/nuxt/pages/showcases/Breadcrumbs/BreadcrumbsSeparator.vue
@@ -34,18 +34,22 @@
         </SfDropdown>
       </li>
       <li
-        v-for="item in breadcrumbs"
+        v-for="(item, index) in breadcrumbs"
         :key="item.name"
         icon=""
         class="peer hidden sm:flex items-center peer-[:nth-of-type(even)]:before:content-[url('@assets/chevron_right.svg')] peer-[:nth-of-type(even)]:before:inline-flex last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
       >
         <SfLink
+          v-if="index < breadcrumbs.length - 1"
           :href="item.link"
           variant="secondary"
           class="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
         >
           {{ item.name }}
         </SfLink>
+        <span v-else>
+          {{ item.name }}
+        </span>
       </li>
     </ol>
   </nav>

--- a/apps/preview/nuxt/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.vue
+++ b/apps/preview/nuxt/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.vue
@@ -36,7 +36,7 @@
       <li
         v-for="(item, index) in breadcrumbs"
         :key="item.name"
-        class="peer hidden sm:flex peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
+        class="peer hidden sm:flex items-center peer-[:nth-of-type(even)]:before:content-['/'] peer-[:nth-of-type(even)]:before:px-2 peer-[:nth-of-type(even)]:before:leading-5 last-of-type:flex last-of-type:before:font-normal last-of-type:before:text-neutral-500 text-neutral-500 last-of-type:text-neutral-900 last-of-type:font-medium"
       >
         <SfLink
           v-if="index === 0"
@@ -47,13 +47,16 @@
           <SfIconHome size="sm" />
         </SfLink>
         <SfLink
-          v-else
+          v-else-if="index < breadcrumbs.length - 1"
           :href="item.link"
           variant="secondary"
           class="leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-inherit"
         >
           {{ item.name }}
         </SfLink>
+        <span v-else>
+          {{ item.name }}
+        </span>
       </li>
     </ol>
   </nav>

--- a/apps/preview/nuxt/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.vue
+++ b/apps/preview/nuxt/pages/showcases/Breadcrumbs/BreadcrumbsWithIcon.vue
@@ -42,7 +42,7 @@
           v-if="index === 0"
           :href="item.link"
           variant="secondary"
-          class-name="inline-flex leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-neutral-500"
+          class="inline-flex leading-5 no-underline hover:underline active:underline whitespace-nowrap outline-secondary-600 text-neutral-500"
         >
           <SfIconHome size="sm" />
         </SfLink>


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes # https://vsf.atlassian.net/jira/software/c/projects/SFUI2/boards/146?modal=detail&selectedIssue=SFUI2-992

# Scope of work

Last item is not a link

<!-- describe what you did -->

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
