### PR TITLE
docs: add SfButton explanation on NavbarBottom

### DIFF
--- a/apps/docs/components/blocks/NavbarBottom.md
+++ b/apps/docs/components/blocks/NavbarBottom.md
@@ -8,6 +8,17 @@ hideToc: true
 
 {{ $frontmatter.description }}
 
+::: tip You can make the navbar items links
+Each item in the navbar is an [`SfButton`](../components/button) component. This means that you can make each item a link by using the `tag` prop. [Learn more about this usage in the component documentation.](../components/button#link-as-a-button)
+
+```html
+<SfButton tag="a" href="#">
+  Will render as an anchor tag
+</SfButton>
+```
+:::
+
+
 ## NavbarBottom with white background
 
 <Showcase showcase-name="NavbarBottom/NavbarBottom" no-paddings style="min-height:200px">

--- a/apps/docs/components/blocks/NavbarBottom.md
+++ b/apps/docs/components/blocks/NavbarBottom.md
@@ -9,13 +9,23 @@ hideToc: true
 {{ $frontmatter.description }}
 
 ::: tip You can make the navbar items links
-Each item in the navbar is an [`SfButton`](../components/button) component. This means that you can make each item a link by using the `tag` prop to make it an `a`, <!-- react -->`NextLink`<!-- end react --><!-- vue -->`NuxtLink`<!-- end vue -->, or any other element/component. [Learn more about this usage in the component documentation.](../components/button#link-as-a-button)
+Each item in the navbar is an [`SfButton`](../components/button) component. This means that you can make each item a link by using the <!-- react -->`as`<!-- end react --><!-- vue -->`tag`<!-- end vue --> prop to make it an `a`, <!-- react -->`NextLink`<!-- end react --><!-- vue -->`NuxtLink`<!-- end vue -->, or any other element/component. [Learn more about this usage in the component documentation.](../components/button#link-as-a-button)
 
+<!-- react -->
+```html
+<SfButton as="a" href="#">
+  Will render as an anchor tag
+</SfButton>
+```
+<!-- end react -->
+<!-- vue -->
 ```html
 <SfButton tag="a" href="#">
   Will render as an anchor tag
 </SfButton>
 ```
+<!-- end vue -->
+
 :::
 
 

--- a/apps/docs/components/blocks/NavbarBottom.md
+++ b/apps/docs/components/blocks/NavbarBottom.md
@@ -9,7 +9,7 @@ hideToc: true
 {{ $frontmatter.description }}
 
 ::: tip You can make the navbar items links
-Each item in the navbar is an [`SfButton`](../components/button) component. This means that you can make each item a link by using the `tag` prop. [Learn more about this usage in the component documentation.](../components/button#link-as-a-button)
+Each item in the navbar is an [`SfButton`](../components/button) component. This means that you can make each item a link by using the `tag` prop to make it an `a`, <!-- react -->`NextLink`<!-- end react --><!-- vue -->`NuxtLink`<!-- end vue -->, or any other element/component. [Learn more about this usage in the component documentation.](../components/button#link-as-a-button)
 
 ```html
 <SfButton tag="a" href="#">


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-796

# Scope of work

- adds callout to the `NavbarBottom` block explaining the usage of `Sf

# Screenshots of visual changes

![image](https://github.com/vuestorefront/storefront-ui/assets/18535681/25ca11ef-f0fc-41c5-a0a8-7f4646af4a7b)


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
