### PR TITLE
feat: navbar top simple mobile

### DIFF
--- a/apps/docs/components/blocks/NavbarTop.md
+++ b/apps/docs/components/blocks/NavbarTop.md
@@ -39,7 +39,7 @@ hideToc: true
 
 The alternate NavbarTop variant designed to work seamlessly with the NavbarBottom, providing a cohesive mobile navigation experience.
 
-By combining with the NavbarBottom, you can create a unified navigation structure that accommodates both top and bottom navigation elements on mobile devices. This ensures a smooth and intuitive user experience, allowing users to access important navigation options easily.
+By combining with the NavbarBottom, you can create a unified navigation structure that accommodates both top and bottom navigation elements on mobile devices. This ensures a smooth and intuitive user experience, allowing users to access important navigation options easily. 
 
 <Showcase showcase-name="NavbarTop/NavbarTopSimpleMobile" no-paddings style="min-height: 500px;">
 

--- a/apps/docs/components/blocks/NavbarTop.md
+++ b/apps/docs/components/blocks/NavbarTop.md
@@ -34,3 +34,33 @@ hideToc: true
 <!-- end react -->
 
 </Showcase>
+
+## NavbarTop with white background and simple mobile bar
+
+The alternate NavbarTop variant designed to work seamlessly with the NavbarBottom, providing a cohesive mobile navigation experience.
+
+By combining with the NavbarBottom, you can create a unified navigation structure that accommodates both top and bottom navigation elements on mobile devices. This ensures a smooth and intuitive user experience, allowing users to access important navigation options easily.
+
+<Showcase showcase-name="NavbarTop/NavbarTopSimpleMobile" no-paddings style="min-height: 500px;">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/NavbarTop/NavbarTopSimpleMobile.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/NavbarTop/NavbarTopSimpleMobile.tsx#source
+<!-- end react -->
+
+</Showcase>
+
+## NavbarTop with filled background and simple mobile bar
+
+<Showcase showcase-name="NavbarTop/NavbarTopFilledSimpleMobile" no-paddings style="min-height: 500px;">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/NavbarTop/NavbarTopFilledSimpleMobile.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/NavbarTop/NavbarTopFilledSimpleMobile.tsx#source
+<!-- end react -->
+
+</Showcase>

--- a/apps/docs/components/blocks/NavbarTop.md
+++ b/apps/docs/components/blocks/NavbarTop.md
@@ -11,7 +11,7 @@ hideToc: true
 
 ## NavbarTop with white background
 
-<Showcase showcase-name="NavbarTop/NavbarTop" no-paddings style="min-height: 500px;">
+<Showcase showcase-name="NavbarTop/NavbarTop" no-paddings style="min-height: 150px;">
 
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/NavbarTop/NavbarTop.vue
@@ -24,7 +24,7 @@ hideToc: true
 
 ## NavbarTop with filled background
 
-<Showcase showcase-name="NavbarTop/NavbarTopFilled" no-paddings style="min-height: 500px;">
+<Showcase showcase-name="NavbarTop/NavbarTopFilled" no-paddings style="min-height: 150px;">
 
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/NavbarTop/NavbarTopFilled.vue
@@ -41,7 +41,7 @@ The alternate NavbarTop variant designed to work seamlessly with the NavbarBotto
 
 By combining with the NavbarBottom, you can create a unified navigation structure that accommodates both top and bottom navigation elements on mobile devices. This ensures a smooth and intuitive user experience, allowing users to access important navigation options easily. 
 
-<Showcase showcase-name="NavbarTop/NavbarTopSimpleMobile" no-paddings style="min-height: 500px;">
+<Showcase showcase-name="NavbarTop/NavbarTopSimpleMobile" no-paddings style="min-height: 150px;">
 
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/NavbarTop/NavbarTopSimpleMobile.vue
@@ -54,7 +54,7 @@ By combining with the NavbarBottom, you can create a unified navigation structur
 
 ## NavbarTop with filled background and simple mobile bar
 
-<Showcase showcase-name="NavbarTop/NavbarTopFilledSimpleMobile" no-paddings style="min-height: 500px;">
+<Showcase showcase-name="NavbarTop/NavbarTopFilledSimpleMobile" no-paddings style="min-height: 150px;">
 
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/NavbarTop/NavbarTopFilledSimpleMobile.vue

--- a/apps/preview/next/pages/showcases/NavbarTop/NavbarTopFilledSimpleMobile.tsx
+++ b/apps/preview/next/pages/showcases/NavbarTop/NavbarTopFilledSimpleMobile.tsx
@@ -1,0 +1,134 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import { ShowcasePageLayout } from '../../showcases';
+// #region source
+import { useState } from 'react';
+import {
+  SfButton,
+  SfIconShoppingCart,
+  SfIconFavorite,
+  SfIconPerson,
+  SfIconExpandMore,
+  SfInput,
+  SfIconSearch,
+  SfIconMenu,
+  SfIconArrowBack,
+} from '@storefront-ui/react';
+
+export default function TopNavFilled() {
+  const [inputValue, setInputValue] = useState('');
+
+  const actionItems = [
+    {
+      icon: <SfIconShoppingCart />,
+      label: '',
+      ariaLabel: 'Cart',
+      role: 'button',
+    },
+    {
+      icon: <SfIconFavorite />,
+      label: '',
+      ariaLabel: 'Wishlist',
+      role: 'button',
+    },
+    {
+      label: 'Log in',
+      icon: <SfIconPerson />,
+      ariaLabel: 'Log in',
+      role: 'login',
+    },
+  ];
+
+  const search = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    alert(`Successfully found 10 results for ${inputValue}`);
+  };
+
+  return (
+    <header className="flex justify-center w-full py-2 px-4 lg:py-5 lg:px-6 text-white border-0 bg-primary-700">
+      <div className="flex flex-wrap lg:flex-nowrap justify-between items-center flex-row md:justify-start h-full max-w-[1536px] w-full">
+        <SfButton variant="tertiary" className="md:hidden text-white" aria-label="Go back">
+          <SfIconArrowBack />
+        </SfButton>
+        <a
+          href="#"
+          aria-label="SF Homepage"
+          className="inline-block mr-4 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm shrink-0"
+        >
+          <img
+            src="http://localhost:3100/@assets/vsf_logo_white.svg"
+            alt="Sf Logo"
+            className="w-[175px] md:h-6 md:w-[176px] lg:w-[12.5rem] lg:h-[1.75rem]"
+          />
+        </a>
+        <SfButton variant="tertiary" className="md:hidden text-white" aria-label="Search">
+          <SfIconSearch />
+        </SfButton>
+        <SfButton
+          aria-label="Open categories"
+          className="hidden md:block lg:hidden order-first lg:order-1 mr-4 text-white hover:text-white active:text-white hover:bg-primary-800 active:bg-primary-900"
+          square
+          variant="tertiary"
+        >
+          <SfIconMenu />
+        </SfButton>
+        <SfButton
+          className="hidden lg:flex lg:mr-4 text-white hover:text-white active:text-white hover:bg-primary-800 active:bg-primary-900"
+          type="button"
+          variant="tertiary"
+          slotSuffix={<SfIconExpandMore className="hidden lg:block" />}
+        >
+          <span className="hidden lg:flex whitespace-nowrap">Browse products</span>
+        </SfButton>
+        <form
+          role="search"
+          className="hidden md:flex flex-[100%] order-last lg:order-3 mt-2 lg:mt-0 pb-2 lg:pb-0"
+          onSubmit={search}
+        >
+          <SfInput
+            value={inputValue}
+            type="search"
+            className="[&::-webkit-search-cancel-button]:appearance-none"
+            placeholder="Search"
+            wrapperClassName="flex-1 h-10 pr-0"
+            size="base"
+            slotSuffix={
+              <span className="flex items-center">
+                <SfButton
+                  variant="tertiary"
+                  square
+                  aria-label="search"
+                  type="submit"
+                  className="rounded-l-none hover:bg-transparent active:bg-transparent"
+                >
+                  <SfIconSearch />
+                </SfButton>
+              </span>
+            }
+            onChange={(event) => setInputValue(event.target.value)}
+          />
+        </form>
+        <nav className="flex-1 hidden md:flex justify-end lg:order-last lg:ml-4">
+          <div className="flex flex-row flex-nowrap">
+            {actionItems.map((actionItem) => (
+              <SfButton
+                key={actionItem.ariaLabel}
+                className="mr-2 -ml-0.5 rounded-md text-white hover:text-white active:text-white hover:bg-primary-800 active:bg-primary-900"
+                aria-label={actionItem.ariaLabel}
+                variant="tertiary"
+                square
+                slotPrefix={actionItem.icon}
+              >
+                {actionItem.role === 'login' && (
+                  <p className="hidden xl:inline-flex whitespace-nowrap">{actionItem.label}</p>
+                )}
+              </SfButton>
+            ))}
+          </div>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+// #endregion source
+TopNavFilled.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/NavbarTop/NavbarTopSimpleMobile.tsx
+++ b/apps/preview/next/pages/showcases/NavbarTop/NavbarTopSimpleMobile.tsx
@@ -1,0 +1,135 @@
+/* eslint-disable no-alert */
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import { ShowcasePageLayout } from '../../showcases';
+// #region source
+import { useState } from 'react';
+import {
+  SfButton,
+  SfIconShoppingCart,
+  SfIconFavorite,
+  SfIconPerson,
+  SfIconExpandMore,
+  SfInput,
+  SfIconSearch,
+  SfIconMenu,
+  SfIconArrowBack,
+} from '@storefront-ui/react';
+
+export default function TopNavSimpleMobile() {
+  const [inputValue, setInputValue] = useState('');
+
+  const actionItems = [
+    {
+      icon: <SfIconShoppingCart />,
+      label: '',
+      ariaLabel: 'Cart',
+      role: 'button',
+    },
+    {
+      icon: <SfIconFavorite />,
+      label: '',
+      ariaLabel: 'Wishlist',
+      role: 'button',
+    },
+    {
+      label: 'Log in',
+      icon: <SfIconPerson />,
+      ariaLabel: 'Log in',
+      role: 'login',
+    },
+  ];
+
+  const search = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    alert(`Successfully found 10 results for ${inputValue}`);
+  };
+
+  return (
+    <header className="flex justify-center w-full py-2 px-4 lg:py-5 lg:px-6 bg-white border-b border-neutral-200">
+      <div className="flex flex-wrap justify-between lg:flex-nowrap items-center flex-row md:justify-start h-full max-w-[1536px] w-full">
+        <SfButton variant="tertiary" className="md:hidden" aria-label="Go back">
+          <SfIconArrowBack />
+        </SfButton>
+        <a
+          href="#"
+          aria-label="SF Homepage"
+          className="inline-block mr-4 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm shrink-0"
+        >
+          <img
+            src="http://localhost:3100/@assets/vsf_logo.svg"
+            alt="Sf Logo"
+            className="w-[175px] md:h-6 md:w-[176px] lg:w-[12.5rem] lg:h-[1.75rem]"
+          />
+        </a>
+        <SfButton variant="tertiary" className="md:hidden" aria-label="Search">
+          <SfIconSearch />
+        </SfButton>
+        <SfButton
+          aria-label="Open categories"
+          className="hidden md:block lg:hidden order-first lg:order-1 mr-4"
+          square
+          variant="tertiary"
+        >
+          <SfIconMenu />
+        </SfButton>
+        <SfButton
+          className="hidden lg:flex lg:mr-4"
+          type="button"
+          variant="tertiary"
+          slotSuffix={<SfIconExpandMore className="hidden lg:block" />}
+        >
+          <span className="hidden lg:flex whitespace-nowrap">Browse products</span>
+        </SfButton>
+        <form
+          role="search"
+          className="hidden md:flex flex-[100%] order-last lg:order-3 mt-2 lg:mt-0 pb-2 lg:pb-0"
+          onSubmit={search}
+        >
+          <SfInput
+            value={inputValue}
+            type="search"
+            className="[&::-webkit-search-cancel-button]:appearance-none"
+            placeholder="Search"
+            wrapperClassName="flex-1 h-10 pr-0"
+            size="base"
+            slotSuffix={
+              <span className="flex items-center">
+                <SfButton
+                  variant="tertiary"
+                  square
+                  aria-label="search"
+                  type="submit"
+                  className="rounded-l-none hover:bg-transparent active:bg-transparent"
+                >
+                  <SfIconSearch />
+                </SfButton>
+              </span>
+            }
+            onChange={(event) => setInputValue(event.target.value)}
+          />
+        </form>
+        <nav className="flex-1 hidden md:flex justify-end lg:order-last lg:ml-4">
+          <div className="flex flex-row flex-nowrap">
+            {actionItems.map((actionItem) => (
+              <SfButton
+                key={actionItem.ariaLabel}
+                className="mr-2 -ml-0.5 rounded-md text-primary-700 hover:bg-primary-100 active:bg-primary-200 hover:text-primary-600 active:text-primary-700"
+                aria-label={actionItem.ariaLabel}
+                variant="tertiary"
+                square
+                slotPrefix={actionItem.icon}
+              >
+                {actionItem.role === 'login' && (
+                  <p className="hidden xl:inline-flex whitespace-nowrap">{actionItem.label}</p>
+                )}
+              </SfButton>
+            ))}
+          </div>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+// #endregion source
+TopNavSimpleMobile.getLayout = ShowcasePageLayout;

--- a/apps/preview/nuxt/pages/showcases/NavbarTop/NavbarTopFilledSimpleMobile.vue
+++ b/apps/preview/nuxt/pages/showcases/NavbarTop/NavbarTopFilledSimpleMobile.vue
@@ -1,0 +1,131 @@
+<template>
+  <header class="flex justify-center w-full py-2 px-4 lg:py-5 lg:px-6 bg-primary-700 border-b border-neutral-200">
+    <div
+      class="flex flex-wrap justify-between lg:flex-nowrap items-center flex-row md:justify-start h-full max-w-[1536px] w-full"
+    >
+      <SfButton variant="tertiary" class="md:hidden text-white" aria-label="Go back">
+        <SfIconArrowBack />
+      </SfButton>
+      <a
+        href="#"
+        aria-label="SF Homepage"
+        class="inline-block mr-4 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm shrink-0"
+      >
+        <img
+          src="http://localhost:3100/@assets/vsf_logo_white.svg"
+          alt="Sf Logo"
+          class="w-[175px] md:h-6 md:w-[176px] lg:w-[12.5rem] lg:h-[1.75rem]"
+        />
+      </a>
+      <SfButton variant="tertiary" class="md:hidden text-white" aria-label="Search">
+        <SfIconSearch />
+      </SfButton>
+      <SfButton
+        aria-label="Open categories"
+        class="hidden md:block text-white hover:text-white active:text-white hover:bg-primary-800 active:bg-primary-900 lg:hidden order-first lg:order-1 mr-4"
+        square
+        variant="tertiary"
+      >
+        <SfIconMenu />
+      </SfButton>
+      <SfButton
+        class="hidden lg:flex text-white hover:text-white active:text-white hover:bg-primary-800 active:bg-primary-900 lg:mr-4"
+        type="button"
+        variant="tertiary"
+      >
+        <template #suffix>
+          <SfIconExpandMore class="hidden lg:block" />
+        </template>
+        <span class="hidden lg:flex whitespace-nowrap">Browse products</span>
+      </SfButton>
+      <form
+        role="search"
+        class="hidden md:flex flex-[100%] order-last lg:order-3 mt-2 lg:mt-0 pb-2 lg:pb-0"
+        @submit.prevent="search"
+      >
+        <SfInput
+          v-model="inputValue"
+          type="search"
+          class="[&::-webkit-search-cancel-button]:appearance-none"
+          placeholder="Search"
+          wrapper-class="flex-1 h-10 pr-0"
+          size="base"
+        >
+          <template #suffix>
+            <span class="flex items-center">
+              <SfButton
+                variant="tertiary"
+                square
+                aria-label="search"
+                type="submit"
+                class="rounded-l-none hover:bg-transparent active:bg-transparent"
+              >
+                <SfIconSearch />
+              </SfButton>
+            </span>
+          </template>
+        </SfInput>
+      </form>
+      <nav class="hidden md:flex flex-1 justify-end lg:order-last lg:ml-4">
+        <div class="flex flex-row flex-nowrap">
+          <SfButton
+            v-for="actionItem in actionItems"
+            :key="actionItem.ariaLabel"
+            class="text-white hover:text-white active:text-white hover:bg-primary-800 active:bg-primary-900 mr-2 -ml-0.5 rounded-md"
+            :aria-label="actionItem.ariaLabel"
+            variant="tertiary"
+            square
+          >
+            <template #prefix>
+              <Component :is="actionItem.icon" />
+            </template>
+            <span v-if="actionItem.role === 'login'" class="hidden xl:inline-flex whitespace-nowrap">{{
+              actionItem.label
+            }}</span>
+          </SfButton>
+        </div>
+      </nav>
+    </div>
+  </header>
+</template>
+<script lang="ts" setup>
+import { ref } from 'vue';
+import {
+  SfButton,
+  SfIconShoppingCart,
+  SfIconFavorite,
+  SfIconPerson,
+  SfIconExpandMore,
+  SfInput,
+  SfIconSearch,
+  SfIconMenu,
+  SfIconArrowBack,
+} from '@storefront-ui/vue';
+
+const actionItems = [
+  {
+    icon: SfIconShoppingCart,
+    ariaLabel: 'Cart',
+    role: 'button',
+    label: '',
+  },
+  {
+    icon: SfIconFavorite,
+    ariaLabel: 'Wishlist',
+    role: 'button',
+    label: '',
+  },
+  {
+    label: 'Log in',
+    icon: SfIconPerson,
+    ariaLabel: 'Log in',
+    role: 'login',
+  },
+];
+
+const inputValue = ref('');
+
+const search = () => {
+  alert(`Successfully found 10 results for ${inputValue.value}`);
+};
+</script>

--- a/apps/preview/nuxt/pages/showcases/NavbarTop/NavbarTopSimpleMobile.vue
+++ b/apps/preview/nuxt/pages/showcases/NavbarTop/NavbarTopSimpleMobile.vue
@@ -1,0 +1,127 @@
+<template>
+  <header class="flex justify-center w-full py-2 px-4 lg:py-5 lg:px-6 bg-white border-b border-neutral-200">
+    <div
+      class="flex flex-wrap justify-between lg:flex-nowrap items-center flex-row md:justify-start h-full max-w-[1536px] w-full"
+    >
+      <SfButton variant="tertiary" class="md:hidden" aria-label="Go back">
+        <SfIconArrowBack />
+      </SfButton>
+      <a
+        href="#"
+        aria-label="SF Homepage"
+        class="inline-block mr-4 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm shrink-0"
+      >
+        <img
+          src="http://localhost:3100/@assets/vsf_logo.svg"
+          alt="Sf Logo"
+          class="w-[175px] md:h-6 md:w-[176px] lg:w-[12.5rem] lg:h-[1.75rem]"
+        />
+      </a>
+      <SfButton variant="tertiary" class="md:hidden" aria-label="Search">
+        <SfIconSearch />
+      </SfButton>
+      <SfButton
+        aria-label="Open categories"
+        class="hidden md:block lg:hidden order-first lg:order-1 mr-4"
+        square
+        variant="tertiary"
+      >
+        <SfIconMenu />
+      </SfButton>
+      <SfButton class="hidden lg:flex lg:mr-4" type="button" variant="tertiary">
+        <template #suffix>
+          <SfIconExpandMore class="hidden lg:block" />
+        </template>
+        <span class="hidden lg:flex whitespace-nowrap">Browse products</span>
+      </SfButton>
+      <form
+        role="search"
+        class="hidden md:flex flex-[100%] order-last lg:order-3 mt-2 lg:mt-0 pb-2 lg:pb-0"
+        @submit.prevent="search"
+      >
+        <SfInput
+          v-model="inputValue"
+          type="search"
+          class="[&::-webkit-search-cancel-button]:appearance-none"
+          placeholder="Search"
+          wrapper-class="flex-1 h-10 pr-0"
+          size="base"
+        >
+          <template #suffix>
+            <span class="flex items-center">
+              <SfButton
+                variant="tertiary"
+                square
+                aria-label="search"
+                type="submit"
+                class="rounded-l-none hover:bg-transparent active:bg-transparent"
+              >
+                <SfIconSearch />
+              </SfButton>
+            </span>
+          </template>
+        </SfInput>
+      </form>
+      <nav class="flex-1 hidden md:flex justify-end lg:order-last lg:ml-4">
+        <div class="flex flex-row flex-nowrap">
+          <SfButton
+            v-for="actionItem in actionItems"
+            :key="actionItem.ariaLabel"
+            class="mr-2 -ml-0.5 rounded-md text-primary-700 hover:bg-primary-100 active:bg-primary-200 hover:text-primary-600 active:text-primary-700"
+            :aria-label="actionItem.ariaLabel"
+            variant="tertiary"
+            square
+          >
+            <template #prefix>
+              <Component :is="actionItem.icon" />
+            </template>
+            <span v-if="actionItem.role === 'login'" class="hidden xl:inline-flex whitespace-nowrap">{{
+              actionItem.label
+            }}</span>
+          </SfButton>
+        </div>
+      </nav>
+    </div>
+  </header>
+</template>
+<script lang="ts" setup>
+import { ref } from 'vue';
+import {
+  SfButton,
+  SfIconShoppingCart,
+  SfIconFavorite,
+  SfIconPerson,
+  SfIconExpandMore,
+  SfInput,
+  SfIconSearch,
+  SfIconMenu,
+  SfIconArrowBack,
+} from '@storefront-ui/vue';
+
+const actionItems = [
+  {
+    icon: SfIconShoppingCart,
+    ariaLabel: 'Cart',
+    role: 'button',
+    label: '',
+  },
+  {
+    icon: SfIconFavorite,
+    ariaLabel: 'Wishlist',
+    role: 'button',
+    label: '',
+  },
+  {
+    label: 'Log in',
+    icon: SfIconPerson,
+    ariaLabel: 'Log in',
+    role: 'login',
+  },
+];
+
+const inputValue = ref('');
+
+const search = () => {
+  alert(`Successfully found 10 results for ${inputValue.value}`);
+};
+</script>


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes # https://vsf.atlassian.net/jira/software/c/projects/SFUI2/boards/69?modal=detail&selectedIssue=SFUI2-1172&assignee=5fcf86fca1d3f100684db8a5

# Scope of work

Blocks for navbar top with simple mobile bar 

<!-- describe what you did -->

# Screenshots of visual changes
<img width="475" alt="Screenshot 2023-06-15 at 08 20 30" src="https://github.com/vuestorefront/storefront-ui/assets/46591755/70c0f5af-30ad-4535-9bfc-8d89cef1964f">

<img width="475" alt="Screenshot 2023-06-15 at 08 20 19" src="https://github.com/vuestorefront/storefront-ui/assets/46591755/72629c85-4f88-4d3a-b9cf-2225a5782a20">


<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
