### PR TITLE
fix: fixed issue with 404 on usage with next link in docs

### DIFF
--- a/apps/docs/components/components/link.md
+++ b/apps/docs/components/components/link.md
@@ -54,12 +54,13 @@ You can [customize your color palette](../customization/theming.html) as a part 
 If you need more customization beyond the built-in variants, we recommend copying the `SfLink` [source code](#source) and modifying it to your needs. This way, you can have all the custom styles for your design system, but still be able to easily use all of our [Blocks](./blocks.html).
 :::
 
-<!-- react -->
+
 
 ## Accessibility notes
 
 Link component can be rendered as an `<a>` or <!-- vue -->`<NuxtLink>`<!-- end vue --><!-- react -->`<NextLink>`<!-- end react --> or any other tag by providing it with prop <!-- vue -->`tag`<!-- end vue --><!-- react -->`as`<!-- end react -->. When no tag provided, the component will render as an `<a>`. To achieve proper accessibility it is important to implement required properties depending on the passed tag.
 
+<!-- react -->
 ### Usage with NextJS Link
 
 `SfLink` can be composed together with `NextJS` link component.


### PR DESCRIPTION
# Related issue


# Scope of work

- changed structure of vue/react sections so the link can load properly

# Screenshots of visual changes

-

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
