### PR TITLE
ci: add realase candidate pipeline action [SFUI2-1184]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,10 +233,11 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
 
   release-next:
-    name: Release next release candidate
+    name: Release release candidate
     runs-on: ubuntu-latest
     needs: [build, build-release, cypress-react, cypress-vue]
-    if: ${{ startsWith( github.ref, 'refs/heads/v2-release' ) && github.event.head_commit.message == '[ci] - release next' }}
+    # If this is any `v2-release/**` branch AND last commit is made by changeset action and its commit message is with "rc" suffix, logic can be found in "release-changeset-changelog.yml"
+    if: ${{ startsWith( github.ref, 'refs/heads/v2-release' ) && github.event.head_commit.message == '[ci] - release rc' }}
     steps:
       - name: Publish release-candidate
         run: echo "Publish now"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - v2
       - v2-develop
+      - v2-release/**
   pull_request:
     types:
       - opened
@@ -230,3 +231,12 @@ jobs:
           # refresh token before Saturday, May 25, 2024
           NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
+
+  release-next:
+    name: Release next release candidate
+    runs-on: ubuntu-latest
+    needs: [build, build-release, cypress-react, cypress-vue]
+    if: ${{ startsWith( github.ref, 'refs/heads/v2-release' ) && github.event.head_commit.message == '[ci] - release next' }}
+    steps:
+      - name: Publish release-candidate
+        run: echo "Publish now"

--- a/.github/workflows/release-changeset-changelog.yml
+++ b/.github/workflows/release-changeset-changelog.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - v2-release/**
+  pull_request:
+    types:
+      - opened
+    branches:
+      - v2-release/**
 
 jobs:
   create-release-changelog:
@@ -20,19 +25,20 @@ jobs:
       - name: Install dependencies
         run: yarn --immutable
       - name: ConsoleLOG
-        ron: echo fromJSON($(cat .changeset/pre.json )).mode
-      - name: Set VAR if .changeset/pre.json file contain "mode:pre"
-        id: vars
-        run: echo "isInPreMode=$(echo ${{ fromJSON($(cat .changeset/pre.json )).mode == "pre" }})" >> $GITHUB_OUTPUT
+        run: echo ${{ fromJSON($(cat .changeset/pre.json )).mode }}
+      - name: Check if .changeset/pre.json file contain "mode:pre"
+        id: prerelease_check
+        run: echo "result=$(echo ${{ fromJSON($(cat .changeset/pre.json )).mode == "pre" }})" >> $GITHUB_OUTPUT
+      - name: ConsoleLOG2
+        run: echo ${{ steps.prerelease_check.output.result }}
       - name: Create PR with changelog
         id: changesets
         uses: changesets/action@v1
         with:
-          version: yarn run changeset-version
-          commit: '[ci] - release${{ steps.vars.output.isInPreMode && " rc" }}'
-          title: '[ci] - release${{ steps.vars.output.isInPreMode && " rc" }}'
+          commit: '[ci] - release${{ steps.prerelease_check.output.result && " rc" }}'
+          title: '[ci] - release${{ steps.prerelease_check.output.result && " rc" }}'
         env:
           # Needs access to publish to npm
           # refresh token before Saturday, May 25, 2024
+          NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-changeset-changelog.yml
+++ b/.github/workflows/release-changeset-changelog.yml
@@ -1,0 +1,37 @@
+name: Generate changelog on v2-release
+on:
+  push:
+    branches:
+      - v2-release/**
+
+jobs:
+  release-canary:
+    name: Release canary package
+    needs: [build, build-release, cypress-react, cypress-vue]
+    if: ${{ github.ref == 'refs/heads/v2-develop' }}
+    # Can't use 'configure-enviroment' because it fails on dev branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.node-version'
+          cache: 'yarn'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: yarn --immutable
+      - name: Bump package version
+        run: yarn changeset version --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build package
+        run: yarn build:release
+      - name: Publish canary version
+        run: yarn changeset publish --tag canary
+        env:
+          # Needs access to publish to npm
+          # refresh token before Saturday, May 25, 2024
+          NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}

--- a/.github/workflows/release-changeset-changelog.yml
+++ b/.github/workflows/release-changeset-changelog.yml
@@ -5,11 +5,9 @@ on:
       - v2-release/**
 
 jobs:
-  release-canary:
-    name: Release canary package
+  create-release-changelog:
+    name: Create PR with changelog
     needs: [build, build-release, cypress-react, cypress-vue]
-    if: ${{ github.ref == 'refs/heads/v2-develop' }}
-    # Can't use 'configure-enviroment' because it fails on dev branch
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -19,19 +17,22 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: 'yarn'
-          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: yarn --immutable
-      - name: Bump package version
-        run: yarn changeset version --snapshot
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build package
-        run: yarn build:release
-      - name: Publish canary version
-        run: yarn changeset publish --tag canary
+      - name: ConsoleLOG
+        ron: echo fromJSON($(cat .changeset/pre.json )).mode
+      - name: Set VAR if .changeset/pre.json file contain "mode:pre"
+        id: vars
+        run: echo "isInPreMode=$(echo ${{ fromJSON($(cat .changeset/pre.json )).mode == "pre" }})" >> $GITHUB_OUTPUT
+      - name: Create PR with changelog
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: yarn run changeset-version
+          commit: '[ci] - release${{ steps.vars.output.isInPreMode && " rc" }}'
+          title: '[ci] - release${{ steps.vars.output.isInPreMode && " rc" }}'
         env:
           # Needs access to publish to npm
           # refresh token before Saturday, May 25, 2024
-          NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/workflow-dispatch-changeset.yml
+++ b/.github/workflows/workflow-dispatch-changeset.yml
@@ -1,0 +1,40 @@
+on:
+  workflow_dispatch:
+    inputs:
+      generate-changelog:
+        description: 'Pick enter for pre-release or exit for production changeset'
+        required: true
+        default: 'enter'
+        type: choice
+        options:
+          - enter
+          - exit
+
+jobs:
+  generation-changelog-on-trigger:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith( github.ref, refs/heads/v2-release ) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.node-version'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn --immutable
+      - name: Change changeset pre based on trigger
+        run: yarn changeset pre ${{ inputs.generate-changelog }} ${{ inputs.generate-changelog == 'enter' && 'next' }}
+      - name: Create PR with changelog
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: yarn run changeset-version
+          commit: '[ci] - release ${{ inputs.generate-changelog }}'
+          title: '[ci] - release ${{ inputs.generate-changelog }}'
+        env:
+          # Needs access to publish to npm
+          # refresh token before Saturday, May 25, 2024
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/workflow-dispatch-changeset.yml
+++ b/.github/workflows/workflow-dispatch-changeset.yml
@@ -14,6 +14,8 @@ jobs:
   generation-changelog-on-trigger:
     runs-on: ubuntu-latest
     if: ${{ startsWith( github.ref, refs/heads/v2-release ) }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -24,17 +26,13 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn --immutable
-      - name: Change changeset pre based on trigger
-        run: yarn changeset pre ${{ inputs.generate-changelog }} ${{ inputs.generate-changelog == 'enter' && 'next' }}
-      - name: Create PR with changelog
-        id: changesets
-        uses: changesets/action@v1
+      - name: Set if trigger is release-candidate or production var
+        id: vars
+        run: echo "tag=$(echo ${{ inputs.generate-changelog == 'enter' && 'next' }}" >> $GITHUB_OUTPUT
+      - name: Change changeset pre based on trigger output
+        run: yarn changeset pre ${{ inputs.generate-changelog }} ${{ steps.vars.outputs.tag }}
+        # push commit with file mode for changeset
+      - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          version: yarn run changeset-version
-          commit: '[ci] - release ${{ inputs.generate-changelog }}'
-          title: '[ci] - release ${{ inputs.generate-changelog }}'
-        env:
-          # Needs access to publish to npm
-          # refresh token before Saturday, May 25, 2024
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          commit_message: Auto merge of .changeset/pre.json file
+          file_pattern: '.changeset/pre.json'

--- a/.github/workflows/workflow-dispatch-changeset.yml
+++ b/.github/workflows/workflow-dispatch-changeset.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   generation-changelog-on-trigger:
     runs-on: ubuntu-latest
-    if: ${{ startsWith( github.ref, refs/heads/v2-release ) }}
+    if: ${{ startsWith( github.ref, "refs/heads/v2-release" ) }}
     permissions:
       contents: write
     steps:
@@ -28,11 +28,11 @@ jobs:
         run: yarn --immutable
       - name: Set if trigger is release-candidate or production var
         id: vars
-        run: echo "tag=$(echo ${{ inputs.generate-changelog == 'enter' && 'next' }}" >> $GITHUB_OUTPUT
+        run: echo "tag=$(echo ${{ inputs.generate-changelog == 'enter' && 'rc' }}" >> $GITHUB_OUTPUT
       - name: Change changeset pre based on trigger output
         run: yarn changeset pre ${{ inputs.generate-changelog }} ${{ steps.vars.outputs.tag }}
         # push commit with file mode for changeset
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Auto merge of .changeset/pre.json file
+          commit_message: Auto merge of ".changeset/pre.json" file
           file_pattern: '.changeset/pre.json'

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "createReactIcons": "node createIcons framework=react input=packages/sfui/assets/ output=packages/sfui/frameworks/react/components/SfIcons/ absolutePathToIconBase=@storefront-ui/react",
     "hygen": "./node_modules/.bin/hygen",
     "component": "yarn hygen component",
-    "component-new": "yarn hygen component new"
+    "component-new": "yarn hygen component new",
+    "changeset-version": "changeset version"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "createReactIcons": "node createIcons framework=react input=packages/sfui/assets/ output=packages/sfui/frameworks/react/components/SfIcons/ absolutePathToIconBase=@storefront-ui/react",
     "hygen": "./node_modules/.bin/hygen",
     "component": "yarn hygen component",
-    "component-new": "yarn hygen component new",
-    "changeset-version": "changeset version"
+    "component-new": "yarn hygen component new"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1184

# Scope of work

Added 3 github actions
- Create changelog PR from changeset on every commit push into `v2-release/**` 
- Create Trigger if this changelog should be for release candidate (rc tag) or production (latest)
- If latest commit message in `v2-release/**` is `[ci] release rc` should run publish with tag `rc`

File `release-changeset-changelog.yml` job `create-release-changelog`
Run every time commit lands into `v2-release/**` branch and creates PR with new changelog either for RC or PROD changelog

File `ci.yml` job `release-next`
Runs only on `v2-release` when last pushed commit name is `[ci] release next` and publish release-candidate with tag `next`, this is benefitial because we can run publish after all `lint` `build` `vue-test` `react-test` checks

File `workflow-dispatch-changeset.yml` job `generation-changelog-on-trigger`
Run after manual trigger regeneration and pushing commit with `.changelog/pre.json` 

![image](https://github.com/vuestorefront/storefront-ui/assets/2566152/45067af8-1182-4c6e-83ce-f4674c4c3a29)


# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
