### PR TITLE
fix(Pagination Block): gap between next and prev buttons [SFUI2-976]

### DIFF
--- a/apps/preview/next/pages/showcases/Pagination/Pagination.tsx
+++ b/apps/preview/next/pages/showcases/Pagination/Pagination.tsx
@@ -15,7 +15,7 @@ export function Showcase() {
 
   return (
     <nav
-      className="flex justify-between items-center border-t border-neutral-200"
+      className="flex justify-between items-end border-t border-neutral-200"
       role="navigation"
       aria-label="pagination"
     >
@@ -32,7 +32,7 @@ export function Showcase() {
         <span className="hidden sm:inline-flex">Previous</span>
       </SfButton>
       <ul className="flex justify-center">
-        {!pages.find((page: number) => page === 1) && (
+        {!pages.includes(1) && (
           <li>
             <div
               className={classNames('flex pt-1 border-t-4 border-transparent', {
@@ -130,7 +130,7 @@ export function Showcase() {
             </div>
           </li>
         )}
-        {!pages.find((page: number) => page === totalPages) && (
+        {!pages.includes(totalPages) && (
           <li>
             <div
               className={classNames('flex pt-1 border-t-4 border-transparent', {

--- a/apps/preview/nuxt/pages/showcases/Pagination/Pagination.vue
+++ b/apps/preview/nuxt/pages/showcases/Pagination/Pagination.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="flex justify-between items-center border-t border-neutral-200" role="navigation" aria-label="pagination">
+  <nav class="flex justify-between items-end" border-t border-neutral-200 role="navigation" aria-label="pagination">
     <SfButton
       type="button"
       size="lg"
@@ -15,7 +15,7 @@
       <span class="hidden sm:inline-flex"> Previous </span>
     </SfButton>
     <ul class="flex justify-center">
-      <li v-if="!pages.find((page) => page === 1)">
+      <li v-if="!pages.includes(1)">
         <div
           :class="[
             'flex pt-1 border-t-4 border-transparent',
@@ -91,7 +91,7 @@
           </button>
         </div>
       </li>
-      <li v-if="!pages.find((page) => page === totalPages)">
+      <li v-if="!pages.includes(totalPages)">
         <div
           :class="[
             'flex pt-1 border-t-4 border-transparent',


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-976

Closes #

# Scope of work

Vertical gap between top border and next and prev buttons, performance change `find` into `inlcudes`

![image](https://github.com/vuestorefront/storefront-ui/assets/2566152/e1b5ab57-b773-40e4-905b-b20ef7aa0d1c)



# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
