### PR TITLE
ci: contributor run no sonarcloud coverage [SFUI2-1099]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ on:
       - edited
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SONAR_TOKEN_REACT: ${{ secrets.SONAR_TOKEN_REACT }}
+  SONAR_TOKEN_VUE: ${{ secrets.SONAR_TOKEN_VUE }}
 
 jobs:
   cache:
@@ -30,28 +30,6 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: NOT_GENERATE_ICON=true && yarn --immutable
-
-  verify-collaborator:
-    name: Verify collaborator
-    needs: [cache]
-    runs-on: ubuntu-latest
-    outputs:
-      isCollaborator: ${{ steps.collaborator.outputs.isCollaborator }}
-    steps:
-      - id: collaborator
-        name: Check if user is a collaborator
-        run: |
-          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-               "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.actor }}" \
-               | grep -q "Collaborator not found" \
-               && echo "isCollaborator=false" >> $GITHUB_OUTPUT \
-               || echo "isCollaborator=true" >> $GITHUB_OUTPUT
-      - name: Run if github_token exists
-        if: ${{ env.GITHUB_TOKEN }}
-        run: echo ${{ env.GITHUB_TOKEN }}
-      - name: Run if SONAR_TOKEN_REACT exists
-        if: ${{ env.SONAR_TOKEN_REACT }}
-        run: echo ${{ env.SONAR_TOKEN_REACT }}
 
   commit-lint:
     name: Validate PR Title (conventional-commit)
@@ -141,7 +119,7 @@ jobs:
 
   cypress-vue:
     name: Run cypress tests(Vue)
-    needs: [cache, lint, verify-collaborator]
+    needs: [cache, lint]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -168,7 +146,7 @@ jobs:
       - name: Post-Cypress (generate coverage)
         run: cd apps/test/vue; yarn generate-coverage
       - name: SonarCloud Scan
-        if: ${{ needs.verify-collaborator.outputs.isCollaborator == 'true' && (success() || failure()) }}
+        if: ${{ env.SONAR_TOKEN_VUE }}
         uses: SonarSource/sonarcloud-github-action@v1.9
         with:
           projectBaseDir: packages/sfui/frameworks/vue
@@ -178,7 +156,7 @@ jobs:
 
   cypress-react:
     name: Run cypress tests(React)
-    needs: [cache, lint, verify-collaborator]
+    needs: [cache, lint]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -203,7 +181,7 @@ jobs:
       - name: Post-Cypress (generate coverage)
         run: cd apps/test/react; yarn generate-coverage
       - name: SonarCloud Scan
-        if: ${{ needs.verify-collaborator.outputs.isCollaborator == 'true' && (success() || failure()) }}
+        if: ${{ env.SONAR_TOKEN_REACT }}
         uses: SonarSource/sonarcloud-github-action@v1.9
         with:
           projectBaseDir: packages/sfui/frameworks/react


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1099

Closes #

# Scope of work

Do not run coverage step for react/vue tests when run on contributor fork

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
