### PR TITLE
fix: incorrect thumb images usage

### DIFF
--- a/apps/preview/nuxt/pages/showcases/Gallery/GalleryVertical.vue
+++ b/apps/preview/nuxt/pages/showcases/Gallery/GalleryVertical.vue
@@ -162,7 +162,7 @@ const onDragged = (event: SfScrollableOnDragEndData) => {
 
 const assignRef = (el: Element | ComponentPublicInstance | null, index: number) => {
   if (!el) return;
-  if (index === thumbImages.length - 1) {
+  if (index === images.length - 1) {
     lastThumbRef.value = el as HTMLButtonElement;
   } else if (index === 0) {
     firstThumbRef.value = el as HTMLButtonElement;


### PR DESCRIPTION
# Scope of work

thumbImage variable is non-existent in GalleryVertical anymore - looks like a rebase error between v2-develop and my assets branch

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
