### PR TITLE
fix: filter sizes typo

### DIFF
--- a/apps/preview/next/pages/showcases/Filters/Size.tsx
+++ b/apps/preview/next/pages/showcases/Filters/Size.tsx
@@ -36,7 +36,7 @@ export default function SizeFilter() {
       className="w-full md:max-w-[376px]"
       summary={
         <div className="flex justify-between p-2 mb-2">
-          <p className="font-medium">Sizes</p>
+          <p className="font-medium">Size</p>
           <SfIconChevronLeft className={classNames('text-neutral-500', `${opened ? 'rotate-90' : '-rotate-90'}`)} />
         </div>
       }


### PR DESCRIPTION
# Related issue

Closes #

# Scope of work

Fixed typo in Size filter block. 

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
