### PR TITLE
ci: release candidate workflow [SFUI2-1184]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - v2
       - v2-develop
+      - '!changeset-release/**'
   pull_request:
     types:
       - opened
@@ -232,8 +233,8 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
 
-  release-next:
-    name: Release release candidate
+  release-rc:
+    name: Release RC package
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -244,6 +245,8 @@ jobs:
         id: commit_message
         run: echo "result=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
       - name: Publish release-candidate
-        # If this is any `v2-release/**` branch AND last commit is made by changeset action and its commit message is with "rc" suffix, logic can be found in "release-changeset-changelog.yml
-        if: ${{ startsWith( github.ref, 'refs/heads/v2-release' ) && steps.commit_message.output.result  == '[ci] - release rc' }}
-        run: echo "Publish now"
+        # If this is any `v2-release/**` branch AND last commit is made by changeset action and its commit message is with "ci: release (rc)", this happens only after merging changesets changelog PR
+        if: "${{ startsWith( github.event.pull_request.head.ref, 'v2-release' ) && contains( steps.commit_message.outputs.result, 'ci: release (rc)' ) }}"
+        run: |
+          yarn changeset version
+          yarn changeset publish

--- a/.github/workflows/generate-changelog-changeset.yml
+++ b/.github/workflows/generate-changelog-changeset.yml
@@ -1,42 +1,28 @@
 name: Create changelog changesets
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+  push:
+    branches:
+      - v2-release/**
 
 jobs:
   create-changelog:
     name: Create changelog
     runs-on: ubuntu-latest
-    if: ${{ startsWith( github.head_ref, 'v2-release' ) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version-file: ".node-version"
-          cache: "yarn"
+          node-version-file: '.node-version'
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn --immutable
-      - name: Find Comment
-        uses: peter-evans/find-comment@v2
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: "!prod-ready"
-      - name: Enter pre-release changelog if !prod-ready comment does not exists
-        if: ${{ !steps.fc.outputs.comment-id }}
-        run: yarn changeset pre enter rc
       - name: Create PR with changelog
-        if: ${{ always() }}
         uses: changesets/action@v1
         with:
-          commit: "[ci] - release [no ci]"
-          title: "[ci] - release"
+          commit: 'ci: release'
+          title: 'ci: release'
         env:
           # Needs access to publish to npm
           # refresh token before Saturday, May 25, 2024


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1184

# Scope of work

Simplify process for creating changelog and publishing release candidate 
Enter and exit pre-release has to be manually
Enter `yarn changeset pre enter rc` -> when changelog PR merge -> auto publish
Exit `yarn changeset pre exit` -> when changelog PR merged -> nothing happens

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
