### PR TITLE
feat: add AccordionItem animation example

### DIFF
--- a/apps/docs/components/components/accordionitem.md
+++ b/apps/docs/components/components/accordionitem.md
@@ -52,9 +52,24 @@ This example only allows one item to be open at a time.
 
 </Showcase>
 
+### Animated
+
+Animate AccordionItem to give that nice feeling of smooth transition.
+
+<Showcase showcase-name="AccordionItem/AccordionAnimate" style="min-height:400px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/AccordionItem/AccordionAnimate.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/AccordionItem/AccordionAnimate.tsx#source
+<!-- end react -->
+
+</Showcase>
+
 ## Accessibility Notes
 
-Since `SfAccordion` uses `<details>` and `<summary>` HTML elements, it inherits all of their accessibility features. 
+Since `SfAccordion` uses `<details>` and `<summary>` HTML elements, it inherits all of their accessibility features.
 
 For example, `<summary>` elements are focusable and can be activated by pressing the `Enter` or `Space` keys.
 

--- a/apps/preview/next/pages/showcases/AccordionItem/AccordionAnimate.tsx
+++ b/apps/preview/next/pages/showcases/AccordionItem/AccordionAnimate.tsx
@@ -1,0 +1,87 @@
+import { ShowcasePageLayout } from '../../showcases';
+
+// #region source
+import { useState } from 'react';
+import { SfAccordionItem } from '@storefront-ui/react';
+import { Transition } from 'react-transition-group';
+import classNames from 'classnames';
+
+const accordionItems = [
+  {
+    id: 'acc-1',
+    summary: 'Where is my order?',
+    details:
+      'We will inform you about the expected delivery time of your order in checkout and in your order confirmation email.',
+  },
+  {
+    id: 'acc-2',
+    summary: 'What if an item is out of stock?',
+    details:
+      "If an item you're interested in is sold out, you can register to be notified when your size is back in stock.",
+  },
+  {
+    id: 'acc-3',
+    summary: 'How do I cancel my order?',
+    details:
+      "If you made a mistake or simply changed your mind after placing an order, there's no need to fuss. As long as your parcel has yet to be picked and packed in our warehouse, you'll have the option to cancel.",
+  },
+];
+
+export default function AccordionAnimate() {
+  const [isTransitioning, setTransitioning] = useState(false);
+  const [opened, setOpened] = useState<string[]>([]);
+
+  const isOpen = (id: string) => opened.includes(id);
+
+  const handleToggle = (id: string) => (open: boolean) => {
+    setTransitioning(true);
+    if (open) {
+      setOpened((current) => [...current, id]);
+    } else {
+      setOpened((current) => current.filter((item) => item !== id));
+    }
+  };
+
+  const handleStopTransition = () => {
+    setTransitioning(false);
+  };
+
+  return (
+    <div className="border border-neutral-200 rounded-md divide-y text-neutral-900">
+      {accordionItems.map(({ id, summary, details }) => (
+        <SfAccordionItem
+          key={id}
+          summary={<p className="p-4 font-medium hover:bg-neutral-100 active:neutral-100">{summary}</p>}
+          onToggle={handleToggle(id)}
+          open={isTransitioning || isOpen(id)}
+        >
+          <Transition
+            in={isOpen(id)}
+            timeout={300}
+            onEntered={handleStopTransition}
+            onExited={handleStopTransition}
+            mountOnEnter
+            unmountOnExit
+          >
+            {(state) => (
+              <div
+                className={classNames('grid transition-[grid-template-rows] duration-300 grid-rows-[0fr]', {
+                  '!grid-rows-[1fr]': state === 'entering' || state === 'entered',
+                  'grid-rows-[0fr]': state === 'exiting',
+                })}
+              >
+                <div className="overflow-hidden">
+                  <p className="p-4">{details}</p>
+                </div>
+              </div>
+            )}
+          </Transition>
+        </SfAccordionItem>
+      ))}
+    </div>
+  );
+}
+
+// #endregion source
+
+AccordionAnimate.getLayout = ShowcasePageLayout;

--- a/apps/preview/nuxt/pages/showcases/AccordionItem/AccordionAnimate.vue
+++ b/apps/preview/nuxt/pages/showcases/AccordionItem/AccordionAnimate.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="border border-neutral-200 rounded-md divide-y text-neutral-900">
+    <SfAccordionItem
+      v-for="({ id, summary, details }, index) in accordionItems"
+      :key="id"
+      :model-value="isTransitioning || opened[index]"
+      @update:model-value="
+        (isOpen) => {
+          isTransitioning = true;
+          opened[index] = isOpen;
+        }
+      "
+    >
+      <template #summary>
+        <p class="p-4 font-medium hover:bg-neutral-100 active:neutral-100">{{ summary }}</p>
+      </template>
+      <Transition
+        enter-from-class="grid grid-rows-[0fr]"
+        enter-to-class="grid grid-rows-[1fr]"
+        leave-from-class="grid grid-rows-[1fr]"
+        leave-to-class="grid grid-rows-[0fr]"
+        @after-leave="isTransitioning = false"
+        @after-enter="isTransitioning = false"
+      >
+        <div v-if="opened[index]" class="grid duration-300 ease-in-out transition-[grid-template-rows]">
+          <div class="overflow-hidden">
+            <p class="p-4">{{ details }}</p>
+          </div>
+        </div>
+      </Transition>
+    </SfAccordionItem>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { SfAccordionItem } from '@storefront-ui/vue';
+import { ref } from 'vue';
+
+const opened = ref<boolean[]>([]);
+const isTransitioning = ref(false);
+
+const accordionItems = [
+  {
+    id: 'acc-1',
+    summary: 'Where is my order?',
+    details:
+      'We will inform you about the expected delivery time of your order in checkout and in your order confirmation email.',
+  },
+  {
+    id: 'acc-2',
+    summary: 'What if an item is out of stock?',
+    details:
+      "If an item you're interested in is sold out, you can register to be notified when your size is back in stock.",
+  },
+  {
+    id: 'acc-3',
+    summary: 'How do I cancel my order?',
+    details:
+      "If you made a mistake or simply changed your mind after placing an order, there's no need to fuss. As long as your parcel has yet to be picked and packed in our warehouse, you'll have the option to cancel.",
+  },
+];
+</script>


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #2561 
[SFUI2-965](https://vsf.atlassian.net/browse/SFUI2-965)

# Scope of work

Adds an example of how to animate AccordionItem

<!-- describe what you did -->

# Screenshots of visual changes

<!-- if visual changes applied -->

Works for both single and multiple items open

https://github.com/vuestorefront/storefront-ui/assets/34419118/842096da-88ef-4d91-bb3f-e266b87acf99


https://github.com/vuestorefront/storefront-ui/assets/34419118/fcab9031-314f-405c-ab98-f711e1467bb7



# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [ ] cypress tests created


[SFUI2-965]: https://vsf.atlassian.net/browse/SFUI2-965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ