### PR TITLE
fix: arrowKeysOn in useTrapFocus

### DIFF
--- a/packages/sfui/frameworks/react/hooks/useTrapFocus/useTrapFocus.ts
+++ b/packages/sfui/frameworks/react/hooks/useTrapFocus/useTrapFocus.ts
@@ -85,10 +85,13 @@ export const useTrapFocus = (containerElementRef: RefObject<HTMLElement | null>,
       arrowFocusGroupSelector && containerElementRef.current?.querySelector(arrowFocusGroupSelector);
     const additionalData = isAnyGroupElement ? { arrowFocusGroupSelector } : {};
 
-    if ((arrowKeysLeftRight && event.key === 'ArrowLeft') || arrowKeysOn) focusPreviousItem({ additionalData });
-    if ((arrowKeysLeftRight && event.key === 'ArrowRight') || arrowKeysOn) focusNextItem({ additionalData });
-    if ((arrowKeysUpDown && event.key === 'ArrowUp') || arrowKeysOn) focusPreviousItem({ additionalData });
-    if ((arrowKeysUpDown && event.key === 'ArrowDown') || arrowKeysOn) focusNextItem({ additionalData });
+    if (arrowKeysOn && (event.key === 'ArrowLeft' || event.key === 'ArrowUp')) focusPreviousItem({ additionalData });
+    if (arrowKeysOn && (event.key === 'ArrowRight' || event.key === 'ArrowDown')) focusNextItem({ additionalData });
+
+    if (arrowKeysLeftRight && event.key === 'ArrowLeft') focusPreviousItem({ additionalData });
+    if (arrowKeysLeftRight && event.key === 'ArrowRight') focusNextItem({ additionalData });
+    if (arrowKeysUpDown && event.key === 'ArrowUp') focusPreviousItem({ additionalData });
+    if (arrowKeysUpDown && event.key === 'ArrowDown') focusNextItem({ additionalData });
 
     if (trapTabs && isTab(event)) focusNextItem({ event });
     if (trapTabs && isTabAndShift(event)) focusPreviousItem({ event });

--- a/packages/sfui/frameworks/vue/composables/useTrapFocus/useTrapFocus.ts
+++ b/packages/sfui/frameworks/vue/composables/useTrapFocus/useTrapFocus.ts
@@ -101,10 +101,13 @@ export const useTrapFocus = (
     const isAnyGroupElement = arrowFocusGroupSelector && containerHTMLElement?.querySelector(arrowFocusGroupSelector);
     const additionalData = isAnyGroupElement ? { arrowFocusGroupSelector } : {};
 
-    if ((arrowKeysLeftRight && event.key === 'ArrowLeft') || arrowKeysOn) focusPreviousItem({ additionalData });
-    if ((arrowKeysLeftRight && event.key === 'ArrowRight') || arrowKeysOn) focusNextItem({ additionalData });
-    if ((arrowKeysUpDown && event.key === 'ArrowUp') || arrowKeysOn) focusPreviousItem({ additionalData });
-    if ((arrowKeysUpDown && event.key === 'ArrowDown') || arrowKeysOn) focusNextItem({ additionalData });
+    if (arrowKeysOn && (event.key === 'ArrowLeft' || event.key === 'ArrowUp')) focusPreviousItem({ additionalData });
+    if (arrowKeysOn && (event.key === 'ArrowRight' || event.key === 'ArrowDown')) focusNextItem({ additionalData });
+
+    if (arrowKeysLeftRight && event.key === 'ArrowLeft') focusPreviousItem({ additionalData });
+    if (arrowKeysLeftRight && event.key === 'ArrowRight') focusNextItem({ additionalData });
+    if (arrowKeysUpDown && event.key === 'ArrowUp') focusPreviousItem({ additionalData });
+    if (arrowKeysUpDown && event.key === 'ArrowDown') focusNextItem({ additionalData });
 
     if (trapTabs && isTab(event)) focusNextItem({ event });
     if (trapTabs && isTabAndShift(event)) focusPreviousItem({ event });


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

With this [PR](https://github.com/vuestorefront/storefront-ui/pull/2722) option `arrowKeysOn` was broken for `useTrapFocus` 

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
