### PR TITLE
chore: use shared organization renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,48 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "timezone": "Europe/Warsaw",
-  "extends": ["config:base", ":disableDependencyDashboard"],
-  "schedule": [
-    "before 5am on Tuesday"
-  ],
-  "packageRules": [
-    {
-      "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "all major dependency bump",
-      "groupSlug": "all-major"
-    },
-    {
-      "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["minor"],
-      "groupName": "all minor dependency bump",
-      "groupSlug": "all-minor"
-    },
-    {
-      "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["patch"],
-      "groupName": "all patch dependency bump",
-      "groupSlug": "all-patch",
-      "automerge": true
-    },
-    {
-      "extends": "packages:linters",
-      "groupName": "linters",
-      "automerge": true
-    },
-    {
-      "extends": "packages:postcss",
-      "groupName": "postcss packages"
-    },
-    {
-      "extends": "packages:test",
-      "groupName": "test packages",
-      "automerge": true
-    },
-    {
-      "groupName": "definitelyTyped",
-      "matchPackagePrefixes": ["@types/"],
-      "automerge": true
-    }
-  ]
+  "extends": ["github>vuestorefront/.github:renovate-config"]
 }


### PR DESCRIPTION
# Scope of work

I've added a renovate config to the shared [.github](https://github.com/vuestorefront/.github) repo

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
