### PR TITLE
feat: add display typography

### DIFF
--- a/apps/docs/components/.vuepress/components/TypographyList.vue
+++ b/apps/docs/components/.vuepress/components/TypographyList.vue
@@ -21,6 +21,9 @@
 /* Vuepress can't use the most recent Tailwind version, this cannot be pulled from the plugin,
   hardcoding the values for now. */
 const typographyClasses = [
+  ['display-1', 'fontSize.6xl', 'lineHeight.extra-tight', 'fontFamily.headings'],
+  ['display-2', 'fontSize.4xl', 'lineHeight.10', 'fontFamily.headings'],
+  ['display-3', 'fontSize.2xl', 'lineHeight.8', 'fontFamily.headings'],
   ['headline-1', 'fontSize.6xl', 'lineHeight.extra-tight', 'fontFamily.headings'],
   ['headline-2', 'fontSize.4xl', 'lineHeight.10', 'fontFamily.headings'],
   ['headline-3', 'fontSize.2xl', 'lineHeight.8', 'fontFamily.headings'],

--- a/apps/preview/next/pages/showcases/Banners/DisplayHorizontal.tsx
+++ b/apps/preview/next/pages/showcases/Banners/DisplayHorizontal.tsx
@@ -14,7 +14,7 @@ const displayDetails = [
     buttonText: 'Discover now',
     reverse: false,
     backgroundColor: 'bg-negative-200',
-    titleClass: 'md:typography-headline-2',
+    titleClass: 'md:typography-display-2',
     subtitleClass: 'md:typography-headline-6',
     descriptionClass: 'md:typography-text-lg',
   },
@@ -66,7 +66,7 @@ export default function DisplayHorizontalBlock() {
                 >
                   {subtitle}
                 </p>
-                <h2 className={classNames('mb-4 mt-2 font-bold typography-headline-3', titleClass)}>{title}</h2>
+                <h2 className={classNames('mb-4 mt-2 font-bold typography-display-3', titleClass)}>{title}</h2>
                 <p className="typography-text-base block mb-4">{description}</p>
                 <SfButton className="!bg-black">{buttonText}</SfButton>
               </div>

--- a/apps/preview/next/pages/showcases/Banners/DisplayVertical.tsx
+++ b/apps/preview/next/pages/showcases/Banners/DisplayVertical.tsx
@@ -44,7 +44,7 @@ export default function DisplayVertical() {
           />
           <div className="flex flex-col items-center p-4 text-center md:p-10">
             <p className="mb-2 font-bold tracking-widest uppercase typography-headline-6">{subtitle}</p>
-            <p className="mb-4 font-bold typography-headline-2">{title}</p>
+            <p className="mb-4 font-bold typography-display-2">{title}</p>
             <p className="mb-4 typography-text-lg">{description}</p>
             <SfButton className="font-semibold !bg-neutral-900">{callToAction}</SfButton>
           </div>

--- a/apps/preview/next/pages/showcases/Banners/DisplayVerticalMultiple.tsx
+++ b/apps/preview/next/pages/showcases/Banners/DisplayVerticalMultiple.tsx
@@ -66,7 +66,7 @@ export default function DisplayVerticalMultiple() {
               />
               <div className="flex flex-col items-center p-4 text-center md:p-10">
                 <p className="mb-2 font-bold tracking-widest uppercase typography-headline-6">{subtitle}</p>
-                <p className="mb-4 font-bold typography-headline-2">{title}</p>
+                <p className="mb-4 font-bold typography-display-2">{title}</p>
                 <p className="mb-4 typography-text-lg">{description}</p>
                 <SfButton className="font-semibold !bg-neutral-900">{callToAction}</SfButton>
               </div>

--- a/apps/preview/next/pages/showcases/Banners/Hero.tsx
+++ b/apps/preview/next/pages/showcases/Banners/Hero.tsx
@@ -25,7 +25,7 @@ export default function Hero() {
           <p className="typography-text-xs md:typography-text-sm font-bold tracking-widest text-neutral-500 uppercase">
             Feel the music
           </p>
-          <h1 className="typography-headline-2 md:typography-headline-1 md:leading-[67.5px] font-bold mt-2 mb-4">
+          <h1 className="typography-display-2 md:typography-display-1 md:leading-[67.5px] font-bold mt-2 mb-4">
             New Wireless Pro
           </h1>
           <p className="typography-text-base md:typography-text-lg">

--- a/apps/preview/nuxt/pages/showcases/Banners/DisplayHorizontal.vue
+++ b/apps/preview/nuxt/pages/showcases/Banners/DisplayHorizontal.vue
@@ -28,7 +28,7 @@
           <p :class="['uppercase typography-text-xs block font-bold tracking-widest', subtitleClass]">
             {{ subtitle }}
           </p>
-          <h2 :class="['mb-4 mt-2 font-bold typography-headline-3', titleClass]">
+          <h2 :class="['mb-4 mt-2 font-bold typography-display-3', titleClass]">
             {{ title }}
           </h2>
           <p class="typography-text-base block mb-4">
@@ -54,7 +54,7 @@ const displayDetails = [
     buttonText: 'Discover now',
     reverse: false,
     backgroundColor: 'bg-negative-200',
-    titleClass: 'md:typography-headline-2',
+    titleClass: 'md:typography-display-2',
     subtitleClass: 'md:typography-headline-6',
     descriptionClass: 'md:typography-text-lg',
   },

--- a/apps/preview/nuxt/pages/showcases/Banners/DisplayVertical.vue
+++ b/apps/preview/nuxt/pages/showcases/Banners/DisplayVertical.vue
@@ -15,7 +15,7 @@
       />
       <div class="flex flex-col items-center p-4 text-center md:p-10">
         <p class="mb-2 font-bold tracking-widest uppercase typography-headline-6">{{ subtitle }}</p>
-        <p class="mb-4 font-bold typography-headline-2">{{ title }}</p>
+        <p class="mb-4 font-bold typography-display-2">{{ title }}</p>
         <p class="mb-4 typography-text-lg">{{ description }}</p>
         <SfButton class="font-semibold !bg-neutral-900">
           {{ callToAction }}

--- a/apps/preview/nuxt/pages/showcases/Banners/DisplayVerticalMultiple.vue
+++ b/apps/preview/nuxt/pages/showcases/Banners/DisplayVerticalMultiple.vue
@@ -16,7 +16,7 @@
         />
         <div class="flex flex-col p-4 text-center md:p-10">
           <p class="mb-2 font-bold tracking-widest uppercase typography-headline-6">{{ subtitle }}</p>
-          <p class="mb-4 font-bold typography-headline-2">{{ title }}</p>
+          <p class="mb-4 font-bold typography-display-2">{{ title }}</p>
           <p class="mb-4 typography-text-lg">{{ description }}</p>
           <SfButton class="font-semibold !bg-neutral-900">
             {{ callToAction }}

--- a/apps/preview/nuxt/pages/showcases/Banners/Hero.vue
+++ b/apps/preview/nuxt/pages/showcases/Banners/Hero.vue
@@ -19,7 +19,7 @@
         <p class="typography-text-xs md:typography-text-sm font-bold tracking-widest text-neutral-500 uppercase">
           Feel the music
         </p>
-        <h1 class="typography-headline-2 md:typography-headline-1 md:leading-[67.5px] font-bold mt-2 mb-4">
+        <h1 class="typography-display-2 md:typography-display-1 md:leading-[67.5px] font-bold mt-2 mb-4">
           New Wireless Pro
         </h1>
         <p class="typography-text-base md:typography-text-lg">

--- a/packages/sfui/typography/index.ts
+++ b/packages/sfui/typography/index.ts
@@ -1,5 +1,5 @@
 import plugin from 'tailwindcss/plugin';
-import type { KeyValuePair, ResolvableTo } from 'tailwindcss/types/config'
+import type { KeyValuePair, ResolvableTo } from 'tailwindcss/types/config';
 
 export type ConfigValue = Record<string, string>;
 export type ConfigKeyValuePair = KeyValuePair<string, ConfigValue>;
@@ -7,76 +7,80 @@ export type Options = { utilityPrefix?: string } | undefined;
 
 declare module 'tailwindcss/types/config' {
   export interface ThemeConfig {
-    sfTypography: ResolvableTo<ConfigKeyValuePair>
+    sfTypography: ResolvableTo<ConfigKeyValuePair>;
   }
 }
 
 const PLUGIN_CONFIG_KEY = 'sfTypography';
 
-export default plugin.withOptions(({ utilityPrefix = 'typography' }: Options = {}) =>
-  function({ matchUtilities, theme }) {
-    matchUtilities(
-      {
-        [utilityPrefix]: (value) => {
-          if (Array.isArray(value.fontSize)) {
-            // user can specify lineHeight, letterSpacing or fontWeight within fontSize configuration
-            // see: https://tailwindcss.com/docs/font-size#providing-a-default-line-height
-            const otherFontProperties = value.fontSize[1];
-            if (otherFontProperties) {
-              value = {
-                ...(typeof otherFontProperties === 'object'
-                  ? otherFontProperties
-                  : { lineHeight: otherFontProperties }
-                ),
-                ...value,
-              };
+export default plugin.withOptions(
+  ({ utilityPrefix = 'typography' }: Options = {}) =>
+    function ({ matchUtilities, theme }) {
+      matchUtilities(
+        {
+          [utilityPrefix]: (value) => {
+            if (Array.isArray(value.fontSize)) {
+              // user can specify lineHeight, letterSpacing or fontWeight within fontSize configuration
+              // see: https://tailwindcss.com/docs/font-size#providing-a-default-line-height
+              const otherFontProperties = value.fontSize[1];
+              if (otherFontProperties) {
+                value = {
+                  ...(typeof otherFontProperties === 'object'
+                    ? otherFontProperties
+                    : { lineHeight: otherFontProperties }),
+                  ...value,
+                };
+              }
+              value.fontSize = value.fontSize[0];
             }
-            value.fontSize = value.fontSize[0];
-          }
-          return { ...value };
+            return { ...value };
+          },
         },
-      },
-      {
-        values: theme(PLUGIN_CONFIG_KEY),
-        supportsNegativeValues: false,
-      }
-    )
-  }, () => ({
+        {
+          values: theme(PLUGIN_CONFIG_KEY),
+          supportsNegativeValues: false,
+        },
+      );
+    },
+  () => ({
     theme: {
-      [PLUGIN_CONFIG_KEY]: ({ theme }) => 
-      [
-        // [name, fontSize, lineHeight, fontFamily]
-        ['headline-1', 'fontSize.6xl', 'lineHeight.extra-tight', 'fontFamily.headings'],
-        ['headline-2', 'fontSize.4xl', 'lineHeight.10', 'fontFamily.headings'],
-        ['headline-3', 'fontSize.2xl', 'lineHeight.8', 'fontFamily.headings'],
-        ['headline-4', 'fontSize.lg', 'lineHeight.7', 'fontFamily.headings'],
-        ['headline-5', 'fontSize.base', 'lineHeight.6', 'fontFamily.headings'],
-        ['headline-6', 'fontSize.sm', 'lineHeight.5', 'fontFamily.headings'],
-        ['text-xl', 'fontSize.xl', 'lineHeight.7'],
-        ['text-lg', 'fontSize.lg', 'lineHeight.7'],
-        ['text-base', 'fontSize.base', 'lineHeight.6'],
-        ['text-sm', 'fontSize.sm', 'lineHeight.5'],
-        ['text-xs', 'fontSize.xs', 'lineHeight.4'],
-        ['button-lg', 'fontSize.lg', 'lineHeight.7'],
-        ['button-base', 'fontSize.base', 'lineHeight.6'],
-        ['button-sm', 'fontSize.sm', 'lineHeight.5'],
-        ['label-lg', 'fontSize.lg', 'lineHeight.7'],
-        ['label-base', 'fontSize.base', 'lineHeight.6'],
-        ['label-sm', 'fontSize.sm', 'lineHeight.5'],
-        ['error-lg', 'fontSize.lg', 'lineHeight.7'],
-        ['error-base', 'fontSize.base', 'lineHeight.6'],
-        ['error-sm', 'fontSize.sm', 'lineHeight.5'],
-        ['hint-lg', 'fontSize.lg', 'lineHeight.7'],
-        ['hint-base', 'fontSize.base', 'lineHeight.6'],
-        ['hint-sm', 'fontSize.sm', 'lineHeight.5'],
-      ].reduce((p, [name, fontSize, lineHeight, fontFamily]) => {
-        p[name] = {
-          fontSize: theme(fontSize),
-          lineHeight: theme(lineHeight),
-          fontFamily: fontFamily ? theme(fontFamily) : undefined,
-        };
-        return p;
-      }, {} as Record<string, ConfigValue>),
+      [PLUGIN_CONFIG_KEY]: ({ theme }) =>
+        [
+          // [name, fontSize, lineHeight, fontFamily]
+          ['display-1', 'fontSize.6xl', 'lineHeight.extra-tight', 'fontFamily.headings'],
+          ['display-2', 'fontSize.4xl', 'lineHeight.10', 'fontFamily.headings'],
+          ['display-3', 'fontSize.2xl', 'lineHeight.8', 'fontFamily.headings'],
+          ['headline-1', 'fontSize.6xl', 'lineHeight.extra-tight', 'fontFamily.headings'],
+          ['headline-2', 'fontSize.4xl', 'lineHeight.10', 'fontFamily.headings'],
+          ['headline-3', 'fontSize.2xl', 'lineHeight.8', 'fontFamily.headings'],
+          ['headline-4', 'fontSize.lg', 'lineHeight.7', 'fontFamily.headings'],
+          ['headline-5', 'fontSize.base', 'lineHeight.6', 'fontFamily.headings'],
+          ['headline-6', 'fontSize.sm', 'lineHeight.5', 'fontFamily.headings'],
+          ['text-xl', 'fontSize.xl', 'lineHeight.7'],
+          ['text-lg', 'fontSize.lg', 'lineHeight.7'],
+          ['text-base', 'fontSize.base', 'lineHeight.6'],
+          ['text-sm', 'fontSize.sm', 'lineHeight.5'],
+          ['text-xs', 'fontSize.xs', 'lineHeight.4'],
+          ['button-lg', 'fontSize.lg', 'lineHeight.7'],
+          ['button-base', 'fontSize.base', 'lineHeight.6'],
+          ['button-sm', 'fontSize.sm', 'lineHeight.5'],
+          ['label-lg', 'fontSize.lg', 'lineHeight.7'],
+          ['label-base', 'fontSize.base', 'lineHeight.6'],
+          ['label-sm', 'fontSize.sm', 'lineHeight.5'],
+          ['error-lg', 'fontSize.lg', 'lineHeight.7'],
+          ['error-base', 'fontSize.base', 'lineHeight.6'],
+          ['error-sm', 'fontSize.sm', 'lineHeight.5'],
+          ['hint-lg', 'fontSize.lg', 'lineHeight.7'],
+          ['hint-base', 'fontSize.base', 'lineHeight.6'],
+          ['hint-sm', 'fontSize.sm', 'lineHeight.5'],
+        ].reduce((p, [name, fontSize, lineHeight, fontFamily]) => {
+          p[name] = {
+            fontSize: theme(fontSize),
+            lineHeight: theme(lineHeight),
+            fontFamily: fontFamily ? theme(fontFamily) : undefined,
+          };
+          return p;
+        }, {} as Record<string, ConfigValue>),
     } as { [PLUGIN_CONFIG_KEY]: ResolvableTo<ConfigKeyValuePair> },
-  })
+  }),
 );


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes [SFUI2-1246](https://vsf.atlassian.net/browse/SFUI2-1246)

# Scope of work

This PR extends typography with 3 new classes:
- `typography-display-1`
- `typography-display-2`
- `typography-display-3`

<!-- describe what you did -->

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created


[SFUI2-1246]: https://vsf.atlassian.net/browse/SFUI2-1246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ