### PR TITLE
poc: virtual focus

### DIFF
--- a/.changeset/five-geese-serve.md
+++ b/.changeset/five-geese-serve.md
@@ -1,0 +1,6 @@
+---
+'@storefront-ui/react': major
+'@storefront-ui/vue': major
+---
+
+Breaking Change - Padding size for square variant of SfButton changed

--- a/apps/preview/next/pages/examples/VirtualFocus.tsx
+++ b/apps/preview/next/pages/examples/VirtualFocus.tsx
@@ -1,0 +1,194 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { SfListItem, useDisclosure, useDropdown, useVirtualFocus } from '@storefront-ui/react';
+
+type SelectOption = {
+  label: string;
+  value: string;
+};
+
+const options: SelectOption[] = [
+  { label: 'Pizza', value: 'pizza' },
+  { label: 'Burger', value: 'burger' },
+  { label: 'Sushi', value: 'sushi' },
+  { label: 'Pasta', value: 'pasta' },
+  { label: 'Coffee', value: 'coffee' },
+];
+
+function VirtualFocusSelect() {
+  const { open, close, toggle, isOpen } = useDisclosure({ initialValue: false });
+  const id = React.useId();
+  const listboxId = React.useId();
+  const [selectedOption, setSelectedOption] = React.useState<SelectOption>();
+  const selectTriggerRef = React.useRef<HTMLDivElement>(null);
+  const { refs, style: dropdownStyle } = useDropdown({ isOpen, onClose: close });
+
+  const selectOption = (option: SelectOption) => {
+    setSelectedOption(option);
+    close();
+    selectTriggerRef.current?.focus();
+  };
+
+  const { onKeyDown, virtualFocus } = useVirtualFocus({
+    container: refs.floating.current,
+    itemSelector: '[role="option"]',
+    onKeyDown: (vf, event) => {
+      if (!isOpen) {
+        open();
+
+        // Possible way of restoring virtual focus on currently selected option:
+        // vf.setItem(selectedOption?.value)
+      }
+
+      switch (event.key) {
+        case 'Escape': {
+          close();
+          break;
+        }
+        case ' ':
+        case 'Enter': {
+          if (!isOpen) {
+            vf.first();
+          } else {
+            const option = options[vf.index];
+            selectOption(option);
+          }
+          break;
+        }
+        case 'ArrowUp': {
+          if (!isOpen) {
+            vf.first();
+          }
+          break;
+        }
+        case 'Tab': {
+          close();
+          break;
+        }
+        default:
+          break;
+      }
+    },
+  });
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      virtualFocus.reset();
+    }
+  }, [isOpen, virtualFocus]);
+
+  return (
+    <div>
+      <label className="font-medium typography-label-sm" htmlFor={id}>
+        Delivery
+      </label>
+      <div ref={refs.setReference} className="relative">
+        <div
+          className="mt-0.5 flex items-center gap-8 relative font-normal typography-text-base ring-1 ring-neutral-300 ring-inset rounded-md py-2 px-4 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2 focus-visible:outline focus-visible:outline-offset cursor-pointer"
+          ref={selectTriggerRef}
+          role="combobox"
+          aria-controls={listboxId}
+          aria-expanded={isOpen}
+          aria-label="Select one option"
+          aria-activedescendant={selectedOption ? `${listboxId}-${selectedOption.value}` : undefined}
+          tabIndex={0}
+          onKeyDown={onKeyDown}
+          onClick={toggle}
+        >
+          {selectedOption ? selectedOption.label : <span className="text-neutral-500">Choose from the list</span>}
+        </div>
+        <ul
+          id={listboxId}
+          ref={refs.setFloating}
+          role="listbox"
+          aria-label="Select one option"
+          className={classNames('w-full py-2 rounded-md shadow-md border border-neutral-100 bg-white z-10', {
+            hidden: !isOpen,
+          })}
+          style={dropdownStyle}
+        >
+          {options.map((option, index) => (
+            <SfListItem
+              id={`${listboxId}-${option.value}`}
+              key={option.value}
+              role="option"
+              as="button"
+              tabIndex={-1}
+              onClick={() => selectOption(option)}
+              disabled={index === 1}
+              aria-selected={option.value === selectedOption?.value}
+              className={classNames('block', {
+                'font-medium': option.value === selectedOption?.value,
+                'outline outline-offset': virtualFocus.index === index,
+              })}
+            >
+              {option.label}
+            </SfListItem>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+const tabs = ['Gallery', 'Message', 'Settings'];
+
+function VitrualFocusTabs() {
+  const [activeTab, setActiveTab] = React.useState(tabs[0]);
+  /**
+   * Putting a ref in a state makes sure that the container we pass to the useVirtualFocus exists.
+   * Standard useRef resutls in error due to initailly undefined container ref.
+   */
+  const [ref, setRef] = React.useState<HTMLDivElement | null>(null);
+
+  const { onKeyDown } = useVirtualFocus({
+    container: ref,
+    itemSelector: '[role="tab"]',
+    useFocus: true,
+    activateOnFocus: true,
+    loop: true,
+    orientation: 'horizontal',
+  });
+
+  return (
+    <div className="mt-6">
+      <div ref={(node) => setRef(node)} role="tablist" className="flex justify-between gap-2">
+        {tabs.map((label) => (
+          <button
+            key={label}
+            type="button"
+            role="tab"
+            tabIndex={activeTab === label ? 0 : -1}
+            className={classNames('py-1 px-2 rounded focus-visible:outline focus-visible:outline-offset', {
+              'bg-primary-700 text-white': activeTab === label,
+            })}
+            onClick={() => setActiveTab(label)}
+            onKeyDown={onKeyDown}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <hr className="my-1" />
+      <div role="tabpanel" className="p-2">
+        {activeTab}
+      </div>
+    </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <div className="max-w-md mx-auto p-6">
+      <input className="mb-6 border border-grey-800 rounded focus-visible:outline focus-visible:outline-offset" />
+      <VirtualFocusSelect />
+      <button
+        type="button"
+        className="mt-6 bg-gray-300 py-1 px-3 rounded focus-visible:outline focus-visible:outline-offset"
+      >
+        Placeholder
+      </button>
+      <VitrualFocusTabs />
+    </div>
+  );
+}

--- a/packages/sfui/frameworks/react/components/SfButton/SfButton.tsx
+++ b/packages/sfui/frameworks/react/components/SfButton/SfButton.tsx
@@ -17,7 +17,7 @@ const getSizeClasses = (size: SfButtonProps['size'], square: SfButtonProps['squa
     case SfButtonSize.sm:
       return [square ? 'p-1.5' : 'leading-5 text-sm py-1.5 px-3', 'gap-1.5'];
     case SfButtonSize.lg:
-      return [square ? 'p-4' : 'py-3 leading-6 px-6', 'gap-3'];
+      return [square ? 'p-3' : 'py-3 leading-6 px-6', 'gap-3'];
     default:
       return [square ? 'p-2' : 'py-2 leading-6 px-4', 'gap-2'];
   }

--- a/packages/sfui/frameworks/react/hooks/useTrapFocus/useTrapFocus.ts
+++ b/packages/sfui/frameworks/react/hooks/useTrapFocus/useTrapFocus.ts
@@ -50,7 +50,7 @@ export const useTrapFocus = (containerElementRef: RefObject<HTMLElement | null>,
     ...options,
   };
 
-  const [currentlyFocused, setCurrentlyFocused] = useState<HTMLElement>();
+  const [currentlyFocused, setCurrentlyFocused] = useState<FocusableElement>();
   const [focusableElements, setFocusableElements] = useState<FocusableElement[]>([]);
   const focusPreviousItem = ({
     event,
@@ -58,13 +58,16 @@ export const useTrapFocus = (containerElementRef: RefObject<HTMLElement | null>,
   }: {
     event?: KeyboardEvent;
     additionalData?: Record<string, unknown>;
-  }) =>
-    focusPrev({
+  }) => {
+    const focusedElement = focusPrev({
       current: currentlyFocused,
       focusables: focusableElements,
       event,
       ...additionalData,
     });
+    // This state should be set whenever focus has changed.
+    setCurrentlyFocused(focusedElement);
+  };
 
   const focusNextItem = ({
     event,
@@ -72,13 +75,15 @@ export const useTrapFocus = (containerElementRef: RefObject<HTMLElement | null>,
   }: {
     event?: KeyboardEvent;
     additionalData?: Record<string, unknown>;
-  }) =>
-    focusNext({
+  }) => {
+    const focusedElement = focusNext({
       current: currentlyFocused,
       focusables: focusableElements,
       event,
       ...additionalData,
     });
+    setCurrentlyFocused(focusedElement);
+  };
 
   const onKeyDownListener = useCallback(
     (event: KeyboardEvent) => {

--- a/packages/sfui/frameworks/react/hooks/useVirtualFocus/index.ts
+++ b/packages/sfui/frameworks/react/hooks/useVirtualFocus/index.ts
@@ -1,0 +1,1 @@
+export { useVirtualFocus } from './useVirtualFocus';

--- a/packages/sfui/frameworks/react/hooks/useVirtualFocus/useVirtualFocus.ts
+++ b/packages/sfui/frameworks/react/hooks/useVirtualFocus/useVirtualFocus.ts
@@ -1,0 +1,211 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable @typescript-eslint/naming-convention */
+import * as React from 'react';
+
+/**
+ * The code below comes partially from Mantine UI lib:
+ * https://github.com/mantinedev/mantine/blob/master/src/mantine-utils/src/create-scoped-keydown-handler/create-scoped-keydown-handler.ts
+ */
+function getPreviousIndex(current: number, elements: HTMLElement[], loop: boolean) {
+  for (let i = current - 1; i >= 0; i -= 1) {
+    /**
+     * Expected TypeError as ekements are of type HTMLElement that disabled property does not exist.
+     * We should find a proper typing to keep checking `disabled` and at the same time let users pass any element.
+     * Originaly type of elements was `HTMLButtonElement[]`, but we don;t want to restrict only to buttons.
+     */
+    if (!elements[i].disabled) {
+      return i;
+    }
+  }
+
+  if (loop) {
+    for (let i = elements.length - 1; i > -1; i -= 1) {
+      if (!elements[i].disabled) {
+        return i;
+      }
+    }
+  }
+
+  return current;
+}
+
+function getNextIndex(current: number, elements: HTMLElement[], loop: boolean) {
+  for (let i = current + 1; i < elements.length; i += 1) {
+    if (!elements[i].disabled) {
+      return i;
+    }
+  }
+
+  if (loop) {
+    for (let i = 0; i < elements.length; i += 1) {
+      if (!elements[i].disabled) {
+        return i;
+      }
+    }
+  }
+
+  return current;
+}
+
+interface VirtualFocus {
+  index: number;
+  reset: () => void;
+  first: () => void;
+}
+
+interface UseVirtualFocusOptions {
+  /** Container element node used to scope the items */
+  container: HTMLElement | null;
+
+  /** Valid selector used to find all items, e.g. '[role="option"]' */
+  itemSelector: string;
+
+  /** By default virtual focus can't use .focus() method. Set `true` If you want to enable that behaviour. Useful for Tabs when you want to make an active tab tab-index="0" while the rest are tab-index="-1" */
+  useFocus?: boolean;
+
+  /** Enable items looping. */
+  loop?: boolean;
+
+  /** Define how items align, e.g. usually listbox options are `vertical` and tabs are `horizontal` */
+  orientation?: 'vertical' | 'horizontal';
+
+  /** Text direction */
+  dir?: 'rtl' | 'ltr';
+
+  /** Click element on focus */
+  activateOnFocus?: boolean;
+
+  /** External keydown handler */
+  onKeyDown?(virtualFocus: VirtualFocus, event: React.KeyboardEvent<HTMLElement>): void;
+}
+
+export const useVirtualFocus = (options: UseVirtualFocusOptions) => {
+  const {
+    container,
+    itemSelector,
+    loop = false,
+    orientation = 'vertical',
+    // dir = 'rtl',
+    useFocus = false,
+    activateOnFocus = false,
+    onKeyDown,
+  } = options;
+  const [virtualFocusIndex, setVirtualFocusIndex] = React.useState<number>(-1);
+
+  const reset = React.useCallback(() => {
+    setVirtualFocusIndex(-1);
+  }, []);
+
+  const first = React.useCallback(() => {
+    setVirtualFocusIndex(0);
+  }, []);
+
+  const virtualFocus = React.useMemo(
+    () => ({
+      index: virtualFocusIndex,
+      reset,
+      first,
+    }),
+    [first, reset, virtualFocusIndex],
+  );
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    // onKeyDown?.(virtualFocus, event);
+
+    const elements = Array.from(container?.querySelectorAll<HTMLElement>(itemSelector) || []);
+    const current = elements.findIndex((el) => event.currentTarget === el);
+    console.log({ container, elements });
+    const _nextIndex = getNextIndex(useFocus ? current : virtualFocus.index, elements, loop);
+    const _previousIndex = getPreviousIndex(useFocus ? current : virtualFocus.index, elements, loop);
+    /**
+     * This code reverts arrows which leeds to reverted behaviour for horizontal orientation. I'm not sure if it's necessery.
+     */
+    // const nextIndex = dir === 'rtl' ? _previousIndex : _nextIndex;
+    // const previousIndex = dir === 'rtl' ? _nextIndex : _previousIndex;
+
+    switch (event.key) {
+      case 'ArrowRight': {
+        if (orientation === 'horizontal') {
+          event.stopPropagation();
+          event.preventDefault();
+
+          setVirtualFocusIndex(_nextIndex);
+
+          useFocus && elements[_nextIndex].focus();
+          activateOnFocus && elements[_nextIndex].click();
+        }
+
+        break;
+      }
+
+      case 'ArrowLeft': {
+        if (orientation === 'horizontal') {
+          event.stopPropagation();
+          event.preventDefault();
+
+          setVirtualFocusIndex(_previousIndex);
+          useFocus && elements[_previousIndex].focus();
+          activateOnFocus && elements[_previousIndex].click();
+        }
+
+        break;
+      }
+
+      case 'ArrowUp': {
+        if (orientation === 'vertical') {
+          event.stopPropagation();
+          event.preventDefault();
+
+          setVirtualFocusIndex(_previousIndex);
+          useFocus && elements[_previousIndex].focus();
+          activateOnFocus && elements[_previousIndex].click();
+        }
+
+        break;
+      }
+
+      case 'ArrowDown': {
+        if (orientation === 'vertical') {
+          event.stopPropagation();
+          event.preventDefault();
+
+          setVirtualFocusIndex(_nextIndex);
+          useFocus && elements[_nextIndex].focus();
+          activateOnFocus && elements[_nextIndex].click();
+        }
+
+        break;
+      }
+
+      case 'Home': {
+        event.stopPropagation();
+        event.preventDefault();
+
+        setVirtualFocusIndex(0);
+        useFocus && !elements[0].disabled && elements[0].focus();
+        break;
+      }
+
+      case 'End': {
+        event.stopPropagation();
+        event.preventDefault();
+
+        const last = elements.length - 1;
+        setVirtualFocusIndex(last);
+        useFocus && !elements[last].disabled && elements[last].focus();
+        break;
+      }
+
+      default:
+        break;
+    }
+
+    onKeyDown?.(virtualFocus, event);
+  };
+
+  return {
+    onKeyDown: handleKeyDown,
+    virtualFocus,
+  };
+};

--- a/packages/sfui/frameworks/react/index.ts
+++ b/packages/sfui/frameworks/react/index.ts
@@ -7,6 +7,7 @@ export * from './hooks/useTooltip';
 export * from './hooks/useTrapFocus';
 export * from './hooks/useFocusVisible';
 export * from './hooks/usePagination';
+export * from './hooks/useVirtualFocus';
 
 // Shared
 export * from './shared';

--- a/packages/sfui/frameworks/vue/components/SfButton/SfButton.vue
+++ b/packages/sfui/frameworks/vue/components/SfButton/SfButton.vue
@@ -43,7 +43,7 @@ const sizeClasses = computed(() => {
     case SfButtonSize.sm:
       return [square.value ? 'p-1.5' : 'leading-5 text-sm py-1.5 px-3', 'gap-1.5'];
     case SfButtonSize.lg:
-      return [square.value ? 'p-4' : 'py-3 leading-6 px-6', 'gap-3'];
+      return [square.value ? 'p-3' : 'py-3 leading-6 px-6', 'gap-3'];
     default:
       return [square.value ? 'p-2' : 'py-2 leading-6 px-4', 'gap-2'];
   }


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes [SFUI2-1238](https://vsf.atlassian.net/browse/SFUI2-1238)

# Scope of work

**This is not a final solution!**

We want to cut don the scope of the `useTrapFocus` hook/composable by removing arrows navigation. This is a PoC of virtual focus implementation in React, so the arrows navigation (keyboard interactions in general) would be handled by the `useVirtualFocus`, and `useTrapFocus` would only trap focus.

# Screenshots of visual changes

Run the app locally and got to `http://localhost:3002/examples/VirtualFocus` and you will see this page. Use Tab and arrows to see how the Select and Tabs components work with virtual focus.

<img width="498" alt="Screenshot 2023-06-30 at 15 09 59" src="https://github.com/vuestorefront/storefront-ui/assets/34419118/05838b1b-19f9-4bc8-b105-1be80ae5416a">


# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created


[SFUI2-1238]: https://vsf.atlassian.net/browse/SFUI2-1238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ