### PR TITLE
ci: exit pre-release changesets when comment created [SFUI2-1184]

### DIFF
--- a/.github/workflows/exit-pre-mode-on-comment.yml
+++ b/.github/workflows/exit-pre-mode-on-comment.yml
@@ -24,12 +24,6 @@ jobs:
           cache: "yarn"
       - name: Install dependencies
         run: yarn --immutable
-      - name: Check if user has write access
-        uses: lannonbr/repo-permission-check-action@2.0.0
-        with:
-          permission: "write"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: resolve pr refs
         id: refs
         uses: eficode/resolve-pr-refs@main

--- a/.github/workflows/exit-pre-mode-on-comment.yml
+++ b/.github/workflows/exit-pre-mode-on-comment.yml
@@ -1,0 +1,56 @@
+name: Exit pre-release
+
+on:
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  exit-pre-release:
+    name: Exit changesets pre-release mode when !exit-rc comment created
+    if: ${{ github.event.comment.body == '!exit-rc' && github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".node-version"
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn --immutable
+      - name: Check if user has write access
+        uses: lannonbr/repo-permission-check-action@2.0.0
+        with:
+          permission: "write"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: resolve pr refs
+        id: refs
+        uses: eficode/resolve-pr-refs@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.refs.outputs.head_ref }}
+      - name: set up env branch name var
+        run: echo "BRANCH_NAME=$(echo $(git branch --show-current))" >> $GITHUB_ENV
+      - name: Exit pre release mode for changesets
+        if: ${{ startsWith( env.BRANCH_NAME, 'v2-release' ) }}
+        run: yarn changeset pre exit
+      - name: Create PR with changelog
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          commit: '[ci] - release'
+          title: '[ci] - release'
+        env:
+          # Needs access to publish to npm
+          # refresh token before Saturday, May 25, 2024
+          NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/exit-pre-mode-on-comment.yml
+++ b/.github/workflows/exit-pre-mode-on-comment.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   exit-pre-release:
     name: Exit changesets pre-release mode when !prod-ready comment created
-    if: ${{ github.event.comment.body == '!prod-ready' && github.event.issue.pull_request }}
+    if: ${{ contains(github.event.comment.body, '!prod-ready') && github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/exit-pre-mode-on-comment.yml
+++ b/.github/workflows/exit-pre-mode-on-comment.yml
@@ -1,4 +1,4 @@
-name: Exit pre-release changesets
+name: Exit changesets pre-release
 on:
   issue_comment:
     types:
@@ -15,8 +15,8 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version-file: ".node-version"
-          cache: "yarn"
+          node-version-file: '.node-version'
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn --immutable
       - name: resolve pr refs

--- a/.github/workflows/exit-pre-mode-on-comment.yml
+++ b/.github/workflows/exit-pre-mode-on-comment.yml
@@ -33,7 +33,6 @@ jobs:
         if: ${{ startsWith( env.BRANCH_NAME, 'v2-release' ) }}
         run: yarn changeset pre exit
       - name: Create PR with changelog
-        id: changesets
         uses: changesets/action@v1
         with:
           commit: '[ci] - release [no ci]'

--- a/.github/workflows/exit-pre-mode-on-comment.yml
+++ b/.github/workflows/exit-pre-mode-on-comment.yml
@@ -1,18 +1,13 @@
-name: Exit pre-release
-
+name: Exit pre-release changesets
 on:
-  workflow_dispatch:
   issue_comment:
-    types: [created]
-
-defaults:
-  run:
-    shell: bash
+    types:
+      - created
 
 jobs:
   exit-pre-release:
-    name: Exit changesets pre-release mode when !exit-rc comment created
-    if: ${{ github.event.comment.body == '!exit-rc' && github.event.issue.pull_request }}
+    name: Exit changesets pre-release mode when !prod-ready comment created
+    if: ${{ github.event.comment.body == '!prod-ready' && github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -26,22 +21,22 @@ jobs:
         run: yarn --immutable
       - name: resolve pr refs
         id: refs
-        uses: eficode/resolve-pr-refs@main
+        uses: eficode/resolve-pr-refs@v0.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
         with:
           ref: ${{ steps.refs.outputs.head_ref }}
-      - name: set up env branch name var
+      - name: Set up env branch name var
         run: echo "BRANCH_NAME=$(echo $(git branch --show-current))" >> $GITHUB_ENV
-      - name: Exit pre release mode for changesets
+      - name: Exit pre-release mode for changesets
         if: ${{ startsWith( env.BRANCH_NAME, 'v2-release' ) }}
         run: yarn changeset pre exit
       - name: Create PR with changelog
         id: changesets
         uses: changesets/action@v1
         with:
-          commit: '[ci] - release'
+          commit: '[ci] - release [no ci]'
           title: '[ci] - release'
         env:
           # Needs access to publish to npm


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1184

# Scope of work

Github action that is triggered on comment creation to exit pre-release mode for changset, its run when:
- when comment is CREATED in PULL REQUEST, can be issue etc
- when comment value is `!prod-ready`
- when branch name starts with `v2-release/**`

NOTE: this PR will be merged directly into `v2` branch !!


# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
