### PR TITLE
fix: typo in the prop section of SfProductCard

### DIFF
--- a/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
+++ b/packages/vue/src/components/organisms/SfProductCard/SfProductCard.vue
@@ -314,7 +314,7 @@ export default {
     },
     isAddedToCart: {
       type: Boolean,
-      deafult: false,
+      default: false,
     },
     addToCartDisabled: {
       type: Boolean,

--- a/packages/vue/src/stories/releases/v0.13.x/v0.13.7/v0.13.7.stories.mdx
+++ b/packages/vue/src/stories/releases/v0.13.x/v0.13.7/v0.13.7.stories.mdx
@@ -8,3 +8,4 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## 🧹 Chores:
 - chore: improved structure for releases section
+- fix: typo in the prop from deafult to default


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #2514 

# Scope of work

<!-- describe what you did -->
Changed typo from `deafult` to `default`

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
