### PR TITLE
poc: scrollable

### DIFF
--- a/apps/preview/nuxt/pages/showcases/Gallery/GalleryHorizontal.vue
+++ b/apps/preview/nuxt/pages/showcases/Gallery/GalleryHorizontal.vue
@@ -5,7 +5,7 @@
       :active-index="activeIndex"
       wrapper-class="h-full min-h-0"
       buttons-placement="none"
-      drag
+      :drag="{ scrollBy: 2 }"
       is-active-index-centered
       @pointerup="onDragged"
     >
@@ -99,7 +99,6 @@ const onDragged = () => {
   // } else if (event.swipeLeft && activeIndex.value < images.length - 1) {
   //   activeIndex.value += 1;
   // }
-  console.log('pointer', elementInCenterIndex.value);
-  activeIndex.value = elementInCenterIndex.value;
+  activeIndex.value = elementInCenterIndex;
 };
 </script>

--- a/apps/preview/nuxt/pages/showcases/Gallery/GalleryHorizontal.vue
+++ b/apps/preview/nuxt/pages/showcases/Gallery/GalleryHorizontal.vue
@@ -5,9 +5,9 @@
       :active-index="activeIndex"
       wrapper-class="h-full min-h-0"
       buttons-placement="none"
-      :drag="{ containerWidth: true }"
+      drag
       is-active-index-centered
-      @on-drag-end="onDragged"
+      @pointerup="onDragged"
     >
       <div
         v-for="({ imageSrc, alt }, index) in images"
@@ -69,7 +69,8 @@ import {
   SfButton,
   SfIconChevronLeft,
   SfIconChevronRight,
-  type SfScrollableOnDragEndData,
+  useScrollable,
+  // type SfScrollableOnDragEndData,
 } from '@storefront-ui/vue';
 
 const withBase = (filepath: string) => `http://localhost:3100/@assets/gallery/${filepath}`;
@@ -88,13 +89,17 @@ const images = [
   { imageSrc: withBase('gallery_11.png'), imageThumbSrc: withBase('gallery_11_thumb.png'), alt: 'backpack11' },
 ];
 
+const { elementInCenterIndex } = useScrollable();
+
 const activeIndex = ref(0);
 
-const onDragged = (event: SfScrollableOnDragEndData) => {
-  if (event.swipeRight && activeIndex.value > 0) {
-    activeIndex.value -= 1;
-  } else if (event.swipeLeft && activeIndex.value < images.length - 1) {
-    activeIndex.value += 1;
-  }
+const onDragged = () => {
+  // if (event.swipeRight && activeIndex.value > 0) {
+  //   activeIndex.value -= 1;
+  // } else if (event.swipeLeft && activeIndex.value < images.length - 1) {
+  //   activeIndex.value += 1;
+  // }
+  console.log('pointer', elementInCenterIndex.value);
+  activeIndex.value = elementInCenterIndex.value;
 };
 </script>

--- a/packages/sfui/frameworks/vue/composables/useScrollable/types.ts
+++ b/packages/sfui/frameworks/vue/composables/useScrollable/types.ts
@@ -11,11 +11,7 @@ import {
   type SfScrollableOnNextData,
 } from '@storefront-ui/shared';
 
-export type UseScrollableOptions = Prettify<
-  ScrollableOptions & {
-    activeIndex?: number;
-  }
->;
+export type UseScrollableOptions = Prettify<ScrollableOptions>;
 
 export {
   type ScrollableOptions,

--- a/packages/sfui/frameworks/vue/composables/useScrollable/useScrollable.ts
+++ b/packages/sfui/frameworks/vue/composables/useScrollable/useScrollable.ts
@@ -5,7 +5,7 @@ import { noop, unrefElement } from '@vueuse/core';
 export function useScrollable<TElement extends HTMLElement>(options?: ComputedRef<Partial<UseScrollableOptions>>) {
   const containerRef = ref<TElement>();
   const scrollable = ref<Scrollable | null>(null);
-  const state = ref({ hasPrev: false, hasNext: false, isDragged: false });
+  const state = ref({ hasPrev: false, hasNext: false, isDragged: false, scrollBy: 0 });
 
   let unregister = noop;
   watch(
@@ -53,7 +53,8 @@ export function useScrollable<TElement extends HTMLElement>(options?: ComputedRe
     disabled: !state.value.hasNext,
   }));
 
-  const elementInCenterIndex = () => scrollable.value?.elementInCenterIndex;
+  const elementInCenterIndex = () => scrollable.value?.elementInCenterIndex();
+
   return {
     containerRef,
     getPrevButtonProps,

--- a/packages/sfui/frameworks/vue/composables/useScrollable/useScrollable.ts
+++ b/packages/sfui/frameworks/vue/composables/useScrollable/useScrollable.ts
@@ -26,7 +26,6 @@ export function useScrollable<TElement extends HTMLElement>(options?: ComputedRe
           options?.value?.onDragStart?.(data);
         },
       });
-
       unregister = scrollable.value?.register();
       const activeIndex = options?.value?.activeIndex;
       if (typeof activeIndex === 'number' && activeIndex >= 0 && options?.value?.isActiveIndexCentered) {
@@ -54,6 +53,7 @@ export function useScrollable<TElement extends HTMLElement>(options?: ComputedRe
     disabled: !state.value.hasNext,
   }));
 
+  const elementInCenterIndex = () => scrollable.value?.elementInCenterIndex;
   return {
     containerRef,
     getPrevButtonProps,
@@ -61,5 +61,6 @@ export function useScrollable<TElement extends HTMLElement>(options?: ComputedRe
     showNext,
     showPrev,
     state,
+    elementInCenterIndex,
   };
 }

--- a/packages/sfui/shared/scrollable/scrollable.ts
+++ b/packages/sfui/shared/scrollable/scrollable.ts
@@ -158,14 +158,19 @@ export default class Scrollable {
       typeof this.options.drag === 'object' && this.options.drag.sensitivity ? this.options.drag.sensitivity : 4;
     // container width options define that no matter how hard you drag x1 -> x2 you will swipe by one container width
     const scrollByOneWidth = typeof this.options.drag === 'object' ? this.options.drag.containerWidth : false;
+    
+    const scrollByMultipleElements = typeof this.options.drag === 'object' ? this.options.drag.scrollBy : null;
     // buffor for nor overshoot whole width/height of container becuase of subpixel, snap will cover unsufficient width/height
     const buffor = 10;
 
     if (options.direction === SfScrollableDirection.vertical) {
       const element = event.pageY - container.offsetTop;
       const scrolling = (element - this.dragScrollY) * sensitivity;
-
-      if (scrollByOneWidth) {
+      console.log('drag', !!scrollByMultipleElements, this.elementInCenterIndex)
+      if (!!scrollByMultipleElements) {
+        console.log('multipleElements')
+        this.dragDistance > -10 ? this.scrollToIndex(this.elementInCenterIndex + scrollByMultipleElements) : this.dragDistance < 10 ? this.scrollToIndex(this.elementInCenterIndex - scrollByMultipleElements) : null;
+      } else if (scrollByOneWidth) {
         // if user just touched not dragged at least 10px - do nothing
         if (Math.abs(this.dragDistance) < 10) return;
         container.scrollLeft =
@@ -177,8 +182,10 @@ export default class Scrollable {
     } else {
       const element = event.pageX - container.offsetLeft;
       const scrolling = (element - this.dragScrollX) * sensitivity;
-
-      if (scrollByOneWidth) {
+      if (!!scrollByMultipleElements) {
+        console.log('elementInCenter', this.elementInCenterIndex);
+        this.dragDistance > -10 ? this.scrollToIndex(this.elementInCenterIndex + scrollByMultipleElements) : this.dragDistance < 10 ? this.scrollToIndex(this.elementInCenterIndex - scrollByMultipleElements) : null;
+      } else if (scrollByOneWidth) {
         // if user just touched not dragged at least 10px - do nothing
         if (Math.abs(this.dragDistance) < 10) return;
         container.scrollLeft =
@@ -210,8 +217,13 @@ export default class Scrollable {
     this.pointerDownOffsetTop = event.offsetY;
 
     if (options.direction === SfScrollableDirection.vertical) {
-      this.dragScrollY = event.pageY - container.offsetTop;
-      this.dragScrollTop = container.scrollTop;
+      // if (!!this.options.drag?.scrollBy) {
+      //   this.scrollTo(this.options.drag?.scrollBy);
+      // } else {
+        this.dragScrollY = event.pageY - container.offsetTop;
+        this.dragScrollTop = container.scrollTop;
+      // }
+      
     } else {
       this.dragScrollX = event.pageX - container.offsetLeft;
       this.dragScrollLeft = container.scrollLeft;
@@ -251,7 +263,6 @@ export default class Scrollable {
 
   private onScrollHandler() {
     this.refresh(this.options.onScroll);
-    console.log(this.elementInCenterIndex)
   }  
 
   private get hasNext() {

--- a/packages/sfui/shared/scrollable/scrollable.ts
+++ b/packages/sfui/shared/scrollable/scrollable.ts
@@ -18,6 +18,7 @@ export default class Scrollable {
   private pointerDownOffsetTop: number;
   private dragDistance: number;
 
+
   private isDraggedPreviously: boolean = false;
   public get isDragged() {
     return this.isDraggedPreviously;
@@ -132,6 +133,14 @@ export default class Scrollable {
     }
   }
 
+  public get elementInCenterIndex(): number | null {
+    const containerHorizontalCenter = this.container.scrollLeft + this.container.getBoundingClientRect().width / 2
+    const centeredElementIndex = Array.from(this.container.children).findIndex(item => {
+      return item.offsetLeft <= containerHorizontalCenter && containerHorizontalCenter <= item.offsetLeft + item.offsetWidth;
+    })
+    return centeredElementIndex;
+  }
+
   public refresh(callback?: (data: SfScrollableOnScrollData) => void) {
     if (callback) {
       requestAnimationFrame(() => {
@@ -186,7 +195,6 @@ export default class Scrollable {
       isDragged: false,
       swipeLeft: this.dragDistance > -10,
       swipeRight: this.dragDistance < 10,
-      elementInCenterIndex: () => this.elementInCenterIndex()
     });
   }
 
@@ -223,7 +231,7 @@ export default class Scrollable {
 
   private scrollTo({ left, top }: { left?: number; top?: number }): void {
     const behavior = this.options.reduceMotion ? 'auto' : 'smooth';
-    this.container.scrollTo({ left, top, behavior });
+    this.container.scrollTo({ left, top, behavior });    
   }
 
   private onScroll(event: Event): void {
@@ -243,18 +251,8 @@ export default class Scrollable {
 
   private onScrollHandler() {
     this.refresh(this.options.onScroll);
-    this.elementInCenterIndex();
-  }
-
-  private elementInCenterIndex(): number  {
-    const containerHorizontalCenter = this.container.scrollLeft + this.container.getBoundingClientRect().width / 2 
-    const centeredElementIndex = Array.from(this.container.children).findIndex(item => {
-      console.log(item.offsetLeft, containerHorizontalCenter, item.offsetLeft + item.offsetWidth)
-      item.offsetLeft <= containerHorizontalCenter && containerHorizontalCenter >= item.offsetLeft + item.offsetWidth;
-    })
-    console.log(centeredElementIndex)
-    return centeredElementIndex;
-  }
+    console.log(this.elementInCenterIndex)
+  }  
 
   private get hasNext() {
     if (this.options.direction === SfScrollableDirection.vertical) {

--- a/packages/sfui/shared/scrollable/scrollable.ts
+++ b/packages/sfui/shared/scrollable/scrollable.ts
@@ -186,6 +186,7 @@ export default class Scrollable {
       isDragged: false,
       swipeLeft: this.dragDistance > -10,
       swipeRight: this.dragDistance < 10,
+      elementInCenterIndex: () => this.elementInCenterIndex()
     });
   }
 
@@ -242,6 +243,17 @@ export default class Scrollable {
 
   private onScrollHandler() {
     this.refresh(this.options.onScroll);
+    this.elementInCenterIndex();
+  }
+
+  private elementInCenterIndex(): number  {
+    const containerHorizontalCenter = this.container.scrollLeft + this.container.getBoundingClientRect().width / 2 
+    const centeredElementIndex = Array.from(this.container.children).findIndex(item => {
+      console.log(item.offsetLeft, containerHorizontalCenter, item.offsetLeft + item.offsetWidth)
+      item.offsetLeft <= containerHorizontalCenter && containerHorizontalCenter >= item.offsetLeft + item.offsetWidth;
+    })
+    console.log(centeredElementIndex)
+    return centeredElementIndex;
   }
 
   private get hasNext() {

--- a/packages/sfui/shared/scrollable/types.ts
+++ b/packages/sfui/shared/scrollable/types.ts
@@ -11,6 +11,7 @@ export enum SfScrollableButtonsPlacement {
 
 export type SfScrollableOnDragStartData = {
   isDragged: boolean;
+  scrollBy?: number;
 };
 
 export type SfScrollableOnDragEndData = SfScrollableOnDragStartData & {
@@ -33,9 +34,10 @@ export type SfScrollableOnNextData = SfScrollableOnPrevData;
 
 export type ScrollableOptions = {
   reduceMotion?: boolean;
-  drag?: { sensitivity?: number; containerWidth?: boolean } | boolean;
+  drag?: { sensitivity?: number; containerWidth?: boolean, scrollBy?: number} | boolean;
   direction?: `${SfScrollableDirection}`;
   isActiveIndexCentered?: boolean;
+  activeIndex?: number;
   onDragStart?: (data: SfScrollableOnDragStartData) => void;
   onDragEnd?: (data: SfScrollableOnDragEndData) => void;
   onScroll?: (data: SfScrollableOnScrollData) => void;

--- a/packages/sfui/shared/scrollable/types.ts
+++ b/packages/sfui/shared/scrollable/types.ts
@@ -16,7 +16,6 @@ export type SfScrollableOnDragStartData = {
 export type SfScrollableOnDragEndData = SfScrollableOnDragStartData & {
   swipeLeft: boolean;
   swipeRight: boolean;
-  elementInCenterIndex: number;
 };
 
 export type SfScrollableOnScrollData = {

--- a/packages/sfui/shared/scrollable/types.ts
+++ b/packages/sfui/shared/scrollable/types.ts
@@ -16,6 +16,7 @@ export type SfScrollableOnDragStartData = {
 export type SfScrollableOnDragEndData = SfScrollableOnDragStartData & {
   swipeLeft: boolean;
   swipeRight: boolean;
+  elementInCenterIndex: number;
 };
 
 export type SfScrollableOnScrollData = {


### PR DESCRIPTION
# Related issue


Closes [#1010](https://vsf.atlassian.net/browse/SFUI2-1010)

# Scope of work

This POC is related to[ the spike](https://vsf.atlassian.net/browse/SFUI2-1010) so it shows possible solutions to meet requirements which `useScrollable` hook doesn't meet currently:

- scrolls elements when dragging by a given number of elements (you can set how many elements will be scrolled on one drag) on mobile and desktop
- returns the index of the element which is in the center of the container 
- custom animation when scrolling (optional)

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
