### PR TITLE
docs: add browser support page [SFUI2-1161]

### DIFF
--- a/apps/docs/components/.vuepress/config.js
+++ b/apps/docs/components/.vuepress/config.js
@@ -15,7 +15,10 @@ const reactMenu = [
   {
     title: 'Getting Started',
     collapsable: true,
-    children: [['/react/getting-started', 'Installation']],
+    children: [
+      ['/react/getting-started', 'Installation'],
+      ['/react/browser-support', 'Browser support'],
+    ],
   },
   {
     title: 'Customization',

--- a/apps/docs/components/react/browser-support.md
+++ b/apps/docs/components/react/browser-support.md
@@ -1,0 +1,36 @@
+---
+layout: DefaultLayout
+hideBreadcrumbs: true
+---
+
+# Browser support
+
+This documentation provides information about the browser support for Storefront-ui, a powerful and versatile front-end UI framework. Understanding the browser compatibility of a UI framework is crucial for developers to ensure that their applications work seamlessly across different browsers and versions. This document will outline the supported browsers, their versions, and any specific considerations or known issues related to compatibility.
+
+## The following browsers are officially supported by Storefront-ui:
+
+**2 last stable versions of each browser**
+
+- Chrome
+- Chrome for Android
+- Firefox
+- Edge
+- Safari
+- Safari on IOS
+- Opera
+
+**latest Firefox ESR (Extended Support Release) [Firefox Release Calendar](https://wiki.mozilla.org/index.php?title=Release_Management/Calendar&redirect=no)**
+
+**No support for Internet Explorer**
+
+
+## How to Update Your Browser
+
+To ensure the best experience with our UI framework, we recommend using the latest version of a supported browser. Here are the links to update some popular browsers:
+
+- [Download Google Chrome](https://www.google.com/chrome/)
+- [Download Mozilla Firefox](https://www.mozilla.org/firefox/)
+- [Download Safari](https://www.apple.com/safari/)
+- [Download Microsoft Edge](https://www.microsoft.com/edge/)
+
+If you are using Internet Explorer, it's recommended to switch to a modern browser like Chrome, Firefox, Safari, or Edge.

--- a/apps/docs/components/react/browser-support.md
+++ b/apps/docs/components/react/browser-support.md
@@ -5,11 +5,11 @@ hideBreadcrumbs: true
 
 # Browser support
 
-This documentation provides information about the browser support for Storefront-ui, a powerful and versatile front-end UI framework. Understanding the browser compatibility of a UI framework is crucial for developers to ensure that their applications work seamlessly across different browsers and versions. This document will outline the supported browsers, their versions, and any specific considerations or known issues related to compatibility.
+Understanding the browser compatibility of a UI framework is crucial for developers to ensure that their applications work seamlessly across different browsers and versions. This document will outline the supported browsers, their versions, and any specific considerations or known issues related to compatibility.
 
 ## The following browsers are officially supported by Storefront-ui:
 
-**2 last stable versions of each browser**
+**The 2 latest stable versions of:**
 
 - Chrome
 - Chrome for Android
@@ -19,7 +19,7 @@ This documentation provides information about the browser support for Storefront
 - Safari on IOS
 - Opera
 
-**latest Firefox ESR (Extended Support Release) [Firefox Release Calendar](https://wiki.mozilla.org/index.php?title=Release_Management/Calendar&redirect=no)**
+**The latest Firefox ESR (Extended Support Release) [Firefox Release Calendar](https://wiki.mozilla.org/index.php?title=Release_Management/Calendar&redirect=no)**
 
 **No support for Internet Explorer**
 

--- a/apps/docs/components/vue/browser-support.md
+++ b/apps/docs/components/vue/browser-support.md
@@ -1,0 +1,36 @@
+---
+layout: DefaultLayout
+hideBreadcrumbs: true
+---
+
+# Browser support
+
+This documentation provides information about the browser support for Storefront-ui, a powerful and versatile front-end UI framework. Understanding the browser compatibility of a UI framework is crucial for developers to ensure that their applications work seamlessly across different browsers and versions. This document will outline the supported browsers, their versions, and any specific considerations or known issues related to compatibility.
+
+## The following browsers are officially supported by Storefront-ui:
+
+**2 last stable versions of each browser**
+
+- Chrome
+- Chrome for Android
+- Firefox
+- Edge
+- Safari
+- Safari on IOS
+- Opera
+
+**latest Firefox ESR (Extended Support Release) [Firefox Release Calendar](https://wiki.mozilla.org/index.php?title=Release_Management/Calendar&redirect=no)**
+
+**No support for Internet Explorer**
+
+
+## How to Update Your Browser
+
+To ensure the best experience with our UI framework, we recommend using the latest version of a supported browser. Here are the links to update some popular browsers:
+
+- [Download Google Chrome](https://www.google.com/chrome/)
+- [Download Mozilla Firefox](https://www.mozilla.org/firefox/)
+- [Download Safari](https://www.apple.com/safari/)
+- [Download Microsoft Edge](https://www.microsoft.com/edge/)
+
+If you are using Internet Explorer, it's recommended to switch to a modern browser like Chrome, Firefox, Safari, or Edge.

--- a/apps/docs/components/vue/browser-support.md
+++ b/apps/docs/components/vue/browser-support.md
@@ -5,11 +5,11 @@ hideBreadcrumbs: true
 
 # Browser support
 
-This documentation provides information about the browser support for Storefront-ui, a powerful and versatile front-end UI framework. Understanding the browser compatibility of a UI framework is crucial for developers to ensure that their applications work seamlessly across different browsers and versions. This document will outline the supported browsers, their versions, and any specific considerations or known issues related to compatibility.
+Understanding the browser compatibility of a UI framework is crucial for developers to ensure that their applications work seamlessly across different browsers and versions. This document will outline the supported browsers, their versions, and any specific considerations or known issues related to compatibility.
 
 ## The following browsers are officially supported by Storefront-ui:
 
-**2 last stable versions of each browser**
+**The 2 latest stable versions of:**
 
 - Chrome
 - Chrome for Android
@@ -19,7 +19,7 @@ This documentation provides information about the browser support for Storefront
 - Safari on IOS
 - Opera
 
-**latest Firefox ESR (Extended Support Release) [Firefox Release Calendar](https://wiki.mozilla.org/index.php?title=Release_Management/Calendar&redirect=no)**
+**The latest Firefox ESR (Extended Support Release) [Firefox Release Calendar](https://wiki.mozilla.org/index.php?title=Release_Management/Calendar&redirect=no)**
 
 **No support for Internet Explorer**
 


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1161

# Scope of work

Adding browser support page in documentation

# Screenshots of visual changes

![image](https://github.com/vuestorefront/storefront-ui/assets/2566152/bca328a5-e50d-4924-82b3-3130f3489d7c)


# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
