### PR TITLE
feat: add e2e test for blocks and component overview

### DIFF
--- a/apps/docs/tests/e2e/overviewCheck.cy.ts
+++ b/apps/docs/tests/e2e/overviewCheck.cy.ts
@@ -6,7 +6,7 @@ describe('Blocks and Components overview check', () => {
   it('Vue', () => {
     cy.visit('/#vue');
     cy.contains('Install for Vue').should('be.visible');
-    cy.get(`h2[id="base-components"]`).should('contain.text', 'Base Components ');
+    cy.get('#base-components').should('contain.text', 'Base Components ');
     overviewVisible().overviewVueComponents();
     cy.visit('/vue/blocks.html');
     overviewVisible().overviewVueBlocks();

--- a/apps/docs/tests/e2e/overviewCheck.cy.ts
+++ b/apps/docs/tests/e2e/overviewCheck.cy.ts
@@ -14,7 +14,7 @@ describe('Blocks and Components overview check', () => {
   it('React', () => {
     cy.visit('/#react');
     cy.contains('Install for React').should('be.visible');
-    cy.get(`h2[id="base-components-2"]`).should('contain.text', 'Base Components ');
+    cy.get('#base-components-2').should('contain.text', 'Base Components ');
     overviewVisible().overviewReactComponents();
     cy.visit('/react/blocks.html');
     overviewVisible().overviewReactBlocks();

--- a/apps/docs/tests/e2e/overviewCheck.cy.ts
+++ b/apps/docs/tests/e2e/overviewCheck.cy.ts
@@ -1,0 +1,22 @@
+import { OverviewVisibleObject } from '../support/pageObject/OverviewVisible.PageObject';
+
+const overviewVisible = () => new OverviewVisibleObject();
+
+describe('Blocks and Components overview check', () => {
+  it('Vue', () => {
+    cy.visit('/#vue');
+    cy.contains('Install for Vue').should('be.visible');
+    cy.get(`h2[id="base-components"]`).should('contain.text', 'Base Components ');
+    overviewVisible().overviewVueComponents();
+    cy.visit('/vue/blocks.html');
+    overviewVisible().overviewVueBlocks();
+  });
+  it('React', () => {
+    cy.visit('/#react');
+    cy.contains('Install for React').should('be.visible');
+    cy.get(`h2[id="base-components-2"]`).should('contain.text', 'Base Components ');
+    overviewVisible().overviewReactComponents();
+    cy.visit('/react/blocks.html');
+    overviewVisible().overviewReactBlocks();
+  });
+});

--- a/apps/docs/tests/fixtures/overviewblocks.json
+++ b/apps/docs/tests/fixtures/overviewblocks.json
@@ -1,0 +1,62 @@
+[
+ 
+  {
+    "url": "/blocks/Alert.html"
+  },
+  {
+    "url": "/blocks/Banners.html"
+  },
+  {
+    "url": "/blocks/Breadcrumbs.html"
+  },
+  {
+    "url": "/blocks/Card.html"
+  },
+  {
+ 
+    "url": "/blocks/Checkout.html"
+  },
+  {
+    "url": "/blocks/Filters.html"
+  },
+  {
+    "url": "/blocks/Footer.html"
+  },
+  {
+    "url": "/blocks/Gallery.html"
+  },
+  {
+    "url": "/blocks/MegaMenu.html"
+  },
+  {
+    "url": "/blocks/NavbarBottom.html"
+  },
+  {
+    "url": "/blocks/NavbarTop.html"
+  },
+  {
+    "url": "/blocks/NewsletterBox.html"
+  },
+  {
+    "url": "/blocks/OrderSummary.html"
+  },
+  {
+    "url": "/blocks/Pagination.html"
+  },
+  {
+    "url": "/blocks/ProductCard.html"
+  },
+  {
+    "url": "/blocks/QuantitySelector.html"
+  },
+  {
+    "url": "/blocks/Review.html"
+  },
+  {
+    "url": "/blocks/Search.html"
+  },
+  {
+    "url": "/blocks/SelectDropdown.html"
+  }
+ 
+]

--- a/apps/docs/tests/fixtures/overviewcomponents.json
+++ b/apps/docs/tests/fixtures/overviewcomponents.json
@@ -1,0 +1,98 @@
+[
+  
+
+  {
+    "url": "/components/accordionitem.html"
+   
+  },
+  {
+    "url": "/components/button.html"
+  },
+  {
+    "url": "/components/checkbox.html"
+  },
+  {
+    "url": "/components/chip.html"
+  },
+  {
+    "url": "/components/counter.html"
+  },
+  {
+    "url": "/components/drawer.html"
+  },
+  {
+    "url": "/components/dropdown.html"
+  },
+  {
+    "url": "/components/iconbase.html"
+  },
+  {
+    "url": "/components/input.html"
+  },
+  {
+    "url": "/components/link.html"
+  },
+  {
+    "url": "/components/listitem.html"
+  },
+  {
+    "url": "/components/loadercircular.html"
+  },
+  {
+    "url": "/components/loaderlinear.html"
+  },
+  {
+    "url": "/components/modal.html"
+  },
+  {
+    "url": "/components/progresscircular.html"
+  },
+  {
+    "url": "/components/progresslinear.html"
+  },
+  {
+    "url": "/components/radio.html"
+  },
+  {
+    "url": "/components/rating.html"
+  },
+  {
+    "url": "/components/scrollable.html"
+  },
+  {
+    "url": "/components/select.html"
+  },
+  {
+    "url": "/components/switch.html"
+  },
+  {
+    "url": "/components/thumbnail.html"
+  },
+  {
+    "url": "/components/tooltip.html"
+  },
+  {
+    "url": "/hooks/useDisclosure.html"
+  },
+  {
+    "url": "/hooks/useDropdown.html"
+  },
+  {
+    "url": "/hooks/useFocusVisible.html"
+  },
+  {
+    "url": "/hooks/usePagination.html"
+  },
+  {
+    "url": "/hooks/usePopover.html"
+  },
+  {
+    "url": "/hooks/useScrollable.html"
+  },
+  {
+    "url": "/hooks/useTooltip.html"
+  },
+  {
+    "url": "/hooks/useTrapFocus.html"
+  }
+]

--- a/apps/docs/tests/support/pageObject/OverviewVisible.PageObject.ts
+++ b/apps/docs/tests/support/pageObject/OverviewVisible.PageObject.ts
@@ -1,0 +1,33 @@
+export class OverviewVisibleObject {
+  overviewVueComponents() {
+    return cy.fixture<Record<string, string>[]>('overviewcomponents.json').then((elements) => {
+      elements.forEach((element) => {
+        cy.get(`a[href="/v2/vue${element.url}"]`).first().should('be.visible');
+      });
+    });
+  }
+
+  overviewVueBlocks() {
+    return cy.fixture<Record<string, string>[]>('overviewblocks.json').then((elements) => {
+      elements.forEach((element) => {
+        cy.get(`a[href="/v2/vue${element.url}"]`).last().should('be.visible');
+      });
+    });
+  }
+
+  overviewReactComponents() {
+    return cy.fixture<Record<string, string>[]>('overviewcomponents.json').then((elements) => {
+      elements.forEach((element) => {
+        cy.get(`a[href="/v2/react${element.url}"]`).first().should('be.visible');
+      });
+    });
+  }
+
+  overviewReactBlocks() {
+    return cy.fixture<Record<string, string>[]>('overviewblocks.json').then((elements) => {
+      elements.forEach((element) => {
+        cy.get(`a[href="/v2/react${element.url}"]`).last().should('be.visible');
+      });
+    });
+  }
+}


### PR DESCRIPTION
# Related issue

<!--[ paste a link to related issue](https://vsf.atlassian.net/browse/SFUI2-1240?atlOrigin=eyJpIjoiNTZhODI1NzhiODcxNDFmZmI4NGJkOTZmZDI5MjI5YjQiLCJwIjoiaiJ9) -->

Closes #

# Scope of work
Automated tasks:
SFUI2 Homepage and some elements are visible
Go to Base component - > You can see overview of base components
Go to Blocks - > You can see overview of Blocks 


# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x ] Self code-reviewed
- [x ] Changes documented
- [x ] cypress tests created
