### PR TITLE
fix: ring instead of border on add to wishlist

### DIFF
--- a/apps/preview/next/pages/showcases/ProductCard/ProductCardVertical.tsx
+++ b/apps/preview/next/pages/showcases/ProductCard/ProductCardVertical.tsx
@@ -20,7 +20,7 @@ export default function ProductCardVertical() {
           variant="tertiary"
           size="sm"
           square
-          className="absolute bottom-0 right-0 mr-2 mb-2 bg-white border border-neutral-200 !rounded-full"
+          className="absolute bottom-0 right-0 mr-2 mb-2 bg-white ring-1 ring-inset ring-neutral-200 !rounded-full"
           aria-label="Add to wishlist"
         >
           <SfIconFavorite size="sm" />

--- a/apps/preview/next/pages/showcases/ProductSlider/Basic.tsx
+++ b/apps/preview/next/pages/showcases/ProductSlider/Basic.tsx
@@ -71,7 +71,7 @@ export default function GalleryVertical() {
       {products.map(({ id, name, price, img }) => (
         <div
           key={id}
-          className="first:ms-auto last:me-auto border border-neutral-200 shrink-0 rounded-md hover:shadow-lg w-[148px] lg:w-[192px]"
+          className="first:ms-auto last:me-auto ring-1 ring-inset ring-neutral-200 shrink-0 rounded-md hover:shadow-lg w-[148px] lg:w-[192px]"
         >
           <div className="relative">
             <SfLink href="#">

--- a/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardVertical.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardVertical.vue
@@ -15,7 +15,7 @@
         variant="tertiary"
         size="sm"
         square
-        class="absolute bottom-0 right-0 mr-2 mb-2 bg-white border border-neutral-200 !rounded-full"
+        class="absolute bottom-0 right-0 mr-2 mb-2 bg-white ring-1 ring-inset ring-neutral-200 !rounded-full"
         aria-label="Add to wishlist"
       >
         <SfIconFavorite size="sm" />

--- a/apps/preview/nuxt/pages/showcases/ProductSlider/Basic.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductSlider/Basic.vue
@@ -36,7 +36,7 @@
           variant="tertiary"
           size="sm"
           square
-          class="absolute bottom-0 right-0 mr-2 mb-2 bg-white border border-neutral-200 !rounded-full"
+          class="absolute bottom-0 right-0 mr-2 mb-2 bg-white ring-1 ring-inset ring-neutral-200 !rounded-full"
           aria-label="Add to wishlist"
         >
           <SfIconFavorite size="sm" />


### PR DESCRIPTION
# Scope of work

"Add to wishilist" button is designed with a ring (not a border). This issue was duplicated directly from ProductCard example, so I fixed it there as well

# Screenshots of visual changes

![image](https://github.com/vuestorefront/storefront-ui/assets/10456649/e411f4e9-bf1f-454c-a12d-3c7fbd4ffe3b)


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
