### PR TITLE
fix: mega menu focusing [SFUI2-1110]

### DIFF
--- a/apps/docs/components/hooks/useDropdown.md
+++ b/apps/docs/components/hooks/useDropdown.md
@@ -94,6 +94,7 @@ For a full list of the possible parameters and return values, see the API sectio
 | --------- | ------------------------ | ------------- | ----------------------------------------- |
 | onClose\* | `() => void`             |               |                                           |
 <!-- react -->
+| onCloseDeps | `string[]`             |               | Dependency array for `useMemo` for `onClose` function |
 | isOpen  | `boolean`                |  `false`             | Recalculates position when isOpen is true |
 <!-- end react -->
 <!-- vue -->

--- a/apps/docs/components/hooks/useScrollable.md
+++ b/apps/docs/components/hooks/useScrollable.md
@@ -5,9 +5,11 @@ description: An easy to use function for creating scrollable slider.
 ---
 
 # useScrollable
+
 ::: warning This is an experimental component
 This component is shipped in our NPM package, but its API might change based on user feedback.
 :::
+
 :::::: slot usage
 
 `useScrollable` gives possibility to create slider scrollable with e.g thumbnails.

--- a/apps/docs/components/hooks/useTrapFocus.md
+++ b/apps/docs/components/hooks/useTrapFocus.md
@@ -41,6 +41,7 @@ function CustomTooltip(props: Props) {
   );
 }
 ```
+
 </SourceCode>
 
 <!-- end react -->
@@ -65,11 +66,16 @@ useTrapFocus(focusTrapElementRef)
   </div>
 </template>
 ```
+
 </SourceCode>
 <!-- end vue -->
 ::::::
 
-::: slot api
+:::::: slot api
+
+::: warning DEPRECATION
+Parameter `arrowKeysOn` will be deprecated since version 2.3
+:::
 
 ## Parameters
 
@@ -90,8 +96,10 @@ useTrapFocus(focusTrapElementRef)
 <!-- react -->
 | activeState  | `boolean` | `true`              | Mount `useTrapFocus` when active is `true`  |
 <!-- end react -->
-| initialFocus    | `number | 'autofocus'` | `0`       | index number of desired focus element on init or first marked element with attribute `autofocus`, for disabling this option use `false` value  |
+| initialFocus    | `number | 'autofocus' | 'container'` | `0`       | index number of desired focus element on init, `autofocus` for first marked element with attribute `autofocus`, `container` so `refElement` would be initially focused, `false` for disabling this option  |
 | arrowKeysOn | `boolean`    | `false`      | Enable/Disable possibility of using keyboard arrows `left`/`right` for jumping through focusable elements              |
+| arrowKeysLeftRight | `boolean`    | `false`      | Enable/Disable possibility of using keyboard arrows `left | up`/`right | down` for jumping through focusable elements              |
+| arrowKeysUpDown | `boolean`    | `false`      | Enable/Disable possibility of using keyboard arrows `up`/`down` for jumping through focusable elements              |
 | initialFocusContainerFallback | `boolean`  | `false`     | Fallback for initial focus           |
 
 ## Return value
@@ -109,7 +117,7 @@ useTrapFocus(focusTrapElementRef)
 | focusPrev           | `() => void` |               |  When trigger jumps to previous focusable element |
 | focusNext           | `() => void` |               |  When trigger jumps to next focusable element |
 
-:::
+::::::
 
 ::: slot source
 <SourceCode>

--- a/apps/docs/components/hooks/useTrapFocus.md
+++ b/apps/docs/components/hooks/useTrapFocus.md
@@ -73,8 +73,9 @@ useTrapFocus(focusTrapElementRef)
 
 :::::: slot api
 
+<!-- TODO: remove arrowKeysOn before 3.0.0 release -->
 ::: warning DEPRECATION
-Parameter `arrowKeysOn` will be deprecated since version 2.3
+Parameter `arrowKeysOn` will be deprecated since version 2.3 and removed in next major version.
 :::
 
 ## Parameters

--- a/apps/docs/components/hooks/useTrapFocus.md
+++ b/apps/docs/components/hooks/useTrapFocus.md
@@ -98,7 +98,7 @@ Parameter `arrowKeysOn` will be deprecated since version 2.3 and removed in next
 | activeState  | `boolean` | `true`              | Mount `useTrapFocus` when active is `true`  |
 <!-- end react -->
 | initialFocus    | `number | 'autofocus' | 'container'` | `0`       | index number of desired focus element on init, `autofocus` for first marked element with attribute `autofocus`, `container` so `refElement` would be initially focused, `false` for disabling this option  |
-| arrowKeysOn | `boolean`    | `false`      | Enable/Disable possibility of using keyboard arrows `left`/`right` for jumping through focusable elements              |
+| arrowKeysOn | `boolean`    | `false`      | (deprecated) Enable/Disable possibility of using keyboard arrows `left`/`right` for jumping through focusable elements              |
 | arrowKeysLeftRight | `boolean`    | `false`      | Enable/Disable possibility of using keyboard arrows `left | up`/`right | down` for jumping through focusable elements              |
 | arrowKeysUpDown | `boolean`    | `false`      | Enable/Disable possibility of using keyboard arrows `up`/`down` for jumping through focusable elements              |
 | initialFocusContainerFallback | `boolean`  | `false`     | Fallback for initial focus           |

--- a/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/BaseMegaMenu.tsx
@@ -48,27 +48,27 @@ const categoriesContent = [
     items: [
       {
         title: "All Women's",
-        link: '/',
+        link: '#',
       },
       {
         title: 'Clothing',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Shoes',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Accessories',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Wearables',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Food & Drinks',
-        link: '/',
+        link: '#',
       },
     ],
   },
@@ -77,27 +77,27 @@ const categoriesContent = [
     items: [
       {
         title: 'All Men’s',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Clothing',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Shoes',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Accessories',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Wearables',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Food & Drinks',
-        link: '/',
+        link: '#',
       },
     ],
   },
@@ -106,37 +106,42 @@ const categoriesContent = [
     items: [
       {
         title: 'All Kids',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Clothing',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Shoes',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Accessories',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Wearables',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Food & Drinks',
-        link: '/',
+        link: '#',
       },
     ],
   },
 ];
 
 export default function BaseMegaMenu() {
-  const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
+  const { close, toggle, isOpen } = useDisclosure();
   const drawerRef = useRef(null);
   const menuRef = useRef(null);
-  useTrapFocus(drawerRef, { activeState: isOpen, arrowKeysOn: true });
+
+  useTrapFocus(drawerRef, {
+    activeState: isOpen,
+    arrowKeysUpDown: true,
+    initialFocus: 'container',
+  });
   useClickAway(menuRef, () => {
     close();
   });

--- a/apps/preview/next/pages/showcases/MegaMenu/MegaMenuNavigation.tsx
+++ b/apps/preview/next/pages/showcases/MegaMenu/MegaMenuNavigation.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 import { ShowcasePageLayout } from '../../showcases';
 // #region source
 import {
@@ -8,15 +10,15 @@ import {
   SfButton,
   SfDrawer,
   SfListItem,
-  useDisclosure,
-  useTrapFocus,
   SfIconChevronRight,
-  useDropdown,
   SfIconMenu,
   SfCounter,
   SfIconArrowBack,
+  useDropdown,
+  useTrapFocus,
+  useDisclosure,
 } from '@storefront-ui/react';
-import { type FocusEvent, Fragment, useRef, useState } from 'react';
+import { type FocusEvent, Fragment, useRef, useState, useMemo, createRef, RefObject } from 'react';
 
 const actionItems = [
   {
@@ -69,7 +71,7 @@ const content: Node = {
       children: [
         {
           key: 'ALL_WOMEN',
-          value: { label: "All Women's", counter: 515, link: '/' },
+          value: { label: "All Women's", counter: 515, link: '#' },
           isLeaf: true,
         },
         {
@@ -79,32 +81,32 @@ const content: Node = {
           children: [
             {
               key: 'ALL_CATEGORIES',
-              value: { label: 'All Categories', counter: 178, link: '/' },
+              value: { label: 'All Categories', counter: 178, link: '#' },
               isLeaf: true,
             },
             {
               key: 'CLOTHING',
-              value: { label: 'Clothing', counter: 30, link: '/' },
+              value: { label: 'Clothing', counter: 30, link: '#' },
               isLeaf: true,
             },
             {
               key: 'SHOES',
-              value: { label: 'Shoes', counter: 28, link: '/' },
+              value: { label: 'Shoes', counter: 28, link: '#' },
               isLeaf: true,
             },
             {
               key: 'ACCESSORIES',
-              value: { label: 'Accessories', counter: 56, link: '/' },
+              value: { label: 'Accessories', counter: 56, link: '#' },
               isLeaf: true,
             },
             {
               key: 'WEARABLES',
-              value: { label: 'Wearables', counter: 12, link: '/' },
+              value: { label: 'Wearables', counter: 12, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FOOD_DRINKS',
-              value: { label: 'Food & Drinks', counter: 52, link: '/' },
+              value: { label: 'Food & Drinks', counter: 52, link: '#' },
               isLeaf: true,
             },
           ],
@@ -116,32 +118,32 @@ const content: Node = {
           children: [
             {
               key: 'ALL_ACTIVITIES',
-              value: { label: 'All Activities', counter: 239, link: '/' },
+              value: { label: 'All Activities', counter: 239, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FITNESS',
-              value: { label: 'Fitness', counter: 83, link: '/' },
+              value: { label: 'Fitness', counter: 83, link: '#' },
               isLeaf: true,
             },
             {
               key: 'PILATES',
-              value: { label: 'Pilates', counter: 65, link: '/' },
+              value: { label: 'Pilates', counter: 65, link: '#' },
               isLeaf: true,
             },
             {
               key: 'TRAINING',
-              value: { label: 'Training', counter: 21, link: '/' },
+              value: { label: 'Training', counter: 21, link: '#' },
               isLeaf: true,
             },
             {
               key: 'CARDIO_WORKOUT',
-              value: { label: 'Cardio Workout', counter: 50, link: '/' },
+              value: { label: 'Cardio Workout', counter: 50, link: '#' },
               isLeaf: true,
             },
             {
               key: 'YOGA',
-              value: { label: 'Yoga', counter: 20, link: '/' },
+              value: { label: 'Yoga', counter: 20, link: '#' },
               isLeaf: true,
             },
           ],
@@ -153,12 +155,12 @@ const content: Node = {
           children: [
             {
               key: 'ALL_DEALS',
-              value: { label: 'All Deals', counter: 98, link: '/' },
+              value: { label: 'All Deals', counter: 98, link: '#' },
               isLeaf: true,
             },
             {
               key: 'OUTLET',
-              value: { label: 'Outlet', counter: 98, link: '/' },
+              value: { label: 'Outlet', counter: 98, link: '#' },
               isLeaf: true,
             },
           ],
@@ -177,7 +179,7 @@ const content: Node = {
       children: [
         {
           key: 'ALL_MEN',
-          value: { label: "All Men's", counter: 364, link: '/' },
+          value: { label: "All Men's", counter: 364, link: '#' },
           isLeaf: true,
         },
         {
@@ -187,32 +189,32 @@ const content: Node = {
           children: [
             {
               key: 'ALL_CATEGORIES',
-              value: { label: 'All Categories', counter: 164, link: '/' },
+              value: { label: 'All Categories', counter: 164, link: '#' },
               isLeaf: true,
             },
             {
               key: 'CLOTHING',
-              value: { label: 'Clothing', counter: 41, link: '/' },
+              value: { label: 'Clothing', counter: 41, link: '#' },
               isLeaf: true,
             },
             {
               key: 'SHOES',
-              value: { label: 'Shoes', counter: 20, link: '/' },
+              value: { label: 'Shoes', counter: 20, link: '#' },
               isLeaf: true,
             },
             {
               key: 'ACCESSORIES',
-              value: { label: 'Accessories', counter: 56, link: '/' },
+              value: { label: 'Accessories', counter: 56, link: '#' },
               isLeaf: true,
             },
             {
               key: 'WEARABLES',
-              value: { label: 'Wearables', counter: 32, link: '/' },
+              value: { label: 'Wearables', counter: 32, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FOOD_DRINKS',
-              value: { label: 'Food & Drinks', counter: 15, link: '/' },
+              value: { label: 'Food & Drinks', counter: 15, link: '#' },
               isLeaf: true,
             },
           ],
@@ -224,27 +226,27 @@ const content: Node = {
           children: [
             {
               key: 'ALL_ACTIVITIES',
-              value: { label: 'All Activities', counter: 132, link: '/' },
+              value: { label: 'All Activities', counter: 132, link: '#' },
               isLeaf: true,
             },
             {
               key: 'TRAINING',
-              value: { label: 'Training', counter: 21, link: '/' },
+              value: { label: 'Training', counter: 21, link: '#' },
               isLeaf: true,
             },
             {
               key: 'WORKOUT',
-              value: { label: 'Workout', counter: 43, link: '/' },
+              value: { label: 'Workout', counter: 43, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FOOTBALL',
-              value: { label: 'Football', counter: 30, link: '/' },
+              value: { label: 'Football', counter: 30, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FITNESS',
-              value: { label: 'Fitness', counter: 38, link: '/' },
+              value: { label: 'Fitness', counter: 38, link: '#' },
               isLeaf: true,
             },
           ],
@@ -256,12 +258,12 @@ const content: Node = {
           children: [
             {
               key: 'ALL_DEALS',
-              value: { label: 'All Deals', counter: 68, link: '/' },
+              value: { label: 'All Deals', counter: 68, link: '#' },
               isLeaf: true,
             },
             {
               key: 'OUTLET',
-              value: { label: 'Outlet', counter: 68, link: '/' },
+              value: { label: 'Outlet', counter: 68, link: '#' },
               isLeaf: true,
             },
           ],
@@ -280,7 +282,7 @@ const content: Node = {
       children: [
         {
           key: 'ALL_KIDS',
-          value: { label: 'All Kids', counter: 263, link: '/' },
+          value: { label: 'All Kids', counter: 263, link: '#' },
           isLeaf: true,
         },
         {
@@ -290,32 +292,32 @@ const content: Node = {
           children: [
             {
               key: 'ALL_CATEGORIES',
-              value: { label: 'All Categories', counter: 192, link: '/' },
+              value: { label: 'All Categories', counter: 192, link: '#' },
               isLeaf: true,
             },
             {
               key: 'CLOTHING',
-              value: { label: 'Clothing', counter: 29, link: '/' },
+              value: { label: 'Clothing', counter: 29, link: '#' },
               isLeaf: true,
             },
             {
               key: 'SHOES',
-              value: { label: 'Shoes', counter: 60, link: '/' },
+              value: { label: 'Shoes', counter: 60, link: '#' },
               isLeaf: true,
             },
             {
               key: 'ACCESSORIES',
-              value: { label: 'Accessories', counter: 48, link: '/' },
+              value: { label: 'Accessories', counter: 48, link: '#' },
               isLeaf: true,
             },
             {
               key: 'WEARABLES',
-              value: { label: 'Wearables', counter: 22, link: '/' },
+              value: { label: 'Wearables', counter: 22, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FOOD_DRINKS',
-              value: { label: 'Food & Drinks', counter: 33, link: '/' },
+              value: { label: 'Food & Drinks', counter: 33, link: '#' },
               isLeaf: true,
             },
           ],
@@ -327,17 +329,17 @@ const content: Node = {
           children: [
             {
               key: 'ALL_ACTIVITIES',
-              value: { label: 'All Activities', counter: 40, link: '/' },
+              value: { label: 'All Activities', counter: 40, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FOOTBALL',
-              value: { label: 'Football', counter: 21, link: '/' },
+              value: { label: 'Football', counter: 21, link: '#' },
               isLeaf: true,
             },
             {
               key: 'BASKETBALL',
-              value: { label: 'Basketball', counter: 19, link: '/' },
+              value: { label: 'Basketball', counter: 19, link: '#' },
               isLeaf: true,
             },
           ],
@@ -349,12 +351,12 @@ const content: Node = {
           children: [
             {
               key: 'ALL_DEALS',
-              value: { label: 'All Deals', counter: 31, link: '/' },
+              value: { label: 'All Deals', counter: 31, link: '#' },
               isLeaf: true,
             },
             {
               key: 'OUTLET',
-              value: { label: 'Outlet', counter: 31, link: '/' },
+              value: { label: 'Outlet', counter: 31, link: '#' },
               isLeaf: true,
             },
           ],
@@ -373,11 +375,40 @@ const findNode = (keys: string[], node: Node): Node => {
 };
 
 export default function MegaMenuNavigation() {
-  const { close, open, isOpen } = useDisclosure({ initialValue: false });
-  const { refs, style } = useDropdown({ isOpen, onClose: close, placement: 'bottom-start', middleware: [] });
   const drawerRef = useRef(null);
-  useTrapFocus(drawerRef, { activeState: isOpen, arrowKeysOn: true });
+  const megaMenuRef = useRef(null);
   const [activeNode, setActiveNode] = useState<string[]>([]);
+
+  const refsByKey = useMemo(() => {
+    const buttonRefs: Record<string, RefObject<HTMLButtonElement>> = {};
+    content.children?.forEach((item) => {
+      buttonRefs[item.key] = createRef();
+    });
+    return buttonRefs;
+  }, [content.children]);
+
+  const { close, open, isOpen } = useDisclosure();
+  const { refs, style } = useDropdown({
+    isOpen,
+    onClose: (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        refsByKey[activeNode[0]]?.current?.focus();
+      }
+      close();
+    },
+    placement: 'bottom-start',
+    middleware: [],
+    onCloseDeps: [activeNode],
+  });
+
+  const trapFocusOptions = {
+    activeState: isOpen,
+    arrowKeysUpDown: true,
+    initialFocus: 'container',
+  } as const;
+  useTrapFocus(megaMenuRef, trapFocusOptions);
+  useTrapFocus(drawerRef, trapFocusOptions);
+
   const activeMenu = findNode(activeNode, content);
   const bannerNode = findNode(activeNode.slice(0, 1), content);
 
@@ -456,6 +487,7 @@ export default function MegaMenuNavigation() {
                   variant="tertiary"
                   onMouseEnter={handleOpenMenu([menuNode.key])}
                   onClick={handleOpenMenu([menuNode.key])}
+                  ref={refsByKey[menuNode.key]}
                   className="group mr-2 !text-neutral-900 hover:!bg-neutral-200 hover:!text-neutral-700 active:!bg-neutral-300 active:!text-neutral-900"
                 >
                   <span>{menuNode.value.label}</span>
@@ -466,7 +498,9 @@ export default function MegaMenuNavigation() {
                   <div
                     key={activeMenu.key}
                     style={style}
-                    className="hidden md:grid gap-x-6 grid-cols-4 bg-white shadow-lg p-6 left-0 right-0"
+                    ref={megaMenuRef}
+                    className="hidden md:grid gap-x-6 grid-cols-4 bg-white shadow-lg p-6 left-0 right-0 outline-none"
+                    tabIndex={0}
                     onMouseLeave={close}
                   >
                     {activeMenu.children?.map((node) =>

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/BaseMegaMenu.vue
@@ -149,11 +149,14 @@ const { isOpen, toggle, close } = useDisclosure();
 const menuRef = ref();
 const drawerRef = ref();
 
+useTrapFocus(drawerRef, {
+  activeState: isOpen,
+  arrowKeysUpDown: true,
+  initialFocus: 'container',
+});
 onClickOutside(menuRef, () => {
   close();
 });
-
-useTrapFocus(drawerRef, { activeState: isOpen, arrowKeysOn: true });
 
 const actionItems = [
   {
@@ -186,27 +189,27 @@ const categoriesContent = [
     items: [
       {
         title: "All Women's",
-        link: '/',
+        link: '#',
       },
       {
         title: 'Clothing',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Shoes',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Accessories',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Wearables',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Food & Drinks',
-        link: '/',
+        link: '#',
       },
     ],
   },
@@ -215,27 +218,27 @@ const categoriesContent = [
     items: [
       {
         title: 'All Men’s',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Clothing',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Shoes',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Accessories',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Wearables',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Food & Drinks',
-        link: '/',
+        link: '#',
       },
     ],
   },
@@ -244,27 +247,27 @@ const categoriesContent = [
     items: [
       {
         title: 'All Kids',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Clothing',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Shoes',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Accessories',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Wearables',
-        link: '/',
+        link: '#',
       },
       {
         title: 'Food & Drinks',
-        link: '/',
+        link: '#',
       },
     ],
   },

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/MegaMenuNavigation.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/MegaMenuNavigation.vue
@@ -45,7 +45,7 @@
           </SfButton>
         </div>
       </div>
-
+      <!-- Desktop dropdown -->
       <nav ref="floatingRef">
         <ul
           class="hidden md:flex px-6 py-2 bg-white border-b border-b-neutral-200 border-b-solid"
@@ -57,8 +57,9 @@
             }
           "
         >
-          <li v-for="menuNode in content.children" :key="menuNode.key">
+          <li v-for="(menuNode, index) in content.children" :key="menuNode.key">
             <SfButton
+              ref="triggerRefs"
               variant="tertiary"
               class="group mr-2 !text-neutral-900 hover:!bg-neutral-200 hover:!text-neutral-700 active:!bg-neutral-300 active:!text-neutral-900"
               @mouseenter="openMenu([menuNode.key])"
@@ -73,9 +74,12 @@
             <div
               v-if="isOpen && activeNode.length === 1 && activeNode[0] === menuNode.key"
               :key="activeMenu.key"
+              ref="megaMenuRef"
               :style="style"
-              class="hidden md:grid gap-x-6 grid-cols-4 bg-white shadow-lg p-6 left-0 right-0"
+              class="hidden md:grid gap-x-6 grid-cols-4 bg-white shadow-lg p-6 left-0 right-0 outline-none"
+              tabindex="0"
               @mouseleave="close()"
+              @keydown.esc="focusTrigger(index)"
             >
               <template v-for="node in activeMenu.children" :key="node.key">
                 <template v-if="node.isLeaf">
@@ -112,6 +116,7 @@
         </ul>
       </nav>
 
+      <!-- Mobile drawer -->
       <div v-if="isOpen" class="md:hidden fixed inset-0 bg-neutral-500 bg-opacity-50" />
       <SfDrawer ref="drawerRef" v-model="isOpen" placement="left" class="md:hidden bg-white w-[320px] overflow-y-auto">
         <nav>
@@ -184,15 +189,16 @@ import {
   SfButton,
   SfDrawer,
   SfListItem,
-  useDisclosure,
-  useTrapFocus,
   SfIconChevronRight,
-  useDropdown,
   SfIconMenu,
   SfCounter,
   SfIconArrowBack,
+  useDisclosure,
+  useTrapFocus,
+  useDropdown,
 } from '@storefront-ui/vue';
 import { ref, computed } from 'vue';
+import { unrefElement } from '@vueuse/core';
 
 const findNode = (keys: string[], node: Node): Node => {
   if (keys.length > 1) {
@@ -203,18 +209,32 @@ const findNode = (keys: string[], node: Node): Node => {
   }
 };
 
-const { close, open, isOpen } = useDisclosure({ initialValue: false });
+const { close, open, isOpen } = useDisclosure();
 const { referenceRef, floatingRef, style } = useDropdown({
   isOpen,
   onClose: close,
   placement: 'bottom-start',
   middleware: [],
 });
+
 const drawerRef = ref();
-useTrapFocus(drawerRef, { activeState: isOpen, arrowKeysOn: true });
+const megaMenuRef = ref();
+const triggerRefs = ref();
 const activeNode = ref<string[]>([]);
+
 const activeMenu = computed(() => findNode(activeNode.value, content));
 const bannerNode = computed(() => findNode(activeNode.value.slice(0, 1), content));
+
+const trapFocusOptions = {
+  activeState: isOpen,
+  arrowKeysUpDown: true,
+  initialFocus: 'container',
+} as const;
+useTrapFocus(
+  computed(() => megaMenuRef.value?.[0]),
+  trapFocusOptions,
+);
+useTrapFocus(drawerRef, trapFocusOptions);
 
 const openMenu = (menuType: string[]) => {
   activeNode.value = menuType;
@@ -227,6 +247,10 @@ const goBack = () => {
 
 const goNext = (key: string) => {
   activeNode.value = [...activeNode.value, key];
+};
+
+const focusTrigger = (index: number) => {
+  unrefElement(triggerRefs.value[index]).focus();
 };
 
 const actionItems = [
@@ -280,7 +304,7 @@ const content: Node = {
       children: [
         {
           key: 'ALL_WOMEN',
-          value: { label: "All Women's", counter: 515, link: '/' },
+          value: { label: "All Women's", counter: 515, link: '#' },
           isLeaf: true,
         },
         {
@@ -290,32 +314,32 @@ const content: Node = {
           children: [
             {
               key: 'ALL_CATEGORIES',
-              value: { label: 'All Categories', counter: 178, link: '/' },
+              value: { label: 'All Categories', counter: 178, link: '#' },
               isLeaf: true,
             },
             {
               key: 'CLOTHING',
-              value: { label: 'Clothing', counter: 30, link: '/' },
+              value: { label: 'Clothing', counter: 30, link: '#' },
               isLeaf: true,
             },
             {
               key: 'SHOES',
-              value: { label: 'Shoes', counter: 28, link: '/' },
+              value: { label: 'Shoes', counter: 28, link: '#' },
               isLeaf: true,
             },
             {
               key: 'ACCESSORIES',
-              value: { label: 'Accessories', counter: 56, link: '/' },
+              value: { label: 'Accessories', counter: 56, link: '#' },
               isLeaf: true,
             },
             {
               key: 'WEARABLES',
-              value: { label: 'Wearables', counter: 12, link: '/' },
+              value: { label: 'Wearables', counter: 12, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FOOD_DRINKS',
-              value: { label: 'Food & Drinks', counter: 52, link: '/' },
+              value: { label: 'Food & Drinks', counter: 52, link: '#' },
               isLeaf: true,
             },
           ],
@@ -327,32 +351,32 @@ const content: Node = {
           children: [
             {
               key: 'ALL_ACTIVITIES',
-              value: { label: 'All Activities', counter: 239, link: '/' },
+              value: { label: 'All Activities', counter: 239, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FITNESS',
-              value: { label: 'Fitness', counter: 83, link: '/' },
+              value: { label: 'Fitness', counter: 83, link: '#' },
               isLeaf: true,
             },
             {
               key: 'PILATES',
-              value: { label: 'Pilates', counter: 65, link: '/' },
+              value: { label: 'Pilates', counter: 65, link: '#' },
               isLeaf: true,
             },
             {
               key: 'TRAINING',
-              value: { label: 'Training', counter: 21, link: '/' },
+              value: { label: 'Training', counter: 21, link: '#' },
               isLeaf: true,
             },
             {
               key: 'CARDIO_WORKOUT',
-              value: { label: 'Cardio Workout', counter: 50, link: '/' },
+              value: { label: 'Cardio Workout', counter: 50, link: '#' },
               isLeaf: true,
             },
             {
               key: 'YOGA',
-              value: { label: 'Yoga', counter: 20, link: '/' },
+              value: { label: 'Yoga', counter: 20, link: '#' },
               isLeaf: true,
             },
           ],
@@ -364,12 +388,12 @@ const content: Node = {
           children: [
             {
               key: 'ALL_DEALS',
-              value: { label: 'All Deals', counter: 98, link: '/' },
+              value: { label: 'All Deals', counter: 98, link: '#' },
               isLeaf: true,
             },
             {
               key: 'OUTLET',
-              value: { label: 'Outlet', counter: 98, link: '/' },
+              value: { label: 'Outlet', counter: 98, link: '#' },
               isLeaf: true,
             },
           ],
@@ -388,7 +412,7 @@ const content: Node = {
       children: [
         {
           key: 'ALL_MEN',
-          value: { label: "All Men's", counter: 364, link: '/' },
+          value: { label: "All Men's", counter: 364, link: '#' },
           isLeaf: true,
         },
         {
@@ -398,32 +422,32 @@ const content: Node = {
           children: [
             {
               key: 'ALL_CATEGORIES',
-              value: { label: 'All Categories', counter: 164, link: '/' },
+              value: { label: 'All Categories', counter: 164, link: '#' },
               isLeaf: true,
             },
             {
               key: 'CLOTHING',
-              value: { label: 'Clothing', counter: 41, link: '/' },
+              value: { label: 'Clothing', counter: 41, link: '#' },
               isLeaf: true,
             },
             {
               key: 'SHOES',
-              value: { label: 'Shoes', counter: 20, link: '/' },
+              value: { label: 'Shoes', counter: 20, link: '#' },
               isLeaf: true,
             },
             {
               key: 'ACCESSORIES',
-              value: { label: 'Accessories', counter: 56, link: '/' },
+              value: { label: 'Accessories', counter: 56, link: '#' },
               isLeaf: true,
             },
             {
               key: 'WEARABLES',
-              value: { label: 'Wearables', counter: 32, link: '/' },
+              value: { label: 'Wearables', counter: 32, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FOOD_DRINKS',
-              value: { label: 'Food & Drinks', counter: 15, link: '/' },
+              value: { label: 'Food & Drinks', counter: 15, link: '#' },
               isLeaf: true,
             },
           ],
@@ -435,27 +459,27 @@ const content: Node = {
           children: [
             {
               key: 'ALL_ACTIVITIES',
-              value: { label: 'All Activities', counter: 132, link: '/' },
+              value: { label: 'All Activities', counter: 132, link: '#' },
               isLeaf: true,
             },
             {
               key: 'TRAINING',
-              value: { label: 'Training', counter: 21, link: '/' },
+              value: { label: 'Training', counter: 21, link: '#' },
               isLeaf: true,
             },
             {
               key: 'WORKOUT',
-              value: { label: 'Workout', counter: 43, link: '/' },
+              value: { label: 'Workout', counter: 43, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FOOTBALL',
-              value: { label: 'Football', counter: 30, link: '/' },
+              value: { label: 'Football', counter: 30, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FITNESS',
-              value: { label: 'Fitness', counter: 38, link: '/' },
+              value: { label: 'Fitness', counter: 38, link: '#' },
               isLeaf: true,
             },
           ],
@@ -467,12 +491,12 @@ const content: Node = {
           children: [
             {
               key: 'ALL_DEALS',
-              value: { label: 'All Deals', counter: 68, link: '/' },
+              value: { label: 'All Deals', counter: 68, link: '#' },
               isLeaf: true,
             },
             {
               key: 'OUTLET',
-              value: { label: 'Outlet', counter: 68, link: '/' },
+              value: { label: 'Outlet', counter: 68, link: '#' },
               isLeaf: true,
             },
           ],
@@ -491,7 +515,7 @@ const content: Node = {
       children: [
         {
           key: 'ALL_KIDS',
-          value: { label: 'All Kids', counter: 263, link: '/' },
+          value: { label: 'All Kids', counter: 263, link: '#' },
           isLeaf: true,
         },
         {
@@ -501,32 +525,32 @@ const content: Node = {
           children: [
             {
               key: 'ALL_CATEGORIES',
-              value: { label: 'All Categories', counter: 192, link: '/' },
+              value: { label: 'All Categories', counter: 192, link: '#' },
               isLeaf: true,
             },
             {
               key: 'CLOTHING',
-              value: { label: 'Clothing', counter: 29, link: '/' },
+              value: { label: 'Clothing', counter: 29, link: '#' },
               isLeaf: true,
             },
             {
               key: 'SHOES',
-              value: { label: 'Shoes', counter: 60, link: '/' },
+              value: { label: 'Shoes', counter: 60, link: '#' },
               isLeaf: true,
             },
             {
               key: 'ACCESSORIES',
-              value: { label: 'Accessories', counter: 48, link: '/' },
+              value: { label: 'Accessories', counter: 48, link: '#' },
               isLeaf: true,
             },
             {
               key: 'WEARABLES',
-              value: { label: 'Wearables', counter: 22, link: '/' },
+              value: { label: 'Wearables', counter: 22, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FOOD_DRINKS',
-              value: { label: 'Food & Drinks', counter: 33, link: '/' },
+              value: { label: 'Food & Drinks', counter: 33, link: '#' },
               isLeaf: true,
             },
           ],
@@ -538,17 +562,17 @@ const content: Node = {
           children: [
             {
               key: 'ALL_ACTIVITIES',
-              value: { label: 'All Activities', counter: 40, link: '/' },
+              value: { label: 'All Activities', counter: 40, link: '#' },
               isLeaf: true,
             },
             {
               key: 'FOOTBALL',
-              value: { label: 'Football', counter: 21, link: '/' },
+              value: { label: 'Football', counter: 21, link: '#' },
               isLeaf: true,
             },
             {
               key: 'BASKETBALL',
-              value: { label: 'Basketball', counter: 19, link: '/' },
+              value: { label: 'Basketball', counter: 19, link: '#' },
               isLeaf: true,
             },
           ],
@@ -560,12 +584,12 @@ const content: Node = {
           children: [
             {
               key: 'ALL_DEALS',
-              value: { label: 'All Deals', counter: 31, link: '/' },
+              value: { label: 'All Deals', counter: 31, link: '#' },
               isLeaf: true,
             },
             {
               key: 'OUTLET',
-              value: { label: 'Outlet', counter: 31, link: '/' },
+              value: { label: 'Outlet', counter: 31, link: '#' },
               isLeaf: true,
             },
           ],

--- a/packages/sfui/frameworks/react/hooks/useDropdown/types.ts
+++ b/packages/sfui/frameworks/react/hooks/useDropdown/types.ts
@@ -3,6 +3,7 @@ import type { UsePopoverOptions } from '../usePopover';
 
 export type UseDropdownOptions = Prettify<
   UsePopoverOptions & {
-    onClose: () => void;
+    onClose: (event: KeyboardEvent) => void;
+    onCloseDeps?: unknown[];
   }
 >;

--- a/packages/sfui/frameworks/react/hooks/useDropdown/useDropdown.ts
+++ b/packages/sfui/frameworks/react/hooks/useDropdown/useDropdown.ts
@@ -4,12 +4,18 @@ import { flip, offset, shift } from '@floating-ui/react-dom';
 import { usePopover, type UseDropdownOptions } from '@storefront-ui/react';
 
 export function useDropdown(options: UseDropdownOptions) {
-  const { onClose, placement = 'bottom', middleware = [offset(8), shift(), flip()], ...popoverOptions } = options;
+  const {
+    onClose,
+    onCloseDeps,
+    placement = 'bottom',
+    middleware = [offset(8), shift(), flip()],
+    ...popoverOptions
+  } = options;
 
   const { refs, style } = usePopover({ placement, middleware, ...popoverOptions });
 
   useClickAway(refs.reference, onClose);
-  useKey('Escape', onClose, { target: refs.reference.current });
+  useKey('Escape', onClose, { target: refs.reference.current }, onCloseDeps);
 
   return { refs, style };
 }


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1110

# Scope of work

- fix focus trap inside megamenu blocks
- change `useTrapFocus` API with possibility of initial focus of `container`
- split `arrowKeysOn` into `arrowKeysLeftRight` and `arrowKeysUpDown`
- fix `useDropdown` and add `onCloseDeps` since internally `useKey` uses `useMemo` 
- change `/` url into `#` since in documentation when you click on desktop link it redirect to `/` 

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
