### PR TITLE
fix: vue blocks containing className

### DIFF
--- a/apps/preview/nuxt/pages/showcases/Card/CategoryCard.vue
+++ b/apps/preview/nuxt/pages/showcases/Card/CategoryCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div className="flex flex-wrap gap-4 lg:gap-6 lg:flex-no-wrap">
+  <div class="flex flex-wrap gap-4 lg:gap-6 lg:flex-no-wrap">
     <div
       v-for="{ title, image } in categories"
       :key="title"

--- a/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownPreselected.vue
+++ b/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownPreselected.vue
@@ -1,5 +1,5 @@
 <template>
-  <label className="font-medium typography-label-sm" :for="id">Product</label>
+  <label class="font-medium typography-label-sm" :for="id">Product</label>
   <div ref="referenceRef" class="relative">
     <div
       :id="id"


### PR DESCRIPTION
# Related issue


# Scope of work

Some vue blocks have `className` instead of `class`

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
