### PR TITLE
feat: poc of block source code display strategy

### DIFF
--- a/apps/docs/components/.vuepress/components/ShowcasePoc.vue
+++ b/apps/docs/components/.vuepress/components/ShowcasePoc.vue
@@ -1,0 +1,120 @@
+<template>
+  <div class="flex flex-col mt-4">
+    <div class="flex justify-end text-sm" v-if="showSource">
+      <button
+        @click="tab = 1"
+        class="px-3 py-2 border-b-2 dark:border-zinc-700"
+        :class="[tab === 1 ? 'text-black dark:text-white border-green dark:border-green' : '']"
+      >
+        Preview
+      </button>
+      <button
+        @click="tab = 2"
+        class="px-3 py-2 border-b-2 dark:border-zinc-700"
+        :class="[tab === 2 ? 'text-black dark:text-white border-green dark:border-green' : '']"
+      >
+        Usage
+      </button>
+      <button
+        @click="tab = 3"
+        class="px-3 py-2 border-b-2 dark:border-zinc-700"
+        :class="[tab === 3 ? 'text-black dark:text-white border-green dark:border-green' : '']"
+      >
+        Code
+      </button>
+    </div>
+    <div ref="wrapperRef" class="relative flex-1 flex flex-col">
+      <div
+        ref="previewElementRef"
+        class="pt-4 flex-grow rounded overflow-hidden"
+        :class="[tab === 1 ? 'flex' : 'hidden']"
+        @mousedown="eventDownListener"
+        @touchstart="eventDownListener"
+      >
+        <div class="absolute inset-0" v-show="isHandlerDragging"></div>
+        <Generate
+          :showcase-path="showcaseName"
+          :allow="allow"
+          class="flex-grow rounded"
+          style="margin-top: 0"
+          :no-paddings="noPaddings"
+        />
+        <div ref="handlerRef" class="select-none rounded-tr items-center hidden sm:flex" style="cursor: ew-resize">
+          <iconify-icon icon="akar-icons:drag-vertical" class="pointer-events-none" />
+        </div>
+      </div>
+
+      <div v-show="tab === 2" class="relative">
+        <SourceCode>
+          <slot name="usage" />
+        </SourceCode>
+      </div>
+      <div v-show="tab === 3" class="relative">
+        <SourceCode>
+          <slot name="code" />
+        </SourceCode>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    showcaseName: {
+      type: String,
+      default: undefined,
+    },
+    noPaddings: {
+      type: Boolean,
+      default: false,
+    },
+    allow: {
+      type: String,
+      default: undefined,
+    },
+    showSource: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  data: () => ({
+    tab: 1,
+    wrapperRef: undefined,
+    handlerRef: undefined,
+    previewElementRef: undefined,
+    isHandlerDragging: false,
+  }),
+  mounted() {
+    document.addEventListener('mousemove', this.eventMoveListener);
+    document.addEventListener('touchmove', this.eventMoveListener);
+    document.addEventListener('mouseup', this.eventUpListener);
+    document.addEventListener('touchup', this.eventUpListener);
+  },
+  unmounted() {
+    document.removeEventListener('mousemove', this.eventMoveListener);
+    document.removeEventListener('touchmove', this.eventMoveListener);
+    document.removeEventListener('mouseup', this.eventUpListener);
+    document.removeEventListener('touchUp', this.eventUpListener);
+  },
+  methods: {
+    eventDownListener(e) {
+      if (e.target === this.$refs.handlerRef) {
+        this.isHandlerDragging = true;
+      }
+    },
+    eventUpListener(e) {
+      this.isHandlerDragging = false;
+    },
+    eventMoveListener(e) {
+      if (!this.isHandlerDragging) return false;
+
+      const containerOffsetLeft = this.$refs.wrapperRef.getBoundingClientRect().left;
+      const pointerRelativeXpos = (e?.clientX || (e?.touches[0] && e?.touches[0]?.pageX)) - containerOffsetLeft;
+      const minWidth = 386;
+
+      this.$refs.previewElementRef.style.maxWidth = `${Math.max(minWidth, pointerRelativeXpos)}px`;
+    },
+  },
+};
+</script>

--- a/apps/docs/components/blocks/Card.md
+++ b/apps/docs/components/blocks/Card.md
@@ -12,16 +12,27 @@ hideToc: true
 
 The default card view with a rectangle shaped image, a title, a description and a button for some additional actions.
 
-<Showcase showcase-name="Card/CardDefault" style="min-height: 600px">
+<ShowcasePoc showcase-name="Card/ProductCardUsage" style="min-height: 600px">
 
+::: slot usage
 <!-- vue -->
-<<<../../preview/nuxt/pages/showcases/Card/CardDefault.vue
+<<<../../preview/nuxt/pages/showcases/Card/ProductCardUsage.vue
 <!-- end vue -->
 <!-- react -->
-<<<../../preview/next/pages/showcases/Card/CardDefault.tsx#source
+<<<../../preview/next/pages/showcases/Card/ProductCardUsage.tsx#source
 <!-- end react -->
+:::
 
-</Showcase>
+::: slot code
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Card/ProductCard.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Card/ProductCard.tsx#source
+<!-- end react -->
+:::
+
+</ShowcasePoc>
 
 ## Category Card
 

--- a/apps/docs/components/blocks/SelectDropdown.md
+++ b/apps/docs/components/blocks/SelectDropdown.md
@@ -18,71 +18,106 @@ The SelectDropdown fully supports the use of the keyboard.
 
 Select Dropdown with preselected option.
 
-<Showcase showcase-name="SelectDropdown/SelectDropdownPreselected" style="min-height:300px">
+<ShowcasePoc showcase-name="SelectDropdown/SelectDropdownPreselected" style="min-height:300px">
 
+::: slot usage
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownPreselected.vue
 <!-- end vue -->
 <!-- react -->
 <<<../../preview/next/pages/showcases/SelectDropdown/SelectDropdownPreselected.tsx#source
 <!-- end react -->
+:::
 
-</Showcase>
+::: slot code
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/SelectDropdown/SelectDropdown.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/SelectDropdown/SelectDropdown.tsx#source
+<!-- end react -->
+:::
+
+</ShowcasePoc>
 
 ## With placeholder
 
 Adding placeholder might be helpful and informative for end users.
 
-<Showcase showcase-name="SelectDropdown/SelectDropdownWithPlaceholder" style="min-height:300px">
+<ShowcasePoc showcase-name="SelectDropdown/SelectDropdownWithPlaceholder" style="min-height:300px">
+::: slot usage
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownWithPlaceholder.vue
 <!-- end vue -->
 <!-- react -->
 <<<../../preview/next/pages/showcases/SelectDropdown/SelectDropdownWithPlaceholder.tsx#source
 <!-- end react -->
-</Showcase>
+:::
+::: slot code
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/SelectDropdown/SelectDropdown.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/SelectDropdown/SelectDropdown.tsx#source
+<!-- end react -->
+:::
+</ShowcasePoc>
 
 ## With required text
 
 By adding a sublabel, the user can easily see if this field is required. Remember to add `aria-required` to help users that use assistive technologies.
 
 <Showcase showcase-name="SelectDropdown/SelectDropdownRequired" style="min-height:300px">
-
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownRequired.vue
 <!-- end vue -->
 <!-- react -->
 <<<../../preview/next/pages/showcases/SelectDropdown/SelectDropdownRequired.tsx#source
 <!-- end react -->
-
 </Showcase>
 
 ## Invalid state
 
 Provide visual cues for end users to indicate occuring error.
 
-<Showcase showcase-name="SelectDropdown/SelectDropdownError" style="min-height:300px">
-
+<ShowcasePoc showcase-name="SelectDropdown/SelectDropdownError" style="min-height:300px">
+::: slot usage
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownError.vue
 <!-- end vue -->
 <!-- react -->
 <<<../../preview/next/pages/showcases/SelectDropdown/SelectDropdownError.tsx#source
 <!-- end react -->
-
-</Showcase>
+:::
+::: slot code
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/SelectDropdown/SelectDropdown.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/SelectDropdown/SelectDropdown.tsx#source
+<!-- end react -->
+:::
+</ShowcasePoc>
 
 ## Disabled state
 
 Differentiate disabled state to smooth UX experience. In such case, keyboard navigation becomes disabled as well and an `aria-disabled="true"` is specified for better accessibility.
 
-<Showcase showcase-name="SelectDropdown/SelectDropdownDisabled" style="min-height:300px">
-
+<ShowcasePoc showcase-name="SelectDropdown/SelectDropdownDisabled" style="min-height:300px">
+::: slot usage
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownDisabled.vue
 <!-- end vue -->
 <!-- react -->
 <<<../../preview/next/pages/showcases/SelectDropdown/SelectDropdownDisabled.tsx#source
 <!-- end react -->
-
-</Showcase>
+:::
+::: slot code
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/SelectDropdown/SelectDropdown.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/SelectDropdown/SelectDropdown.tsx#source
+<!-- end react -->
+:::
+</ShowcasePoc>

--- a/apps/preview/next/pages/showcases/Card/ProductCard.tsx
+++ b/apps/preview/next/pages/showcases/Card/ProductCard.tsx
@@ -1,0 +1,35 @@
+import { ShowcasePageLayout } from '../../showcases';
+// #region source
+import { SfButton } from '@storefront-ui/react';
+
+interface ProductCardProps {
+  url: string;
+  title: string;
+  buttonLabel: string;
+  description?: string;
+  image?: string;
+}
+
+export default function ProductCard(props: ProductCardProps) {
+  const { url, title, description, buttonLabel, image } = props;
+  return (
+    <div className="flex flex-col min-w-[325px] max-w-[375px] lg:w-[496px] relative border border-neutral-200 rounded-md hover:shadow-xl">
+      <a
+        className="absolute inset-0 z-1 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-md"
+        href={url}
+        aria-label={title}
+      />
+      <img src={image} alt={title} className="object-cover h-auto rounded-t-md aspect-video" />
+      <div className="flex flex-col items-start p-4 grow">
+        <p className="font-medium typography-text-base">{title}</p>
+        <p className="mt-1 mb-4 font-normal typography-text-sm text-neutral-700">{description}</p>
+        <SfButton size="sm" variant="tertiary" className="relative mt-auto">
+          {buttonLabel}
+        </SfButton>
+      </div>
+    </div>
+  );
+}
+
+// #endregion source
+ProductCard.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/Card/ProductCardUsage.tsx
+++ b/apps/preview/next/pages/showcases/Card/ProductCardUsage.tsx
@@ -1,0 +1,45 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+/* eslint-disable jsx-a11y/anchor-has-content */
+import { ShowcasePageLayout } from '../../showcases';
+// #region source
+import { SfButton } from '@storefront-ui/react';
+import ProductCard from './ProductCard';
+
+const cardDetails = [
+  {
+    url: '#',
+    image: 'http://localhost:3100/@assets/card-3.png',
+    title: 'Sip Sustainably: The Rise of Boxed Water',
+    description:
+      'Boxed water is a sustainable alternative to traditional plastic bottles, made from renewable resources.',
+    buttonLabel: 'Read more',
+  },
+  {
+    url: '#',
+    image: 'http://localhost:3100/@assets/card-2.png',
+    title: 'Ride the Future: Exploring the Benefits of e-Bikes',
+    description:
+      'Eco-friendly, efficient, and fun modes of transportation that provide a range of benefits for riders and the environment.',
+    buttonLabel: 'Read more',
+  },
+  {
+    url: '#',
+    image: 'http://localhost:3100/@assets/card-1.png',
+    title: 'Unleash the Ultimate Listening Experience',
+    description:
+      'Audiophile headphones offer unmatched sound quality and clarity, making them the go-to choice for music enthusiasts.',
+    buttonLabel: 'Read more',
+  },
+];
+
+export default function ProductCardUsage() {
+  return (
+    <div className="flex flex-wrap gap-4 lg:gap-6 lg:flex-nowrap">
+      {cardDetails.map((card) => (
+        <ProductCard key={card.title} {...card} />
+      ))}
+    </div>
+  );
+}
+// #endregion source
+ProductCardUsage.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/Checkout/CheckoutContactForm.tsx
+++ b/apps/preview/next/pages/showcases/Checkout/CheckoutContactForm.tsx
@@ -1,12 +1,31 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import { ShowcasePageLayout } from '../../showcases';
 // #region source
-import { SfInput, SfButton, SfSelect } from '@storefront-ui/react';
+import { SfInput, SfButton } from '@storefront-ui/react';
 import { useState, ChangeEvent, FormEventHandler } from 'react';
+import SelectDropdown from '../SelectDropdown/SelectDropdown';
 
 export default function ContactForm() {
   const [invalid, setInvalid] = useState(true);
-  const options = [1, 7, 20, 27, 30, 30, 31, 32, 33, 34, 36, 39, 40, 41, 43, 44, 45, 46, 47, 48, 49, 51];
+  // const options = [1, 7, 20, 27, 30, 30, 31, 32, 33, 34, 36, 39, 40, 41, 43, 44, 45, 46, 47, 48, 49, 51];
+  const options = [
+    {
+      label: '+39	🇮🇹',
+      value: 'IT',
+    },
+    {
+      label: '+44	🇬🇧',
+      value: 'GB',
+    },
+    {
+      label: '+48	🇵🇱',
+      value: 'PL',
+    },
+    {
+      label: '+49	🇩🇪',
+      value: 'DE',
+    },
+  ];
   const emailRegExp = /^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/;
 
   const handleValidation = (event: ChangeEvent<HTMLInputElement>) =>
@@ -48,13 +67,7 @@ export default function ContactForm() {
       <label className="flex flex-col gap-y-0.5">
         <span className="font-medium typography-text-sm">Phone number</span>
         <div className="flex">
-          <SfSelect name="phone-country-code" className="w-16 mr-4" placeholder="--" autoComplete="tel-country-code">
-            {options.map((option) => (
-              <option value={option} key={option}>
-                {option}
-              </option>
-            ))}
-          </SfSelect>
+          <SelectDropdown name="phone-country-code" options={options} className="w-26 mr-4" defaultValue={options[0]} />
           <SfInput
             name="phone-national"
             wrapperClassName="w-full"

--- a/apps/preview/next/pages/showcases/SelectDropdown/SelectDropdown.tsx
+++ b/apps/preview/next/pages/showcases/SelectDropdown/SelectDropdown.tsx
@@ -1,0 +1,137 @@
+import { ShowcasePageLayout } from '../../showcases';
+// #region source
+import { useId, useRef, useState, type KeyboardEvent } from 'react';
+import classNames from 'classnames';
+import {
+  SfIconExpandMore,
+  SfListItem,
+  useDisclosure,
+  useDropdown,
+  SfIconCheck,
+  useTrapFocus,
+} from '@storefront-ui/react';
+
+type SelectOption = {
+  label: string;
+  value: string;
+};
+
+interface SelectDropdownProps {
+  options: SelectOption[];
+  label?: string;
+  name?: string;
+  placeholder?: string;
+  defaultValue?: SelectOption;
+  disabled?: boolean;
+  isError?: boolean;
+  className?: string;
+}
+
+export default function SelectDropdown(props: SelectDropdownProps) {
+  const { options, label, name, disabled, isError, defaultValue, placeholder, className } = props;
+  const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
+  const [selectedOption, setSelectedOption] = useState<SelectOption | undefined>(defaultValue);
+  const id = useId();
+  const listboxId = useId();
+  const selectTriggerRef = useRef<HTMLDivElement>(null);
+
+  const { refs, style: dropdownStyle } = useDropdown({ isOpen, onClose: close });
+
+  useTrapFocus(refs.floating, {
+    arrowKeysOn: true,
+    activeState: isOpen,
+    initialFocusContainerFallback: true,
+  });
+
+  const selectOption = (option: SelectOption) => {
+    setSelectedOption(option);
+    close();
+    selectTriggerRef.current?.focus();
+  };
+
+  const handleTriggerKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === ' ') toggle();
+  };
+
+  const handleOptionItemKeyDown = (event: KeyboardEvent<HTMLLIElement>, option: SelectOption) => {
+    if (event.key === ' ' || event.key === 'Enter') selectOption(option);
+  };
+
+  return (
+    <>
+      <label className="font-medium typography-label-sm" htmlFor={id}>
+        {label}
+      </label>
+      <input id={id} hidden name={name} value={selectedOption?.value} />
+      <div ref={refs.setReference} className={classNames('relative', className)}>
+        <div
+          ref={selectTriggerRef}
+          role="combobox"
+          aria-required="true"
+          aria-controls={listboxId}
+          aria-expanded={isOpen}
+          aria-disabled={disabled}
+          aria-label="Select one option"
+          aria-activedescendant={selectedOption ? `${listboxId}-${selectedOption.value}` : undefined}
+          className={classNames(
+            'flex items-center gap-8 relative font-normal typography-text-base ring-1 ring-inset rounded-md py-2 px-4',
+            {
+              'mt-0.5': label,
+            },
+            disabled
+              ? 'bg-disabled-100 ring-disabled-300 cursor-not-allowed'
+              : 'ring-neutral-300 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2 cursor-pointer',
+            isError
+              ? 'ring-2 ring-negative-700'
+              : 'ring-1 ring-neutral-300 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2',
+          )}
+          tabIndex={disabled ? -1 : 0}
+          onKeyDown={handleTriggerKeyDown}
+          onClick={() => !disabled && toggle()}
+        >
+          {selectedOption ? (
+            <span className="whitespace-nowrap">{selectedOption.label}</span>
+          ) : (
+            <span className={disabled ? 'text-disabled-500' : 'text-neutral-500'}>{placeholder}</span>
+          )}
+          <SfIconExpandMore
+            className={classNames(
+              'ml-auto transition-transform ease-in-out duration-300',
+              { 'rotate-180': isOpen },
+              disabled ? 'text-disabled-500' : 'text-neutral-500',
+            )}
+          />
+        </div>
+        <ul
+          id={listboxId}
+          ref={refs.setFloating}
+          role="listbox"
+          aria-label="Select one option"
+          className={classNames('w-full py-2 rounded-md shadow-md border border-neutral-100 bg-white z-10', {
+            hidden: !isOpen,
+          })}
+          style={dropdownStyle}
+        >
+          {options.map((option) => (
+            <SfListItem
+              id={`${listboxId}-${option.value}`}
+              key={option.value}
+              role="option"
+              tabIndex={0}
+              aria-selected={option.value === selectedOption?.value}
+              className={classNames('block', { 'font-medium': option.value === selectedOption?.value })}
+              onClick={() => selectOption(option)}
+              onKeyDown={(event) => handleOptionItemKeyDown(event, option)}
+              slotSuffix={option.value === selectedOption?.value && <SfIconCheck className="text-primary-700" />}
+            >
+              {option.label}
+            </SfListItem>
+          ))}
+        </ul>
+      </div>
+      {isError && <p className="text-negative-700 typography-text-sm font-medium mt-0.5">No option selected</p>}
+    </>
+  );
+}
+// #endregion source
+SelectDropdown.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/SelectDropdown/SelectDropdownDisabled.tsx
+++ b/apps/preview/next/pages/showcases/SelectDropdown/SelectDropdownDisabled.tsx
@@ -1,22 +1,8 @@
 import { ShowcasePageLayout } from '../../showcases';
 // #region source
-import { useId, useRef, useState, type KeyboardEvent } from 'react';
-import classNames from 'classnames';
-import {
-  SfIconExpandMore,
-  SfListItem,
-  useDisclosure,
-  useDropdown,
-  SfIconCheck,
-  useTrapFocus,
-} from '@storefront-ui/react';
+import SelectDropdown from './SelectDropdown';
 
-type SelectOption = {
-  label: string;
-  value: string;
-};
-
-const options: SelectOption[] = [
+const options = [
   {
     label: 'Today',
     value: 'today',
@@ -32,105 +18,7 @@ const options: SelectOption[] = [
 ];
 
 export default function SelectDropdownDisabled() {
-  const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
-  const [selectedOption, setSelectedOption] = useState<SelectOption>();
-  const id = useId();
-  const listboxId = useId();
-  const selectTriggerRef = useRef<HTMLDivElement>(null);
-  const isDisabled = true;
-
-  const { refs, style: dropdownStyle } = useDropdown({ isOpen, onClose: close });
-
-  useTrapFocus(refs.floating, {
-    arrowKeysOn: true,
-    activeState: isOpen,
-    initialFocusContainerFallback: true,
-  });
-
-  const selectOption = (option: SelectOption) => {
-    setSelectedOption(option);
-    close();
-    selectTriggerRef.current?.focus();
-  };
-
-  const handleTriggerKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === ' ') toggle();
-  };
-
-  const handleOptionItemKeyDown = (event: KeyboardEvent<HTMLLIElement>, option: SelectOption) => {
-    if (event.key === ' ' || event.key === 'Enter') selectOption(option);
-  };
-
-  return (
-    <>
-      <label
-        className={classNames('font-medium typography-label-sm', { 'text-disabled-900': isDisabled })}
-        htmlFor={id}
-      >
-        Delivery
-      </label>
-      <div ref={refs.setReference} className="relative">
-        <div
-          ref={selectTriggerRef}
-          role="combobox"
-          aria-required="true"
-          aria-controls={listboxId}
-          aria-expanded={isOpen}
-          aria-disabled={isDisabled}
-          aria-label="Select one option"
-          aria-activedescendant={selectedOption ? `${listboxId}-${selectedOption.value}` : undefined}
-          className={classNames(
-            'mt-0.5 flex items-center gap-8 relative font-normal typography-text-base ring-1 ring-inset rounded-md py-2 px-4 focus-visible:outline focus-visible:outline-offset',
-            isDisabled
-              ? 'bg-disabled-100 ring-disabled-300 cursor-not-allowed'
-              : 'ring-neutral-300 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2 cursor-pointer',
-          )}
-          tabIndex={isDisabled ? -1 : 0}
-          onKeyDown={handleTriggerKeyDown}
-          onClick={() => !isDisabled && toggle()}
-        >
-          {selectedOption ? (
-            selectedOption.label
-          ) : (
-            <span className={isDisabled ? 'text-disabled-500' : 'text-neutral-500'}>Choose from the list</span>
-          )}
-          <SfIconExpandMore
-            className={classNames(
-              'ml-auto transition-transform ease-in-out duration-300',
-              { 'rotate-180': isOpen },
-              isDisabled ? 'text-disabled-500' : 'text-neutral-500',
-            )}
-          />
-        </div>
-        <ul
-          id={listboxId}
-          ref={refs.setFloating}
-          role="listbox"
-          aria-label="Select one option"
-          className={classNames('w-full py-2 rounded-md shadow-md border border-neutral-100 bg-white z-10', {
-            hidden: !isOpen,
-          })}
-          style={dropdownStyle}
-        >
-          {options.map((option) => (
-            <SfListItem
-              id={`${listboxId}-${option.value}`}
-              key={option.value}
-              role="option"
-              tabIndex={0}
-              aria-selected={option.value === selectedOption?.value}
-              className={classNames('block', { 'font-medium': option.value === selectedOption?.value })}
-              onClick={() => selectOption(option)}
-              onKeyDown={(event) => handleOptionItemKeyDown(event, option)}
-              slotSuffix={option.value === selectedOption?.value && <SfIconCheck className="text-primary-700" />}
-            >
-              {option.label}
-            </SfListItem>
-          ))}
-        </ul>
-      </div>
-    </>
-  );
+  return <SelectDropdown options={options} label="Delivery" disabled />;
 }
 // #endregion source
 SelectDropdownDisabled.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/SelectDropdown/SelectDropdownError.tsx
+++ b/apps/preview/next/pages/showcases/SelectDropdown/SelectDropdownError.tsx
@@ -1,23 +1,8 @@
 import { ShowcasePageLayout } from '../../showcases';
 // #region source
-import { useId, useRef, useState, type KeyboardEvent } from 'react';
-import classNames from 'classnames';
-import {
-  SfIconExpandMore,
-  SfListItem,
-  useDisclosure,
-  useDropdown,
-  SfIconCheck,
-  useTrapFocus,
-  InitialFocusType,
-} from '@storefront-ui/react';
+import SelectDropdown from './SelectDropdown';
 
-type SelectOption = {
-  label: string;
-  value: string;
-};
-
-const options: SelectOption[] = [
+const options = [
   {
     label: 'Today',
     value: 'today',
@@ -33,97 +18,7 @@ const options: SelectOption[] = [
 ];
 
 export default function SelectDropdownError() {
-  const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
-  const [selectedOption, setSelectedOption] = useState<SelectOption>();
-  const id = useId();
-  const listboxId = useId();
-  const selectTriggerRef = useRef<HTMLDivElement>(null);
-  const isValid = !!selectedOption;
-
-  const { refs, style: dropdownStyle } = useDropdown({ isOpen, onClose: close });
-
-  useTrapFocus(refs.floating, {
-    arrowKeysUpDown: true,
-    activeState: isOpen,
-    initialFocus: InitialFocusType.autofocus,
-    initialFocusContainerFallback: true,
-  });
-
-  const selectOption = (option: SelectOption) => {
-    setSelectedOption(option);
-    close();
-    selectTriggerRef.current?.focus();
-  };
-
-  const handleTriggerKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === ' ') toggle();
-  };
-
-  const handleOptionItemKeyDown = (event: KeyboardEvent<HTMLLIElement>, option: SelectOption) => {
-    if (event.key === ' ' || event.key === 'Enter') selectOption(option);
-  };
-
-  return (
-    <>
-      <label className="font-medium typography-label-sm" htmlFor={id}>
-        Delivery
-      </label>
-      <div ref={refs.setReference} className="relative">
-        <div
-          ref={selectTriggerRef}
-          role="combobox"
-          aria-required="true"
-          aria-controls={listboxId}
-          aria-expanded={isOpen}
-          aria-label="Select one option"
-          aria-activedescendant={selectedOption ? `${listboxId}-${selectedOption.value}` : undefined}
-          className={classNames(
-            'mt-0.5 flex items-center gap-8 relative font-normal typography-text-base ring-inset rounded-md py-2 px-4 focus-visible:outline focus-visible:outline-offset cursor-pointer',
-            isValid
-              ? 'ring-1 ring-neutral-300 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2'
-              : 'ring-2 ring-negative-700',
-          )}
-          tabIndex={0}
-          onKeyDown={handleTriggerKeyDown}
-          onClick={toggle}
-        >
-          {selectedOption ? selectedOption.label : <span className="text-neutral-500">Choose from the list</span>}
-          <SfIconExpandMore
-            className={classNames('ml-auto text-neutral-500 transition-transform ease-in-out duration-300', {
-              'rotate-180': isOpen,
-            })}
-          />
-        </div>
-        <ul
-          id={listboxId}
-          ref={refs.setFloating}
-          role="listbox"
-          aria-label="Select one option"
-          className={classNames('w-full py-2 rounded-md shadow-md border border-neutral-100 bg-white z-10', {
-            hidden: !isOpen,
-          })}
-          style={dropdownStyle}
-        >
-          {options.map((option) => (
-            <SfListItem
-              id={`${listboxId}-${option.value}`}
-              key={option.value}
-              role="option"
-              tabIndex={0}
-              aria-selected={option.value === selectedOption?.value}
-              className={classNames('block', { 'font-medium': option.value === selectedOption?.value })}
-              onClick={() => selectOption(option)}
-              onKeyDown={(event) => handleOptionItemKeyDown(event, option)}
-              slotSuffix={option.value === selectedOption?.value && <SfIconCheck className="text-primary-700" />}
-            >
-              {option.label}
-            </SfListItem>
-          ))}
-        </ul>
-      </div>
-      {!isValid && <p className="text-negative-700 typography-text-sm font-medium mt-0.5">No option selected</p>}
-    </>
-  );
+  return <SelectDropdown options={options} label="Delivery" isError />;
 }
 // #endregion source
 SelectDropdownError.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/SelectDropdown/SelectDropdownPreselected.tsx
+++ b/apps/preview/next/pages/showcases/SelectDropdown/SelectDropdownPreselected.tsx
@@ -1,23 +1,8 @@
 import { ShowcasePageLayout } from '../../showcases';
 // #region source
-import { useId, useRef, useState, type KeyboardEvent } from 'react';
-import classNames from 'classnames';
-import {
-  SfIconExpandMore,
-  SfListItem,
-  useDisclosure,
-  useDropdown,
-  SfIconCheck,
-  useTrapFocus,
-  InitialFocusType,
-} from '@storefront-ui/react';
+import SelectDropdown from './SelectDropdown';
 
-type SelectOption = {
-  label: string;
-  value: string;
-};
-
-const options: SelectOption[] = [
+const options = [
   {
     label: 'Startup',
     value: 'startup',
@@ -33,90 +18,7 @@ const options: SelectOption[] = [
 ];
 
 export default function SelectDropdownPreselected() {
-  const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
-  const [selectedOption, setSelectedOption] = useState<SelectOption>(options[0]);
-  const id = useId();
-  const listboxId = useId();
-  const selectTriggerRef = useRef<HTMLDivElement>(null);
-
-  const { refs, style: dropdownStyle } = useDropdown({ isOpen, onClose: close });
-
-  useTrapFocus(refs.floating, {
-    arrowKeysUpDown: true,
-    activeState: isOpen,
-    initialFocus: InitialFocusType.autofocus,
-    initialFocusContainerFallback: true,
-  });
-
-  const selectOption = (option: SelectOption) => {
-    setSelectedOption(option);
-    close();
-    selectTriggerRef.current?.focus();
-  };
-
-  const handleTriggerKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === ' ') toggle();
-  };
-
-  const handleOptionItemKeyDown = (event: KeyboardEvent<HTMLLIElement>, option: SelectOption) => {
-    if (event.key === ' ' || event.key === 'Enter') selectOption(option);
-  };
-
-  return (
-    <>
-      <label className="font-medium typography-label-sm" htmlFor={id}>
-        Product
-      </label>
-      <div ref={refs.setReference} className="relative">
-        <div
-          ref={selectTriggerRef}
-          id={id}
-          role="combobox"
-          aria-controls={listboxId}
-          aria-expanded={isOpen}
-          aria-label="Select one option"
-          aria-activedescendant={selectedOption ? `${listboxId}-${selectedOption.value}` : undefined}
-          className="mt-0.5 flex items-center gap-8 relative font-normal typography-text-base ring-1 ring-neutral-300 ring-inset rounded-md py-2 px-4 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2 focus-visible:outline focus-visible:outline-offset cursor-pointer"
-          tabIndex={0}
-          onKeyDown={handleTriggerKeyDown}
-          onClick={toggle}
-        >
-          {selectedOption ? selectedOption.label : <span className="text-neutral-500">Choose from the list</span>}
-          <SfIconExpandMore
-            className={classNames('ml-auto text-neutral-500 transition-transform ease-in-out duration-300', {
-              'rotate-180': isOpen,
-            })}
-          />
-        </div>
-        <ul
-          id={listboxId}
-          ref={refs.setFloating}
-          role="listbox"
-          aria-label="Select one option"
-          className={classNames('w-full py-2 rounded-md shadow-md border border-neutral-100 bg-white z-10', {
-            hidden: !isOpen,
-          })}
-          style={dropdownStyle}
-        >
-          {options.map((option) => (
-            <SfListItem
-              id={`${listboxId}-${option.value}`}
-              key={option.value}
-              role="option"
-              tabIndex={0}
-              aria-selected={option.value === selectedOption?.value}
-              className={classNames('block', { 'font-medium': option.value === selectedOption?.value })}
-              onClick={() => selectOption(option)}
-              onKeyDown={(event) => handleOptionItemKeyDown(event, option)}
-              slotSuffix={option.value === selectedOption?.value && <SfIconCheck className="text-primary-700" />}
-            >
-              {option.label}
-            </SfListItem>
-          ))}
-        </ul>
-      </div>
-    </>
-  );
+  return <SelectDropdown options={options} label="Delivery" defaultValue={options[0]} />;
 }
 // #endregion source
 SelectDropdownPreselected.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/SelectDropdown/SelectDropdownWithPlaceholder.tsx
+++ b/apps/preview/next/pages/showcases/SelectDropdown/SelectDropdownWithPlaceholder.tsx
@@ -1,23 +1,8 @@
 import { ShowcasePageLayout } from '../../showcases';
 // #region source
-import { useId, useRef, useState, type KeyboardEvent } from 'react';
-import classNames from 'classnames';
-import {
-  SfIconExpandMore,
-  SfListItem,
-  useDisclosure,
-  useDropdown,
-  SfIconCheck,
-  useTrapFocus,
-  InitialFocusType,
-} from '@storefront-ui/react';
+import SelectDropdown from './SelectDropdown';
 
-type SelectOption = {
-  label: string;
-  value: string;
-};
-
-const options: SelectOption[] = [
+const options = [
   {
     label: 'Today',
     value: 'today',
@@ -33,90 +18,7 @@ const options: SelectOption[] = [
 ];
 
 export default function SelectDropdownWithPlaceholder() {
-  const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
-  const [selectedOption, setSelectedOption] = useState<SelectOption>();
-  const id = useId();
-  const listboxId = useId();
-  const selectTriggerRef = useRef<HTMLDivElement>(null);
-
-  const { refs, style: dropdownStyle } = useDropdown({ isOpen, onClose: close });
-
-  useTrapFocus(refs.floating, {
-    arrowKeysUpDown: true,
-    activeState: isOpen,
-    initialFocus: InitialFocusType.autofocus,
-    initialFocusContainerFallback: true,
-  });
-
-  const selectOption = (option: SelectOption) => {
-    setSelectedOption(option);
-    close();
-    selectTriggerRef.current?.focus();
-  };
-
-  const handleTriggerKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === ' ') toggle();
-  };
-
-  const handleOptionItemKeyDown = (event: KeyboardEvent<HTMLLIElement>, option: SelectOption) => {
-    if (event.key === ' ' || event.key === 'Enter') selectOption(option);
-  };
-
-  return (
-    <>
-      <label className="font-medium typography-label-sm" htmlFor={id}>
-        Delivery
-      </label>
-      <div ref={refs.setReference} className="relative">
-        <div
-          ref={selectTriggerRef}
-          role="combobox"
-          aria-required="true"
-          aria-controls={listboxId}
-          aria-expanded={isOpen}
-          aria-label="Select one option"
-          aria-activedescendant={selectedOption ? `${listboxId}-${selectedOption.value}` : undefined}
-          className="mt-0.5 flex items-center gap-8 relative font-normal typography-text-base ring-1 ring-neutral-300 ring-inset rounded-md py-2 px-4 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2 focus-visible:outline focus-visible:outline-offset cursor-pointer"
-          tabIndex={0}
-          onKeyDown={handleTriggerKeyDown}
-          onClick={toggle}
-        >
-          {selectedOption ? selectedOption.label : <span className="text-neutral-500">Choose from the list</span>}
-          <SfIconExpandMore
-            className={classNames('ml-auto text-neutral-500 transition-transform ease-in-out duration-300', {
-              'rotate-180': isOpen,
-            })}
-          />
-        </div>
-        <ul
-          id={listboxId}
-          ref={refs.setFloating}
-          role="listbox"
-          aria-label="Select one option"
-          className={classNames('w-full py-2 rounded-md shadow-md border border-neutral-100 bg-white z-10', {
-            hidden: !isOpen,
-          })}
-          style={dropdownStyle}
-        >
-          {options.map((option) => (
-            <SfListItem
-              id={`${listboxId}-${option.value}`}
-              key={option.value}
-              role="option"
-              tabIndex={0}
-              aria-selected={option.value === selectedOption?.value}
-              className={classNames('block', { 'font-medium': option.value === selectedOption?.value })}
-              onClick={() => selectOption(option)}
-              onKeyDown={(event) => handleOptionItemKeyDown(event, option)}
-              slotSuffix={option.value === selectedOption?.value && <SfIconCheck className="text-primary-700" />}
-            >
-              {option.label}
-            </SfListItem>
-          ))}
-        </ul>
-      </div>
-    </>
-  );
+  return <SelectDropdown options={options} label="Delivery" placeholder="Choose from the list" />;
 }
 // #endregion source
 SelectDropdownWithPlaceholder.getLayout = ShowcasePageLayout;

--- a/apps/preview/nuxt/pages/showcases/Card/ProductCard.vue
+++ b/apps/preview/nuxt/pages/showcases/Card/ProductCard.vue
@@ -1,0 +1,42 @@
+<template>
+  <div
+    class="flex flex-col min-w-[325px] max-w-[375px] lg:w-[496px] relative border border-neutral-200 rounded-md hover:shadow-xl"
+  >
+    <a
+      class="absolute inset-0 z-1 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-md"
+      href="#"
+    />
+    <img :src="image" :alt="title" class="object-cover h-auto rounded-t-md aspect-video" />
+    <div class="flex flex-col items-start p-4 grow">
+      <p class="font-medium typography-text-base">{{ title }}</p>
+      <p class="mt-1 mb-4 font-normal typography-text-sm text-neutral-700">{{ description }}</p>
+      <SfButton size="sm" variant="tertiary" class="relative mt-auto">{{ buttonLabel }}</SfButton>
+    </div>
+  </div>
+</template>
+<script lang="ts" setup>
+import { SfButton } from '@storefront-ui/vue';
+
+defineProps({
+  url: {
+    type: String,
+    default: '',
+  },
+  title: {
+    type: String,
+    default: '',
+  },
+  buttonLabel: {
+    type: String,
+    default: '',
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+  image: {
+    type: String,
+    default: '',
+  },
+});
+</script>

--- a/apps/preview/nuxt/pages/showcases/Card/ProductCardUsage.vue
+++ b/apps/preview/nuxt/pages/showcases/Card/ProductCardUsage.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="flex flex-wrap gap-4 lg:gap-6 lg:flex-nowrap">
+    <ProductCard v-for="card in cardDetails" :key="card.title" v-bind="card" />
+  </div>
+</template>
+<script lang="ts" setup>
+import ProductCard from './ProductCard.vue';
+
+const cardDetails = [
+  {
+    url: '#',
+    image: 'http://localhost:3100/@assets/card-3.png',
+    title: 'Sip Sustainably: The Rise of Boxed Water',
+    description:
+      'Boxed water is a sustainable alternative to traditional plastic bottles, made from renewable resources.',
+    buttonLabel: 'Read more',
+  },
+  {
+    url: '#',
+    image: 'http://localhost:3100/@assets/card-2.png',
+    title: 'Ride the Future: Exploring the Benefits of e-Bikes',
+    description:
+      'Eco-friendly, efficient, and fun modes of transportation that provide a range of benefits for riders and the environment.',
+    buttonLabel: 'Read more',
+  },
+  {
+    url: '#',
+    image: 'http://localhost:3100/@assets/card-1.png',
+    title: 'Unleash the Ultimate Listening Experience',
+    description:
+      'Audiophile headphones offer unmatched sound quality and clarity, making them the go-to choice for music enthusiasts.',
+    buttonLabel: 'Read more',
+  },
+];
+</script>

--- a/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdown.vue
+++ b/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdown.vue
@@ -1,0 +1,132 @@
+<template>
+  <label class="font-medium typography-label-sm" :class="{ 'text-disabled-900': disabled }" :for="id">Delivery</label>
+  <div ref="referenceRef" class="relative">
+    <div
+      :id="id"
+      ref="selectTriggerRef"
+      role="combobox"
+      :aria-controls="listboxId"
+      :aria-expanded="isOpen"
+      :aria-disabled="disabled"
+      aria-label="Select one option"
+      :aria-activedescendant="selectedOption ? `${listboxId}-${selectedOption.value}` : undefined"
+      class="mt-0.5 flex items-center gap-8 relative font-normal typography-text-base ring-1 ring-inset rounded-md py-2 px-4"
+      :class="
+        disabled
+          ? 'bg-disabled-100 ring-disabled-300 cursor-not-allowed'
+          : 'ring-neutral-300 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2 cursor-pointer'
+      "
+      :tabindex="disabled ? undefined : 0"
+      @keydown.space="toggle()"
+      @click="!disabled && toggle()"
+    >
+      <template v-if="selectedOption">{{ selectedOption.label }}</template>
+      <span v-else :class="disabled ? 'text-disabled-500' : 'text-neutral-500'">{{ placeholder }}</span>
+      <SfIconExpandMore
+        class="ml-auto transition-transform ease-in-out duration-300"
+        :class="[{ 'rotate-180': isOpen }, disabled ? 'text-disabled-500' : 'text-neutral-500']"
+      />
+    </div>
+    <ul
+      v-show="isOpen"
+      :id="listboxId"
+      ref="floatingRef"
+      role="listbox"
+      aria-label="Select one option"
+      class="w-full py-2 rounded-md shadow-md border border-neutral-100 bg-white z-10"
+      :style="dropdownStyle"
+    >
+      <SfListItem
+        v-for="option in options"
+        :id="`${listboxId}-${option.value}`"
+        :key="option.value"
+        role="option"
+        tabindex="0"
+        :aria-selected="option.value === selectedOption?.value"
+        class="block"
+        :class="{ 'font-medium': option.value === selectedOption?.value }"
+        @click="selectOption(option)"
+        @keydown.enter="selectOption(option)"
+        @keydown.space="selectOption(option)"
+      >
+        {{ option.label }}
+        <template #suffix>
+          <SfIconCheck v-if="option.value === selectedOption?.value" class="text-primary-700" />
+        </template>
+      </SfListItem>
+    </ul>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, type Ref, type PropType } from 'vue';
+import { unrefElement } from '@vueuse/core';
+import {
+  useDropdown,
+  useDisclosure,
+  SfIconExpandMore,
+  SfListItem,
+  SfIconCheck,
+  useId,
+  useTrapFocus,
+} from '@storefront-ui/vue';
+
+type SelectOption = {
+  label: string;
+  value: string;
+};
+
+const props = defineProps({
+  options: {
+    type: Array as PropType<Array<SelectOption>>,
+    required: true,
+  },
+  label: {
+    type: String,
+    required: true,
+  },
+  placeholder: {
+    type: String,
+    default: '',
+  },
+  defaultValue: {
+    type: Object as PropType<SelectOption>,
+    default: undefined,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  isError: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
+const selectedOption = ref<SelectOption | undefined>(props.defaultValue);
+const id = useId();
+const listboxId = `select-dropdown-${id}`;
+const selectTriggerRef = ref<HTMLDivElement>();
+
+const {
+  referenceRef,
+  floatingRef,
+  style: dropdownStyle,
+} = useDropdown({
+  isOpen,
+  onClose: close,
+});
+
+useTrapFocus(floatingRef as Ref<HTMLUListElement>, {
+  arrowKeysOn: true,
+  activeState: isOpen,
+  initialFocusContainerFallback: true,
+});
+
+const selectOption = (option: SelectOption) => {
+  selectedOption.value = option;
+  close();
+  unrefElement(selectTriggerRef as Ref<HTMLDivElement>)?.focus();
+};
+</script>

--- a/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownDisabled.vue
+++ b/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownDisabled.vue
@@ -1,82 +1,11 @@
 <template>
-  <label class="font-medium typography-label-sm" :class="{ 'text-disabled-900': isDisabled }" :for="id">Delivery</label>
-  <div ref="referenceRef" class="relative">
-    <div
-      :id="id"
-      ref="selectTriggerRef"
-      role="combobox"
-      :aria-controls="listboxId"
-      :aria-expanded="isOpen"
-      :aria-disabled="isDisabled"
-      aria-label="Select one option"
-      :aria-activedescendant="selectedOption ? `${listboxId}-${selectedOption.value}` : undefined"
-      class="mt-0.5 flex items-center gap-8 relative font-normal typography-text-base ring-1 ring-inset rounded-md py-2 px-4"
-      :class="
-        isDisabled
-          ? 'bg-disabled-100 ring-disabled-300 cursor-not-allowed'
-          : 'ring-neutral-300 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2 cursor-pointer'
-      "
-      :tabindex="isDisabled ? undefined : 0"
-      @keydown.space="toggle()"
-      @click="!isDisabled && toggle()"
-    >
-      <template v-if="selectedOption">{{ selectedOption.label }}</template>
-      <span v-else :class="isDisabled ? 'text-disabled-500' : 'text-neutral-500'">Choose from the list</span>
-      <SfIconExpandMore
-        class="ml-auto transition-transform ease-in-out duration-300"
-        :class="[{ 'rotate-180': isOpen }, isDisabled ? 'text-disabled-500' : 'text-neutral-500']"
-      />
-    </div>
-    <ul
-      v-show="isOpen"
-      :id="listboxId"
-      ref="floatingRef"
-      role="listbox"
-      aria-label="Select one option"
-      class="w-full py-2 rounded-md shadow-md border border-neutral-100 bg-white z-10"
-      :style="dropdownStyle"
-    >
-      <SfListItem
-        v-for="option in options"
-        :id="`${listboxId}-${option.value}`"
-        :key="option.value"
-        role="option"
-        tabindex="0"
-        :aria-selected="option.value === selectedOption?.value"
-        class="block"
-        :class="{ 'font-medium': option.value === selectedOption?.value }"
-        @click="selectOption(option)"
-        @keydown.enter="selectOption(option)"
-        @keydown.space="selectOption(option)"
-      >
-        {{ option.label }}
-        <template #suffix>
-          <SfIconCheck v-if="option.value === selectedOption?.value" class="text-primary-700" />
-        </template>
-      </SfListItem>
-    </ul>
-  </div>
+  <SelectDropdown :options="options" label="Delivery" :disabled="true" />
 </template>
 
 <script lang="ts" setup>
-import { ref, type Ref } from 'vue';
-import { unrefElement } from '@vueuse/core';
-import {
-  useDropdown,
-  useDisclosure,
-  SfIconExpandMore,
-  SfListItem,
-  SfIconCheck,
-  useId,
-  useTrapFocus,
-} from '@storefront-ui/vue';
+import SelectDropdown from './SelectDropdown.vue';
 
-type SelectOption = {
-  label: string;
-  value: string;
-};
-
-const options: SelectOption[] = [
+const options = [
   {
     label: 'Today',
     value: 'today',
@@ -90,32 +19,4 @@ const options: SelectOption[] = [
     value: 'anytime',
   },
 ];
-
-const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
-const isDisabled = ref(true);
-const selectedOption = ref<SelectOption>();
-const id = useId();
-const listboxId = `select-dropdown-${id}`;
-const selectTriggerRef = ref<HTMLDivElement>();
-
-const {
-  referenceRef,
-  floatingRef,
-  style: dropdownStyle,
-} = useDropdown({
-  isOpen,
-  onClose: close,
-});
-
-useTrapFocus(floatingRef as Ref<HTMLUListElement>, {
-  arrowKeysUpDown: true,
-  activeState: isOpen,
-  initialFocusContainerFallback: true,
-});
-
-const selectOption = (option: SelectOption) => {
-  selectedOption.value = option;
-  close();
-  unrefElement(selectTriggerRef as Ref<HTMLDivElement>)?.focus();
-};
 </script>

--- a/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownError.vue
+++ b/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownError.vue
@@ -1,82 +1,11 @@
 <template>
-  <label class="font-medium typography-label-sm" :for="id">Delivery</label>
-  <div ref="referenceRef" class="relative">
-    <div
-      :id="id"
-      ref="selectTriggerRef"
-      role="combobox"
-      :aria-controls="listboxId"
-      :aria-expanded="isOpen"
-      aria-label="Select one option"
-      :aria-activedescendant="selectedOption ? `${listboxId}-${selectedOption.value}` : undefined"
-      class="mt-0.5 flex items-center gap-8 relative ring-inset rounded-md py-2 px-4 font-normal typography-text-base focus-visible:outline focus-visible:outline-offset cursor-pointer"
-      :class="
-        isValid
-          ? 'ring-1 ring-neutral-300 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2'
-          : 'ring-2 ring-negative-700'
-      "
-      tabindex="0"
-      @keydown.space="toggle()"
-      @click="toggle()"
-    >
-      <template v-if="selectedOption">{{ selectedOption.label }}</template>
-      <span v-else class="text-neutral-500">Choose from the list</span>
-      <SfIconExpandMore
-        class="ml-auto text-neutral-500 transition-transform ease-in-out duration-300"
-        :class="{ 'rotate-180': isOpen }"
-      />
-    </div>
-    <ul
-      v-show="isOpen"
-      :id="listboxId"
-      ref="floatingRef"
-      role="listbox"
-      aria-label="Select one option"
-      class="w-full py-2 rounded-md shadow-md border border-neutral-100 bg-white z-10"
-      :style="dropdownStyle"
-    >
-      <SfListItem
-        v-for="option in options"
-        :id="`${listboxId}-${option.value}`"
-        :key="option.value"
-        role="option"
-        tabindex="0"
-        :aria-selected="option.value === selectedOption?.value"
-        class="block"
-        :class="{ 'font-medium': option.value === selectedOption?.value }"
-        @click="selectOption(option)"
-        @keydown.enter="selectOption(option)"
-        @keydown.space="selectOption(option)"
-      >
-        {{ option.label }}
-        <template #suffix>
-          <SfIconCheck v-if="option.value === selectedOption?.value" class="text-primary-700" />
-        </template>
-      </SfListItem>
-    </ul>
-  </div>
-  <p v-if="!isValid" class="text-negative-700 typography-text-sm font-medium mt-0.5">No option selected</p>
+  <SelectDropdown :options="options" label="Delivery" :is-error="true" />
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, type Ref } from 'vue';
-import { unrefElement } from '@vueuse/core';
-import {
-  useDropdown,
-  useDisclosure,
-  SfIconExpandMore,
-  SfListItem,
-  SfIconCheck,
-  useId,
-  useTrapFocus,
-} from '@storefront-ui/vue';
+import SelectDropdown from './SelectDropdown.vue';
 
-type SelectOption = {
-  label: string;
-  value: string;
-};
-
-const options: SelectOption[] = [
+const options = [
   {
     label: 'Today',
     value: 'today',
@@ -90,32 +19,4 @@ const options: SelectOption[] = [
     value: 'anytime',
   },
 ];
-
-const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
-const selectedOption = ref<SelectOption>();
-const id = useId();
-const listboxId = `select-dropdown-${id}`;
-const isValid = computed(() => !!selectedOption.value);
-const selectTriggerRef = ref<HTMLDivElement>();
-
-const {
-  referenceRef,
-  floatingRef,
-  style: dropdownStyle,
-} = useDropdown({
-  isOpen,
-  onClose: close,
-});
-
-useTrapFocus(floatingRef as Ref<HTMLUListElement>, {
-  arrowKeysUpDown: true,
-  activeState: isOpen,
-  initialFocusContainerFallback: true,
-});
-
-const selectOption = (option: SelectOption) => {
-  selectedOption.value = option;
-  close();
-  unrefElement(selectTriggerRef as Ref<HTMLDivElement>)?.focus();
-};
 </script>

--- a/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownPreselected.vue
+++ b/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownPreselected.vue
@@ -1,114 +1,22 @@
 <template>
-  <label className="font-medium typography-label-sm" :for="id">Product</label>
-  <div ref="referenceRef" class="relative">
-    <div
-      :id="id"
-      ref="selectTriggerRef"
-      role="combobox"
-      :aria-controls="listboxId"
-      :aria-expanded="isOpen"
-      aria-label="Select one option"
-      :aria-activedescendant="selectedOption ? `${listboxId}-${selectedOption.value}` : undefined"
-      class="mt-0.5 flex items-center gap-8 relative font-normal typography-text-base ring-1 ring-neutral-300 ring-inset rounded-md py-2 px-4 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2 focus-visible:outline focus-visible:outline-offset cursor-pointer"
-      tabindex="0"
-      @keydown.space="toggle()"
-      @click="toggle()"
-    >
-      <template v-if="selectedOption">{{ selectedOption.label }}</template>
-      <span v-else class="text-neutral-500">Choose from the list</span>
-      <SfIconExpandMore
-        class="ml-auto text-neutral-500 transition-transform ease-in-out duration-300"
-        :class="{ 'rotate-180': isOpen }"
-      />
-    </div>
-    <ul
-      v-show="isOpen"
-      :id="listboxId"
-      ref="floatingRef"
-      role="listbox"
-      aria-label="Select one option"
-      class="w-full py-2 rounded-md shadow-md border border-neutral-100 bg-white z-10"
-      :style="dropdownStyle"
-    >
-      <SfListItem
-        v-for="option in options"
-        :id="`${listboxId}-${option.value}`"
-        :key="option.value"
-        role="option"
-        tabindex="0"
-        :aria-selected="option.value === selectedOption?.value"
-        class="block"
-        :class="{ 'font-medium': option.value === selectedOption?.value }"
-        @click="selectOption(option)"
-        @keydown.enter="selectOption(option)"
-        @keydown.space="selectOption(option)"
-      >
-        {{ option.label }}
-        <template #suffix>
-          <SfIconCheck v-if="option.value === selectedOption?.value" class="text-primary-700" />
-        </template>
-      </SfListItem>
-    </ul>
-  </div>
+  <SelectDropdown :options="options" label="Delivery" :default-value="options[0]" />
 </template>
 
 <script lang="ts" setup>
-import { ref, type Ref } from 'vue';
-import { unrefElement } from '@vueuse/core';
-import {
-  useDropdown,
-  useDisclosure,
-  SfIconExpandMore,
-  SfListItem,
-  SfIconCheck,
-  useId,
-  useTrapFocus,
-} from '@storefront-ui/vue';
+import SelectDropdown from './SelectDropdown.vue';
 
-type SelectOption = {
-  label: string;
-  value: string;
-};
-
-const options: SelectOption[] = [
+const options = [
   {
-    label: 'Startup',
-    value: 'startup',
+    label: 'Today',
+    value: 'today',
   },
   {
-    label: 'Business',
-    value: 'business',
+    label: 'Tomorrow',
+    value: 'tomorrow',
   },
   {
-    label: 'Enterprise',
-    value: 'enterprise',
+    label: 'Anytime',
+    value: 'anytime',
   },
 ];
-
-const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
-const selectedOption = ref<SelectOption>(options[0]);
-const id = useId();
-const listboxId = `select-dropdown-${id}`;
-const selectTriggerRef = ref<HTMLDivElement>();
-
-const {
-  referenceRef,
-  floatingRef,
-  style: dropdownStyle,
-} = useDropdown({
-  isOpen,
-  onClose: close,
-});
-
-useTrapFocus(floatingRef as Ref<HTMLUListElement>, {
-  arrowKeysUpDown: true,
-  activeState: isOpen,
-  initialFocusContainerFallback: true,
-});
-
-const selectOption = (option: SelectOption) => {
-  selectedOption.value = option;
-  close();
-  unrefElement(selectTriggerRef as Ref<HTMLDivElement>)?.focus();
-};
 </script>

--- a/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownWithPlaceholder.vue
+++ b/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownWithPlaceholder.vue
@@ -1,76 +1,11 @@
 <template>
-  <label class="font-medium typography-label-sm" :for="id">Delivery</label>
-  <div ref="referenceRef" class="relative">
-    <div
-      :id="id"
-      ref="selectTriggerRef"
-      role="combobox"
-      :aria-controls="listboxId"
-      :aria-expanded="isOpen"
-      aria-label="Select one option"
-      :aria-activedescendant="selectedOption ? `${listboxId}-${selectedOption.value}` : undefined"
-      class="mt-0.5 flex items-center gap-8 relative font-normal typography-text-base ring-1 ring-neutral-300 ring-inset rounded-md py-2 px-4 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2 focus-visible:outline focus-visible:outline-offset cursor-pointer"
-      tabindex="0"
-      @keydown.space="toggle()"
-      @click="toggle()"
-    >
-      <template v-if="selectedOption">{{ selectedOption.label }}</template>
-      <span v-else class="text-neutral-500">Choose from the list</span>
-      <SfIconExpandMore
-        class="ml-auto text-neutral-500 transition-transform ease-in-out duration-300"
-        :class="{ 'rotate-180': isOpen }"
-      />
-    </div>
-    <ul
-      v-show="isOpen"
-      :id="listboxId"
-      ref="floatingRef"
-      role="listbox"
-      aria-label="Select one option"
-      class="w-full py-2 rounded-md shadow-md border border-neutral-100 bg-white z-10"
-      :style="dropdownStyle"
-    >
-      <SfListItem
-        v-for="option in options"
-        :id="`${listboxId}-${option.value}`"
-        :key="option.value"
-        role="option"
-        tabindex="0"
-        :aria-selected="option.value === selectedOption?.value"
-        class="block"
-        :class="{ 'font-medium': option.value === selectedOption?.value }"
-        @click="selectOption(option)"
-        @keydown.enter="selectOption(option)"
-        @keydown.space="selectOption(option)"
-      >
-        {{ option.label }}
-        <template #suffix>
-          <SfIconCheck v-if="option.value === selectedOption?.value" class="text-primary-700" />
-        </template>
-      </SfListItem>
-    </ul>
-  </div>
+  <SelectDropdown :options="options" label="Delivery" placeholder="Choose from the list" />
 </template>
 
 <script lang="ts" setup>
-import { ref, type Ref } from 'vue';
-import { unrefElement } from '@vueuse/core';
-import {
-  useDropdown,
-  useDisclosure,
-  SfIconExpandMore,
-  SfListItem,
-  SfIconCheck,
-  useId,
-  useTrapFocus,
-} from '@storefront-ui/vue';
+import SelectDropdown from './SelectDropdown.vue';
 
-type SelectOption = {
-  label: string;
-  value: string;
-};
-
-const options: SelectOption[] = [
+const options = [
   {
     label: 'Today',
     value: 'today',
@@ -84,31 +19,4 @@ const options: SelectOption[] = [
     value: 'anytime',
   },
 ];
-
-const { close, toggle, isOpen } = useDisclosure({ initialValue: false });
-const selectedOption = ref<SelectOption>();
-const id = useId();
-const listboxId = `select-dropdown-${id}`;
-const selectTriggerRef = ref<HTMLDivElement>();
-
-const {
-  referenceRef,
-  floatingRef,
-  style: dropdownStyle,
-} = useDropdown({
-  isOpen,
-  onClose: close,
-});
-
-useTrapFocus(floatingRef as Ref<HTMLUListElement>, {
-  arrowKeysUpDown: true,
-  activeState: isOpen,
-  initialFocusContainerFallback: true,
-});
-
-const selectOption = (option: SelectOption) => {
-  selectedOption.value = option;
-  close();
-  unrefElement(selectTriggerRef as Ref<HTMLDivElement>)?.focus();
-};
 </script>


### PR DESCRIPTION
# Related issue

Closes: [SFUI2-1156](https://vsf.atlassian.net/browse/SFUI2-1156)
RFC: [A blocks source code display strategy](https://vsf.atlassian.net/wiki/spaces/SFUI/pages/149880885/A+blocks+source+code+display+strategy)

# Scope of work

<!-- describe what you did -->

This PoC shows how we could deliver Blocks' source code to be more "production ready".

Blocks would be implemented in a more standard way as components. It would require additional usage file, and one extra tab in the Block's iframe section.

# Screenshots of visual changes

<!-- if visual changes applied -->

<img width="1139" alt="Screenshot 2023-05-31 at 16 49 24" src="https://github.com/vuestorefront/storefront-ui/assets/34419118/e8d4851b-2bf6-4771-bf7c-ecb7bc09b481">



[SFUI2-1156]: https://vsf.atlassian.net/browse/SFUI2-1156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ