### PR TITLE
fix: errors during building packages [SFUI2-1163]

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky install",
     "build": "yarn update-browserlist-db && yarn generate-icons && yarn build:peer-next && turbo run build",
     "dev:docs": "yarn update-browserlist-db && turbo run dev:docs",
-    "dev": "yarn update-browserlist-db && yarn build:typography && yarn build:peer-next && yarn build:tailwind-config && yarn build:test-utils && turbo run dev --parallel",
+    "dev": "yarn update-browserlist-db && yarn build:typography && yarn build:peer-next && yarn build:tailwind-config && yarn build:test-utils && yarn build:react && turbo run dev --parallel",
     "dev:shared": "turbo run dev:shared",
     "update-browserlist-db": "yarn dlx browserslist@latest",
     "lint": "yarn build:typography && yarn build:peer-next && yarn build:tailwind-config && turbo run lint",

--- a/packages/config/tailwind/tsconfig.json
+++ b/packages/config/tailwind/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@storefront-ui/typescript-config/base.json",
   "compilerOptions": {
+    "outDir": "./dist",
     "sourceMap": true,
     "noEmit": true,
     "target": "ESNext",
@@ -8,5 +9,6 @@
     "baseUrl": ".",
     "types": ["vite/client"]
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["./dist/**/*"]
 }

--- a/packages/sfui/frameworks/react/tsconfig.json
+++ b/packages/sfui/frameworks/react/tsconfig.json
@@ -3,6 +3,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
+    "outDir": "./dist",
     "declaration": false,
     "declarationMap": false,
     "strictPropertyInitialization": false,
@@ -34,5 +35,6 @@
   "include": [
     "**/*.ts",
     "**/*.tsx"
-  ]
+  ],
+  "exclude": ["./dist/**/*"]
 }

--- a/packages/sfui/frameworks/vue/composables/useTrapFocus/useTrapFocus.ts
+++ b/packages/sfui/frameworks/vue/composables/useTrapFocus/useTrapFocus.ts
@@ -19,6 +19,13 @@ type UseTrapFocusOptions = TabbableOptions &
     arrowKeysOn?: boolean;
   };
 
+type UseTrapFocusReturn = {
+  current: Ref<HTMLElement | undefined>;
+  focusables: Ref<FocusableElement[]>;
+  focusNext: typeof focusNext;
+  focusPrev: typeof focusPrev;
+};
+
 const defaultOptions = {
   trapTabs: true,
   activeState: ref(true),
@@ -27,7 +34,10 @@ const defaultOptions = {
   arrowKeysOn: false,
 };
 
-export const useTrapFocus = (containerElementRef: Ref<HTMLElement | undefined>, options?: UseTrapFocusOptions) => {
+export const useTrapFocus = (
+  containerElementRef: Ref<HTMLElement | undefined>,
+  options?: UseTrapFocusOptions,
+): UseTrapFocusReturn => {
   const {
     trapTabs,
     arrowFocusGroupSelector,

--- a/packages/sfui/frameworks/vue/tsconfig.json
+++ b/packages/sfui/frameworks/vue/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@storefront-ui/typescript-config/base.json",
   "compilerOptions": {
+    "outDir": "./dist",
     "strict": true,
     "skipLibCheck": true,
     "importHelpers": true,
@@ -12,6 +13,7 @@
     "module": "ESNext",
     "allowJs": true,
     "resolveJsonModule": true,
+    "incremental": true,
     "jsx": "preserve",
     "baseUrl": ".",
     "types": [
@@ -24,5 +26,6 @@
   "include": [
     "**/*.ts",
     "**/*.vue"
-  ]
+  ],
+  "exclude": ["./dist/**/*"]
 }

--- a/packages/sfui/shared/tsconfig.json
+++ b/packages/sfui/shared/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@storefront-ui/typescript-config/base.json",
   "compilerOptions": {
+    "outDir": "./dist",
     "strict": true,
     "skipLibCheck": true,
     "importHelpers": true,
@@ -18,7 +19,6 @@
       "vite/client"
     ]
   },
-  "include": [
-    "**/*.ts"
-  ]
+  "include": ["**/*.ts"],
+  "exclude": ["./dist/**/*"]
 }

--- a/packages/sfui/tw-plugin-peer-next/tsconfig.json
+++ b/packages/sfui/tw-plugin-peer-next/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@storefront-ui/typescript-config/base.json",
   "compilerOptions": {
+    "outDir": "./dist",
     "sourceMap": true,
     "noEmit": true,
     "target": "ESNext",
@@ -10,7 +11,6 @@
       "vite/client"
     ]
   },
-  "include": [
-    "**/*.ts"
-  ]
+  "include": ["**/*.ts"],
+  "exclude": ["./dist/**/*"]
 }

--- a/packages/sfui/typography/tsconfig.json
+++ b/packages/sfui/typography/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@storefront-ui/typescript-config/base.json",
   "compilerOptions": {
+    "outDir": "./dist",
     "sourceMap": true,
     "noEmit": true,
     "target": "ESNext",
@@ -10,7 +11,6 @@
       "vite/client"
     ]
   },
-  "include": [
-    "**/*.ts"
-  ]
+  "include": ["**/*.ts"],
+  "exclude": ["./dist/**/*"]
 }


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1163

# Scope of work

- `useTrapFocus` error `The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.`

![image](https://github.com/vuestorefront/storefront-ui/assets/2566152/264c02ac-c044-47ea-ac0e-9b987da95903)

- overwriting existing dists and proper defined `outDir`

![image (12)](https://github.com/vuestorefront/storefront-ui/assets/2566152/af5a3636-854b-40d2-96aa-3c6946da8909)


# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
