### PR TITLE
docs: accessibility notes should be closer to top of the page

### DIFF
--- a/apps/docs/components/blocks/Gallery.md
+++ b/apps/docs/components/blocks/Gallery.md
@@ -15,6 +15,10 @@ The Gallery presents a visually appealing and user-friendly collection of images
 
 The Gallery is primarily intended for use on product pages, where it serves as an effective tool for showcasing product images. The choice between the vertical and horizontal variants should depend on the layout of the product page, ensuring optimal visual presentation. Additionally, the variant with bullets should be considered, particularly for mobile devices, as it offers a compact and easily accessible navigation format.
 
+## Accessibility notes
+
+The Gallery supports the use of the keyboard (Tab/alt+Tab) to navigate through images.
+
 ## Product Gallery with vertical thumbnails
 
 Changing an image is provided by hover on the thumbnail or dragging the main image. There are buttons to scroll thumbnails up and down.
@@ -74,7 +78,3 @@ In this block there is added arrow key navigation. When focus is on one of the t
 <!-- end react -->
 
 </Showcase>
-
-## Accessibility notes
-
-The Gallery supports the use of the keyboard (Tab/alt+Tab) to navigate through images.

--- a/apps/docs/components/blocks/Gallery.md
+++ b/apps/docs/components/blocks/Gallery.md
@@ -17,7 +17,7 @@ The Gallery is primarily intended for use on product pages, where it serves as a
 
 ## Accessibility notes
 
-The Gallery supports the use of the keyboard (Tab/alt+Tab) to navigate through images.
+The Gallery supports the use of the keyboard (Tab/shift+Tab) to navigate through images.
 
 ## Product Gallery with vertical thumbnails
 

--- a/apps/docs/components/blocks/ProductSlider.md
+++ b/apps/docs/components/blocks/ProductSlider.md
@@ -12,7 +12,11 @@ This block has been built on top of experimental base component. The API and str
 
 The example allows for scrollable content with product cards, providing a visually appealing and interactive way to showcase products.
 
-## Basic
+## Accessibility notes
+
+The ProductSlider supports the use of the keyboard (Tab/alt+Tab) to navigate through images.
+
+## Basic ProductSlider
 
 Users can easily navigate through the cards by swiping or using navigation arrows, making it convenient to explore a collection of products within a limited space. The component is responsive and adapts to different devices, ensuring a consistent and enjoyable browsing experience.
 
@@ -28,7 +32,3 @@ For further customization options, please refer to our documentation on the [Scr
 <!-- end react -->
 
 </Showcase>
-
-## Accessibility notes
-
-The ProductSlider supports the use of the keyboard (Tab/alt+Tab) to navigate through images.

--- a/apps/docs/components/blocks/ProductSlider.md
+++ b/apps/docs/components/blocks/ProductSlider.md
@@ -14,7 +14,7 @@ The example allows for scrollable content with product cards, providing a visual
 
 ## Accessibility notes
 
-The ProductSlider supports the use of the keyboard (Tab/alt+Tab) to navigate through images.
+The ProductSlider supports the use of the keyboard (Tab/shift+Tab) to navigate through images.
 
 ## Basic ProductSlider
 


### PR DESCRIPTION
# Scope of work

move accessibility notes higher on the documentation page
change name for the example to something more descriptive

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
