### PR TITLE
chore: fix nuxt next windows alias regex [SFUI2-1244]

### DIFF
--- a/apps/preview/next/next.config.mjs
+++ b/apps/preview/next/next.config.mjs
@@ -19,7 +19,7 @@ export default {
   webpack(config) {
     if (!isProd) {
       config.module.rules.push({
-        test: /\/sfui\/frameworks\/react\/index\.ts/,
+        test: /[\\\/]sfui[\\\/]frameworks[\\\/]react[\\\/]index\.ts/,
         loader: 'string-replace-loader',
         options: {
           // only for dev purposes in monorepo:
@@ -28,7 +28,7 @@ export default {
           // import type { PropsWithStyle } from '@storefront-ui/react';
 
           // export { SfThumbnailSize };
-          search: /^export \* from '\.\/components\/([^']+?)';/gm,
+          search: /^export \* from '\.[\\\/]components[\\\/]([^']+?)';/gm,
           replace: (_match, componentName) => {
             const path = join(
               process.cwd(),

--- a/apps/preview/nuxt/nuxt.config.ts
+++ b/apps/preview/nuxt/nuxt.config.ts
@@ -53,8 +53,8 @@ export default defineNuxtConfig({
         async transform(code, id) {
           // only for dev purposes in monorepo:
           // Because Nuxt does not respect proper order of imports in index.ts and on initial load types file are not available when import of component is loaded first
-          if (/\/sfui\/frameworks\/vue\/index\.ts/.test(id)) {
-            code = code.replace(/^export \* from '\.\/components\/([^']+?)';/gm, (_match, componentName) => {
+          if (/[\\\/]sfui[\\\/]frameworks[\\\/]vue[\\\/]index\.ts/.test(id)) {
+            code = code.replace(/^export \* from '\.[\\\/]components[\\\/]([^']+?)';/gm, (_match, componentName) => {
               const path = join(
                 __dirname,
                 '..',


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1244

# Scope of work

On windows file path is different than on linux
Windows: `file/path/component.tsx`
Linux `file\path\component.tsx`

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
