### PR TITLE
fix: remove glide instance on component destroy [SFUI2-1261]

### DIFF
--- a/packages/vue/src/components/organisms/SfCarousel/SfCarousel.vue
+++ b/packages/vue/src/components/organisms/SfCarousel/SfCarousel.vue
@@ -123,6 +123,11 @@ export default {
       this.glide = glide;
     });
   },
+  beforeDestroy() {
+    if (this.glide) {
+      this.glide.destroy();
+    }
+  },
   methods: {
     go(direct) {
       if (!this.glide) return;

--- a/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.vue
+++ b/packages/vue/src/components/organisms/SfGroupedProduct/SfGroupedProduct.vue
@@ -81,6 +81,11 @@ export default {
   mounted() {
     this.$nextTick(this.glideMount);
   },
+  beforeDestroy() {
+    if (this.glide) {
+      this.glide.destroy();
+    }
+  },
   methods: {
     glideMount() {
       if (!this.$slots.default || !this.hasCarousel) return;

--- a/packages/vue/src/components/organisms/SfHero/SfHero.vue
+++ b/packages/vue/src/components/organisms/SfHero/SfHero.vue
@@ -108,6 +108,11 @@ export default {
       });
     }
   },
+  beforeDestroy() {
+    if (this.glide) {
+      this.glide.destroy();
+    }
+  },
   methods: {
     go(direct) {
       if (!this.glide) return;


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #2405, #2400
closes https://vsf.atlassian.net/jira/software/c/projects/SFUI2/boards/146?selectedIssue=SFUI2-1261

# Scope of work

Make sure that glide instance is properly destroyed when component unmounts

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
