### PR TITLE
fix: focus border around image is not visible

### DIFF
--- a/apps/docs/components/blocks/Gallery.md
+++ b/apps/docs/components/blocks/Gallery.md
@@ -15,6 +15,10 @@ The Gallery presents a visually appealing and user-friendly collection of images
 
 The Gallery is primarily intended for use on product pages, where it serves as an effective tool for showcasing product images. The choice between the vertical and horizontal variants should depend on the layout of the product page, ensuring optimal visual presentation. Additionally, the variant with bullets should be considered, particularly for mobile devices, as it offers a compact and easily accessible navigation format.
 
+## Accessibility notes
+
+The Gallery supports the use of the keyboard (Tab/shift+Tab) to navigate through images.
+
 ## Product Gallery with vertical thumbnails
 
 Changing an image is provided by hover on the thumbnail or dragging the main image. There are buttons to scroll thumbnails up and down.
@@ -74,7 +78,3 @@ In this block there is added arrow key navigation. When focus is on one of the t
 <!-- end react -->
 
 </Showcase>
-
-## Accessibility notes
-
-The Gallery supports the use of the keyboard (Tab/alt+Tab) to navigate through images.

--- a/apps/docs/components/blocks/ProductSlider.md
+++ b/apps/docs/components/blocks/ProductSlider.md
@@ -12,7 +12,11 @@ This block has been built on top of experimental base component. The API and str
 
 The example allows for scrollable content with product cards, providing a visually appealing and interactive way to showcase products.
 
-## Basic
+## Accessibility notes
+
+The ProductSlider supports the use of the keyboard (Tab/shift+Tab) to navigate through images.
+
+## Basic ProductSlider
 
 Users can easily navigate through the cards by swiping or using navigation arrows, making it convenient to explore a collection of products within a limited space. The component is responsive and adapts to different devices, ensuring a consistent and enjoyable browsing experience.
 
@@ -28,7 +32,3 @@ For further customization options, please refer to our documentation on the [Scr
 <!-- end react -->
 
 </Showcase>
-
-## Accessibility notes
-
-The ProductSlider supports the use of the keyboard (Tab/alt+Tab) to navigate through images.

--- a/apps/preview/next/pages/showcases/ProductCard/ProductCardVertical.tsx
+++ b/apps/preview/next/pages/showcases/ProductCard/ProductCardVertical.tsx
@@ -6,7 +6,7 @@ export default function ProductCardVertical() {
   return (
     <div className="border border-neutral-200 rounded-md hover:shadow-lg max-w-[300px]">
       <div className="relative">
-        <SfLink href="#">
+        <SfLink href="#" className="block">
           <img
             src="http://localhost:3100/@assets/sneakers.png"
             alt="Great product"

--- a/apps/preview/next/pages/showcases/ProductCard/ProductCardVertical.tsx
+++ b/apps/preview/next/pages/showcases/ProductCard/ProductCardVertical.tsx
@@ -20,7 +20,7 @@ export default function ProductCardVertical() {
           variant="tertiary"
           size="sm"
           square
-          className="absolute bottom-0 right-0 mr-2 mb-2 bg-white border border-neutral-200 !rounded-full"
+          className="absolute bottom-0 right-0 mr-2 mb-2 bg-white ring-1 ring-inset ring-neutral-200 !rounded-full"
           aria-label="Add to wishlist"
         >
           <SfIconFavorite size="sm" />

--- a/apps/preview/next/pages/showcases/ProductSlider/Basic.tsx
+++ b/apps/preview/next/pages/showcases/ProductSlider/Basic.tsx
@@ -62,7 +62,7 @@ ButtonNext.defaultProps = { disabled: false };
 export default function GalleryVertical() {
   return (
     <SfScrollable
-      className="m-auto items-center w-full [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+      className="m-auto py-4 items-center w-full [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
       buttons-placement="floating"
       drag
       slotPreviousButton={<ButtonPrev />}
@@ -74,7 +74,7 @@ export default function GalleryVertical() {
           className="first:ms-auto last:me-auto ring-1 ring-inset ring-neutral-200 shrink-0 rounded-md hover:shadow-lg w-[148px] lg:w-[192px]"
         >
           <div className="relative">
-            <SfLink href="#">
+            <SfLink href="#" className="block">
               <img
                 src={img.src}
                 alt={img.alt}

--- a/apps/preview/next/pages/showcases/ProductSlider/Basic.tsx
+++ b/apps/preview/next/pages/showcases/ProductSlider/Basic.tsx
@@ -71,7 +71,7 @@ export default function GalleryVertical() {
       {products.map(({ id, name, price, img }) => (
         <div
           key={id}
-          className="first:ms-auto last:me-auto border border-neutral-200 shrink-0 rounded-md hover:shadow-lg w-[148px] lg:w-[192px]"
+          className="first:ms-auto last:me-auto ring-1 ring-inset ring-neutral-200 shrink-0 rounded-md hover:shadow-lg w-[148px] lg:w-[192px]"
         >
           <div className="relative">
             <SfLink href="#">

--- a/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardVertical.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardVertical.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="border border-neutral-200 rounded-md hover:shadow-lg max-w-[300px]">
     <div class="relative">
-      <SfLink href="#">
+      <SfLink href="#" class="block">
         <img
           src="http://localhost:3100/@assets/sneakers.png"
           alt="Great product"

--- a/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardVertical.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardVertical.vue
@@ -15,7 +15,7 @@
         variant="tertiary"
         size="sm"
         square
-        class="absolute bottom-0 right-0 mr-2 mb-2 bg-white border border-neutral-200 !rounded-full"
+        class="absolute bottom-0 right-0 mr-2 mb-2 bg-white ring-1 ring-inset ring-neutral-200 !rounded-full"
         aria-label="Add to wishlist"
       >
         <SfIconFavorite size="sm" />

--- a/apps/preview/nuxt/pages/showcases/ProductSlider/Basic.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductSlider/Basic.vue
@@ -36,7 +36,7 @@
           variant="tertiary"
           size="sm"
           square
-          class="absolute bottom-0 right-0 mr-2 mb-2 bg-white border border-neutral-200 !rounded-full"
+          class="absolute bottom-0 right-0 mr-2 mb-2 bg-white ring-1 ring-inset ring-neutral-200 !rounded-full"
           aria-label="Add to wishlist"
         >
           <SfIconFavorite size="sm" />

--- a/apps/preview/nuxt/pages/showcases/ProductSlider/Basic.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductSlider/Basic.vue
@@ -1,6 +1,6 @@
 <template>
   <SfScrollable
-    class="m-auto items-center w-full [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+    class="m-auto py-4 items-center w-full [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
     buttons-placement="floating"
     drag
   >
@@ -22,7 +22,7 @@
       class="first:ms-auto last:me-auto border border-neutral-200 shrink-0 rounded-md hover:shadow-lg w-[148px] lg:w-[192px]"
     >
       <div class="relative">
-        <SfLink href="#">
+        <SfLink href="#" class="block">
           <img
             :src="img.src"
             :alt="img.alt"


### PR DESCRIPTION
# Scope of work

Focus ring was not being displayed for image at all for ProductCard (and [it should be](https://www.figma.com/file/CWOkbpne0tDpSenT4ZEUTQ/%F0%9F%9B%A0-SFUI-2-%7C-Design-Kit-v2.4-(development)?type=design&node-id=14013%3A45717&t=yfc7Yt1fxaKSWAds-1)).
This issue got copied over to ProductSlider, so I fixed it there as well.

# Screenshots of visual changes

before:
![image](https://github.com/vuestorefront/storefront-ui/assets/10456649/1ad1585a-421f-408f-a280-b698a802ed2e)

after:
![image](https://github.com/vuestorefront/storefront-ui/assets/10456649/18bc485d-244e-4d09-89e6-9c788ad722a2)


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
