### PR TITLE
fix: search arrow key handling [SFUI2-1205]

### DIFF
--- a/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
@@ -1,6 +1,6 @@
 import { ShowcasePageLayout } from '../../showcases';
 // #region source
-import { type ChangeEvent, type FormEvent, useState, useRef } from 'react';
+import { type ChangeEvent, type KeyboardEvent, type FormEvent, useState, useRef } from 'react';
 import { useDebounce } from 'react-use';
 import { offset } from '@floating-ui/react-dom';
 import {

--- a/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchBasic.tsx
@@ -62,7 +62,8 @@ export default function SearchBasic() {
     placement: 'bottom-start',
     middleware: [offset(4)],
   });
-  useTrapFocus(dropdownListRef, {
+  const { focusables: focusableElements, updateFocusableElements } = useTrapFocus(dropdownListRef, {
+    trapTabs: false,
     initialFocus: false,
     arrowKeysUpDown: true,
     activeState: isOpen,
@@ -100,6 +101,24 @@ export default function SearchBasic() {
     handleFocusInput();
   };
 
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') handleReset();
+    if (event.key === 'ArrowUp') {
+      open();
+      updateFocusableElements();
+      if (isOpen && focusableElements.length > 0) {
+        focusableElements[focusableElements.length - 1].focus();
+      }
+    }
+    if (event.key === 'ArrowDown') {
+      open();
+      updateFocusableElements();
+      if (isOpen && focusableElements.length > 0) {
+        focusableElements[0].focus();
+      }
+    }
+  };
+
   useDebounce(
     () => {
       if (searchValue) {
@@ -132,6 +151,7 @@ export default function SearchBasic() {
         onFocus={open}
         aria-label="Search"
         placeholder="Search 'MacBook' or 'iPhone'..."
+        onKeyDown={handleInputKeyDown}
         slotPrefix={<SfIconSearch />}
         slotSuffix={
           isResetButton && (

--- a/apps/preview/next/pages/showcases/Search/SearchWithButton.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchWithButton.tsx
@@ -65,7 +65,12 @@ export default function SearchWithIcon() {
     placement: 'bottom-start',
     middleware: [offset(4)],
   });
-  useTrapFocus(dropdownListRef, { arrowKeysUpDown: true, activeState: isOpen, initialFocus: false });
+  const { focusables: focusableElements, updateFocusableElements } = useTrapFocus(dropdownListRef, {
+    trapTabs: false,
+    arrowKeysUpDown: true,
+    activeState: isOpen,
+    initialFocus: false,
+  });
   const isResetButton = Boolean(searchValue);
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
@@ -97,6 +102,24 @@ export default function SearchWithIcon() {
     setSearchValue(phrase);
     close();
     handleFocusInput();
+  };
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') handleReset();
+    if (event.key === 'ArrowUp') {
+      open();
+      updateFocusableElements();
+      if (isOpen && focusableElements.length > 0) {
+        focusableElements[focusableElements.length - 1].focus();
+      }
+    }
+    if (event.key === 'ArrowDown') {
+      open();
+      updateFocusableElements();
+      if (isOpen && focusableElements.length > 0) {
+        focusableElements[0].focus();
+      }
+    }
   };
 
   useDebounce(
@@ -133,6 +156,7 @@ export default function SearchWithIcon() {
           wrapperClassName="w-full ring-0 active:ring-0 hover:ring-0 focus-within:ring-0 border-y border-l border-neutral-200 rounded-r-none hover:border-primary-800 active:border-primary-700 active:border-y-2 active:border-l-2 focus-within:border-y-2 focus-within:border-l-2 focus-within:border-primary-700"
           aria-label="Search"
           placeholder="Search 'jackets' or 'dresses'..."
+          onKeyDown={handleInputKeyDown}
           slotPrefix={<SfIconSearch />}
           slotSuffix={
             isResetButton && (

--- a/apps/preview/next/pages/showcases/Search/SearchWithButton.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchWithButton.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 import { ShowcasePageLayout } from '../../showcases';
 // #region source
-import { type ChangeEvent, type FormEvent, useState, useRef } from 'react';
+import { type ChangeEvent, type FormEvent, type KeyboardEvent, useState, useRef } from 'react';
 import { useDebounce } from 'react-use';
 import { offset } from '@floating-ui/react-dom';
 import {

--- a/apps/preview/next/pages/showcases/Search/SearchWithIcon.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchWithIcon.tsx
@@ -66,7 +66,12 @@ export default function SearchWithIcon() {
     placement: 'bottom-start',
     middleware: [offset(4)],
   });
-  useTrapFocus(dropdownListRef, { arrowKeysUpDown: true, activeState: isOpen, initialFocus: false });
+  const { focusables: focusableElements, updateFocusableElements } = useTrapFocus(dropdownListRef, {
+    trapTabs: false,
+    arrowKeysUpDown: true,
+    activeState: isOpen,
+    initialFocus: false,
+  });
   const isResetButton = Boolean(searchValue);
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
@@ -98,6 +103,24 @@ export default function SearchWithIcon() {
     setSearchValue(phrase);
     close();
     handleFocusInput();
+  };
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') handleReset();
+    if (event.key === 'ArrowUp') {
+      open();
+      updateFocusableElements();
+      if (isOpen && focusableElements.length > 0) {
+        focusableElements[focusableElements.length - 1].focus();
+      }
+    }
+    if (event.key === 'ArrowDown') {
+      open();
+      updateFocusableElements();
+      if (isOpen && focusableElements.length > 0) {
+        focusableElements[0].focus();
+      }
+    }
   };
 
   useDebounce(
@@ -134,6 +157,7 @@ export default function SearchWithIcon() {
           wrapperClassName="w-full ring-0 active:ring-0 hover:ring-0 focus-within:ring-0 border-y border-l border-neutral-200 rounded-r-none hover:border-primary-800 active:border-primary-700 active:border-y-2 active:border-l-2 focus-within:border-y-2 focus-within:border-l-2 focus-within:border-primary-700"
           aria-label="Search"
           placeholder="Search 'MacBook' or 'iPhone'..."
+          onKeyDown={handleInputKeyDown}
           slotPrefix={<SfIconSearch />}
           slotSuffix={
             isResetButton && (

--- a/apps/preview/next/pages/showcases/Search/SearchWithIcon.tsx
+++ b/apps/preview/next/pages/showcases/Search/SearchWithIcon.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 import { ShowcasePageLayout } from '../../showcases';
 // #region source
-import { type ChangeEvent, type FormEvent, useState, useRef } from 'react';
+import { type ChangeEvent, type FormEvent, type KeyboardEvent, useState, useRef } from 'react';
 import { useDebounce } from 'react-use';
 import { offset } from '@floating-ui/react-dom';
 import {

--- a/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
@@ -6,6 +6,7 @@
       aria-label="Search"
       placeholder="Search 'MacBook' or 'iPhone'..."
       @focus="open"
+      @keydown="handleInputKeyDown"
     >
       <template #prefix><SfIconSearch /></template>
       <template #suffix>
@@ -78,7 +79,12 @@ const { referenceRef, floatingRef, style } = useDropdown({
   placement: 'bottom-start',
   middleware: [offset(4)],
 });
-useTrapFocus(dropdownListRef as Ref<HTMLElement>, { arrowKeysUpDown: true, activeState: isOpen, initialFocus: false });
+const { focusables: focusableElements } = useTrapFocus(dropdownListRef as Ref<HTMLElement>, {
+  trapTabs: false,
+  arrowKeysUpDown: true,
+  activeState: isOpen,
+  initialFocus: false,
+});
 
 const submit = () => {
   close();
@@ -101,6 +107,22 @@ const selectValue = (phrase: string) => {
   inputModel.value = phrase;
   close();
   focusInput();
+};
+
+const handleInputKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+  if (event.key === 'Escape') reset();
+  if (event.key === 'ArrowUp') {
+    open();
+    if (isOpen && focusableElements.value.length > 0) {
+      focusableElements.value[focusableElements.value.length - 1].focus();
+    }
+  }
+  if (event.key === 'ArrowDown') {
+    open();
+    if (isOpen && focusableElements.value.length > 0) {
+      focusableElements.value[0].focus();
+    }
+  }
 };
 
 watch(inputModel, () => {

--- a/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchBasic.vue
@@ -109,7 +109,7 @@ const selectValue = (phrase: string) => {
   focusInput();
 };
 
-const handleInputKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+const handleInputKeyDown = (event: KeyboardEvent) => {
   if (event.key === 'Escape') reset();
   if (event.key === 'ArrowUp') {
     open();

--- a/apps/preview/nuxt/pages/showcases/Search/SearchWithButton.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchWithButton.vue
@@ -8,6 +8,7 @@
         aria-label="Search"
         placeholder="Search 'jackets' or 'dresses'..."
         @focus="open"
+        @keydown="handleInputKeyDown"
       >
         <template #prefix><SfIconSearch /></template>
         <template #suffix>
@@ -93,7 +94,12 @@ const { referenceRef, floatingRef, style } = useDropdown({
   placement: 'bottom-start',
   middleware: [offset(4)],
 });
-useTrapFocus(dropdownListRef as Ref<HTMLElement>, { arrowKeysUpDown: true, activeState: isOpen, initialFocus: false });
+const { focusables: focusableElements } = useTrapFocus(dropdownListRef as Ref<HTMLElement>, {
+  trapTabs: false,
+  arrowKeysUpDown: true,
+  activeState: isOpen,
+  initialFocus: false,
+});
 
 const submit = () => {
   close();
@@ -116,6 +122,22 @@ const selectValue = (phrase: string) => {
   inputModel.value = phrase;
   close();
   focusInput();
+};
+
+const handleInputKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+  if (event.key === 'Escape') reset();
+  if (event.key === 'ArrowUp') {
+    open();
+    if (isOpen && focusableElements.value.length > 0) {
+      focusableElements.value[focusableElements.value.length - 1].focus();
+    }
+  }
+  if (event.key === 'ArrowDown') {
+    open();
+    if (isOpen && focusableElements.value.length > 0) {
+      focusableElements.value[0].focus();
+    }
+  }
 };
 
 watch(inputModel, () => {

--- a/apps/preview/nuxt/pages/showcases/Search/SearchWithButton.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchWithButton.vue
@@ -124,7 +124,7 @@ const selectValue = (phrase: string) => {
   focusInput();
 };
 
-const handleInputKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+const handleInputKeyDown = (event: KeyboardEvent) => {
   if (event.key === 'Escape') reset();
   if (event.key === 'ArrowUp') {
     open();

--- a/apps/preview/nuxt/pages/showcases/Search/SearchWithIcon.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchWithIcon.vue
@@ -8,6 +8,7 @@
         aria-label="Search"
         placeholder="Search 'MacBook' or 'iPhone'..."
         @focus="open"
+        @keydown="handleInputKeyDown"
       >
         <template #prefix><SfIconSearch /></template>
         <template #suffix>
@@ -86,7 +87,12 @@ const { referenceRef, floatingRef, style } = useDropdown({
   placement: 'bottom-start',
   middleware: [offset(4)],
 });
-useTrapFocus(dropdownListRef as Ref<HTMLElement>, { arrowKeysUpDown: true, activeState: isOpen, initialFocus: false });
+const { focusables: focusableElements } = useTrapFocus(dropdownListRef as Ref<HTMLElement>, {
+  trapTabs: false,
+  arrowKeysUpDown: true,
+  activeState: isOpen,
+  initialFocus: false,
+});
 
 const submit = () => {
   close();
@@ -109,6 +115,22 @@ const selectValue = (phrase: string) => {
   inputModel.value = phrase;
   close();
   focusInput();
+};
+
+const handleInputKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+  if (event.key === 'Escape') reset();
+  if (event.key === 'ArrowUp') {
+    open();
+    if (isOpen && focusableElements.value.length > 0) {
+      focusableElements.value[focusableElements.value.length - 1].focus();
+    }
+  }
+  if (event.key === 'ArrowDown') {
+    open();
+    if (isOpen && focusableElements.value.length > 0) {
+      focusableElements.value[0].focus();
+    }
+  }
 };
 
 watch(inputModel, () => {

--- a/apps/preview/nuxt/pages/showcases/Search/SearchWithIcon.vue
+++ b/apps/preview/nuxt/pages/showcases/Search/SearchWithIcon.vue
@@ -117,7 +117,7 @@ const selectValue = (phrase: string) => {
   focusInput();
 };
 
-const handleInputKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+const handleInputKeyDown = (event: KeyboardEvent) => {
   if (event.key === 'Escape') reset();
   if (event.key === 'ArrowUp') {
     open();


### PR DESCRIPTION
# Related issue

Closes [#1205](https://vsf.atlassian.net/browse/SFUI2-1205)

# Scope of work

Added bottom/up arrow handling when focused on the input field. Now it moves focus to the dropdown items. 

# Screenshots of visual changes

![search_key_handling](https://github.com/vuestorefront/storefront-ui/assets/32042425/dce7e822-8a91-4750-b352-e381288b1fd5)

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
