### PR TITLE
fix: breaking change - sfbutton padding size  (#2815)

### DIFF
--- a/.changeset/five-geese-serve.md
+++ b/.changeset/five-geese-serve.md
@@ -1,0 +1,6 @@
+---
+'@storefront-ui/react': major
+'@storefront-ui/vue': major
+---
+
+Breaking Change - Padding size for square variant of SfButton changed

--- a/packages/sfui/frameworks/react/components/SfButton/SfButton.tsx
+++ b/packages/sfui/frameworks/react/components/SfButton/SfButton.tsx
@@ -17,7 +17,7 @@ const getSizeClasses = (size: SfButtonProps['size'], square: SfButtonProps['squa
     case SfButtonSize.sm:
       return [square ? 'p-1.5' : 'leading-5 text-sm py-1.5 px-3', 'gap-1.5'];
     case SfButtonSize.lg:
-      return [square ? 'p-4' : 'py-3 leading-6 px-6', 'gap-3'];
+      return [square ? 'p-3' : 'py-3 leading-6 px-6', 'gap-3'];
     default:
       return [square ? 'p-2' : 'py-2 leading-6 px-4', 'gap-2'];
   }

--- a/packages/sfui/frameworks/vue/components/SfButton/SfButton.vue
+++ b/packages/sfui/frameworks/vue/components/SfButton/SfButton.vue
@@ -43,7 +43,7 @@ const sizeClasses = computed(() => {
     case SfButtonSize.sm:
       return [square.value ? 'p-1.5' : 'leading-5 text-sm py-1.5 px-3', 'gap-1.5'];
     case SfButtonSize.lg:
-      return [square.value ? 'p-4' : 'py-3 leading-6 px-6', 'gap-3'];
+      return [square.value ? 'p-3' : 'py-3 leading-6 px-6', 'gap-3'];
     default:
       return [square.value ? 'p-2' : 'py-2 leading-6 px-4', 'gap-2'];
   }


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1226?atlOrigin=eyJpIjoiNjVhNTc3NjNlYWYyNGZiZDllMmYxZTcwYjk1NGRiZWUiLCJwIjoiaiJ9

# Scope of work

- changed padding right from 14px to 12px

# Screenshots of visual changes

-

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
