### PR TITLE
feat: (sfui2-1239) prose styling

### DIFF
--- a/apps/docs/components/.vuepress/config.js
+++ b/apps/docs/components/.vuepress/config.js
@@ -24,6 +24,7 @@ const reactMenu = [
       ['/react/customization/theming', 'Theming'],
       ['/react/customization/overriding-default-styles', 'Overriding Default Styles'],
       ['/react/customization/typography', 'Typography'],
+      ['/react/customization/prose', 'Prose'],
     ],
   },
   {
@@ -68,6 +69,7 @@ const vueMenu = [
       ['/vue/customization/theming', 'Theming'],
       ['/vue/customization/overriding-default-styles', 'Overriding Default Styles'],
       ['/vue/customization/typography', 'Typography'],
+      ['/vue/customization/prose', 'Prose'],
     ],
   },
   {

--- a/apps/docs/components/blocks/Typography.md
+++ b/apps/docs/components/blocks/Typography.md
@@ -6,7 +6,9 @@ hideToc: true
 ---
 # Typography
 
-{{ $frontmatter.description }}
+One of the prominent features of the Tailwind Typography plugin is the ```prose``` class. The ```prose``` class is designed to create a consistent and readable typographic style for large blocks of text, such as paragraphs, articles, blog posts, or any other content-heavy sections of your website.
+
+When you apply the prose class to a container element, it automatically applies a set of carefully crafted styles to enhance the readability and overall aesthetics of the text. Examples of the mentioned styles can be found below.
 
 ## Headings
 

--- a/apps/docs/components/blocks/Typography.md
+++ b/apps/docs/components/blocks/Typography.md
@@ -8,17 +8,120 @@ hideToc: true
 
 {{ $frontmatter.description }}
 
-## Typography styles
+## Headings
 
-The default card view with a rectangle shaped image, a title, a description and a button for some additional actions.
+Styles for ```<h1>```, ```<h2>```, ```<h3>``` and ```<h4>``` are applied out of the box when ```prose``` class is applied to the container.
 
-<Showcase showcase-name="Typography/TypographyDefault" style="min-height: 600px">
+<Showcase showcase-name="Typography/Headings" style="min-height:400px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Typography/Headings.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Typography/Headings.tsx#source
+<!-- end react -->
+
+</Showcase>
+
+## Leadings
+
+To apply leading text style,```lead``` class must be assigned to the chosen tag.
+
+<Showcase showcase-name="Typography/Leading" style="min-height:200px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Typography/Leading.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Typography/Leading.tsx#source
+<!-- end react -->
+
+</Showcase>
+
+## Paragraph
+
+Simple paragraph styling.
+
+<Showcase showcase-name="Typography/Paragraph" style="min-height:200px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Typography/Paragraph.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Typography/Paragraph.tsx#source
+<!-- end react -->
+
+</Showcase>
+
+## Quote
+
+For quotes, please use ```<blockquote>``` tag and ```<figcaption>``` for signature.
+
+<Showcase showcase-name="Typography/Quote" style="min-height:200px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Typography/Quote.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Typography/Quote.tsx#source
+<!-- end react -->
+
+</Showcase>
+
+## Figure
+
+Figure is an example of image using ```<figcaption />``` for capturing the picture.
+
+<Showcase showcase-name="Typography/Figure" style="min-height:400px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Typography/Figure.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Typography/Figure.tsx#source
+<!-- end react -->
+
+</Showcase>
+
+## Table
+
+Simple example of styling tables of contents.
+
+<Showcase showcase-name="Typography/Table" style="min-height:200px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Typography/Table.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Typography/Table.tsx#source
+<!-- end react -->
+
+</Showcase>
+
+## List
+
+Simple example of styling the lists.
+
+<Showcase showcase-name="Typography/List" style="min-height:200px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Typography/List.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Typography/List.tsx#source
+<!-- end react -->
+
+</Showcase>
+
+## Example content styled with ```prose```
+
+<Showcase showcase-name="Typography/TypographyDefault" style="min-height:1800px">
 
 <!-- vue -->
 <<<../../preview/nuxt/pages/showcases/Typography/TypographyDefault.vue
 <!-- end vue -->
 <!-- react -->
-<<<../../preview/next/pages/showcases/Typograhy/TypographyDefault.tsx#source
+<<<../../preview/next/pages/showcases/Typography/TypographyDefault.tsx#source
 <!-- end react -->
 
 </Showcase>

--- a/apps/docs/components/blocks/Typography.md
+++ b/apps/docs/components/blocks/Typography.md
@@ -1,0 +1,25 @@
+---
+layout: DefaultLayout
+hideBreadcrumbs: true
+description: Typography based on Tailwind Typography plugin
+hideToc: true
+---
+# Typography
+
+{{ $frontmatter.description }}
+
+## Typography styles
+
+The default card view with a rectangle shaped image, a title, a description and a button for some additional actions.
+
+<Showcase showcase-name="Typography/TypographyDefault" style="min-height: 600px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Typography/TypographyDefault.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Typograhy/TypographyDefault.tsx#source
+<!-- end react -->
+
+</Showcase>
+

--- a/apps/docs/components/customization/prose.md
+++ b/apps/docs/components/customization/prose.md
@@ -1,10 +1,9 @@
 ---
 layout: DefaultLayout
 hideBreadcrumbs: true
-description: Typography based on Tailwind Typography plugin
 hideToc: true
 ---
-# Typography
+# Prose styling
 
 One of the prominent features of the Tailwind Typography plugin is the ```prose``` class. The ```prose``` class is designed to create a consistent and readable typographic style for large blocks of text, such as paragraphs, articles, blog posts, or any other content-heavy sections of your website.
 

--- a/apps/docs/components/package.json
+++ b/apps/docs/components/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@microsoft/api-documenter": "^7.21.5",
     "@microsoft/api-extractor": "^7.34.4",
+    "@tailwindcss/typography": "^0.5.9",
     "@vuepress/plugin-active-header-links": "^1.9.8",
     "@vuepress/plugin-back-to-top": "^1.9.8",
     "@vuepress/plugin-medium-zoom": "^1.9.8",

--- a/apps/docs/components/package.json
+++ b/apps/docs/components/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@microsoft/api-documenter": "^7.21.5",
     "@microsoft/api-extractor": "^7.34.4",
-    "@tailwindcss/typography": "^0.5.9",
     "@vuepress/plugin-active-header-links": "^1.9.8",
     "@vuepress/plugin-back-to-top": "^1.9.8",
     "@vuepress/plugin-medium-zoom": "^1.9.8",

--- a/apps/docs/components/tailwind.config.js
+++ b/apps/docs/components/tailwind.config.js
@@ -47,5 +47,5 @@ module.exports = {
       brightness: ['hover', 'focus'],
     },
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/typography')],
 };

--- a/apps/docs/components/tailwind.config.js
+++ b/apps/docs/components/tailwind.config.js
@@ -47,5 +47,5 @@ module.exports = {
       brightness: ['hover', 'focus'],
     },
   },
-  plugins: [require('@tailwindcss/typography')],
+  plugins: [],
 };

--- a/apps/docs/tests/fixtures/elements.json
+++ b/apps/docs/tests/fixtures/elements.json
@@ -195,7 +195,6 @@
     "className": "card"
   },
   {
- 
     "url": "/blocks/Checkout.html",
     "name": "Checkout",
     "className": "checkout"
@@ -267,8 +266,13 @@
   },
   {
     "url": "/blocks/SelectDropdown.html",
-    "name": "Select Dropdown ",
+    "name": "Select Dropdown",
     "className": "select-dropdown"
+  },
+  {
+    "url": "/blocks/Typography.html",
+    "name": "Typography",
+    "className": "typography"
   },
   {
     "url": "/migration.html",

--- a/apps/docs/tests/fixtures/elements.json
+++ b/apps/docs/tests/fixtures/elements.json
@@ -15,6 +15,11 @@
     "className": "typography"
   },
   {
+    "url": "/customization/prose.html",
+    "name": "Prose",
+    "className": "prose"
+  },
+  {
     "url": "/components.html",
     "name": "Base Components",
     "className": "base-components"
@@ -268,11 +273,6 @@
     "url": "/blocks/SelectDropdown.html",
     "name": "Select Dropdown",
     "className": "select-dropdown"
-  },
-  {
-    "url": "/blocks/Typography.html",
-    "name": "Typography",
-    "className": "typography"
   },
   {
     "url": "/migration.html",

--- a/apps/preview/next/package.json
+++ b/apps/preview/next/package.json
@@ -32,6 +32,7 @@
     "@storefront-ui/tests-shared": "workspace:*",
     "@storefront-ui/tw-plugin-peer-next": "workspace:*",
     "@storefront-ui/typography": "workspace:*",
+    "@tailwindcss/typography": "^0.5.9",
     "@types/lodash-es": "^4.17.6",
     "@types/node": "^18.13.0",
     "@types/react": "^18.0.28",

--- a/apps/preview/next/pages/showcases/Typography/Figure.tsx
+++ b/apps/preview/next/pages/showcases/Typography/Figure.tsx
@@ -1,0 +1,13 @@
+import { ShowcasePageLayout } from '../../showcases';
+
+export default function Figure() {
+  return (
+    <figure className="prose">
+      <img src="http://localhost:3100/@assets/card-3.png" />
+      <figcaption>The Nike Air Max 270 in action</figcaption>
+    </figure>
+  );
+}
+
+// #endregion source
+Figure.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/Typography/Figure.tsx
+++ b/apps/preview/next/pages/showcases/Typography/Figure.tsx
@@ -3,7 +3,7 @@ import { ShowcasePageLayout } from '../../showcases';
 export default function Figure() {
   return (
     <figure className="prose">
-      <img src="http://localhost:3100/@assets/card-3.png" />
+      <img src="http://localhost:3100/@assets/card-3.png" alt="Example of marketing card" />
       <figcaption>The Nike Air Max 270 in action</figcaption>
     </figure>
   );

--- a/apps/preview/next/pages/showcases/Typography/Headings.tsx
+++ b/apps/preview/next/pages/showcases/Typography/Headings.tsx
@@ -1,0 +1,15 @@
+import { ShowcasePageLayout } from '../../showcases';
+
+export default function Headings() {
+  return (
+    <div className="prose">
+      <h1>H1</h1>
+      <h2>H2</h2>
+      <h3>H3</h3>
+      <h4>H4</h4>
+    </div>
+  );
+}
+
+// #endregion source
+Headings.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/Typography/Leading.tsx
+++ b/apps/preview/next/pages/showcases/Typography/Leading.tsx
@@ -1,0 +1,12 @@
+import { ShowcasePageLayout } from '../../showcases';
+
+export default function Leading() {
+  return (
+    <div className="prose">
+      <span className="lead">Leading text</span>
+    </div>
+  );
+}
+
+// #endregion source
+Leading.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/Typography/List.tsx
+++ b/apps/preview/next/pages/showcases/Typography/List.tsx
@@ -1,0 +1,14 @@
+import { ShowcasePageLayout } from '../../showcases';
+
+export default function List() {
+  return (
+    <ul className="prose">
+      <li>List item</li>
+      <li>List item</li>
+      <li>List item</li>
+    </ul>
+  );
+}
+
+// #endregion source
+List.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/Typography/Paragraph.tsx
+++ b/apps/preview/next/pages/showcases/Typography/Paragraph.tsx
@@ -1,0 +1,8 @@
+import { ShowcasePageLayout } from '../../showcases';
+
+export default function Paragraph() {
+  return <p className="prose">Paragraph text</p>;
+}
+
+// #endregion source
+Paragraph.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/Typography/Quote.tsx
+++ b/apps/preview/next/pages/showcases/Typography/Quote.tsx
@@ -1,0 +1,13 @@
+import { ShowcasePageLayout } from '../../showcases';
+
+export default function Quote() {
+  return (
+    <figure className="prose">
+      <blockquote>Quote Text</blockquote>
+      <figcaption>—Signature</figcaption>
+    </figure>
+  );
+}
+
+// #endregion source
+Quote.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/Typography/Table.tsx
+++ b/apps/preview/next/pages/showcases/Typography/Table.tsx
@@ -1,0 +1,29 @@
+import { ShowcasePageLayout } from '../../showcases';
+
+export default function Table() {
+  return (
+    <div className="prose">
+      <table>
+        <thead>
+          <tr>
+            <th>Header</th>
+            <th>Header</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Content</td>
+            <td>Content</td>
+          </tr>
+          <tr>
+            <td>Content</td>
+            <td>Content</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// #endregion source
+Table.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/Typography/TypographyDefault.tsx
+++ b/apps/preview/next/pages/showcases/Typography/TypographyDefault.tsx
@@ -16,7 +16,7 @@ export default function TypographyDefault() {
         sleek and modern design.
       </p>
       <figure>
-        <img src="http://localhost:3100/@assets/card-3.png" />
+        <img src="http://localhost:3100/@assets/card-3.png" alt="Example of marketing card" />
         <figcaption>The Nike Air Max 270 in action</figcaption>
       </figure>
       <hr />

--- a/apps/preview/next/pages/showcases/Typography/TypographyDefault.tsx
+++ b/apps/preview/next/pages/showcases/Typography/TypographyDefault.tsx
@@ -1,10 +1,10 @@
 import { ShowcasePageLayout } from '../../showcases';
 
 export default function TypographyDefault() {
-  return <div>
+  return <>
     <h1>Heading 1</h1>
     <h2>Heading 2</h2>
-  </div>;
+  </>;
 }
 
 // #endregion source

--- a/apps/preview/next/pages/showcases/Typography/TypographyDefault.tsx
+++ b/apps/preview/next/pages/showcases/Typography/TypographyDefault.tsx
@@ -1,10 +1,86 @@
 import { ShowcasePageLayout } from '../../showcases';
 
 export default function TypographyDefault() {
-  return <>
-    <h1>Heading 1</h1>
-    <h2>Heading 2</h2>
-  </>;
+  return (
+    <div className="prose">
+      <figcaption>The New Winner</figcaption>
+      <h1>Nike Air Max 270</h1>
+      <span className="lead">Experience ultimate comfort and style with the Nike Air Max 270 sneakers.</span>
+      <p>Paragraph text</p>
+      <figure>
+        <blockquote>“Every step is a cushioned stride with the Air Max 270 technology.”</blockquote>
+        <figcaption>—Signature</figcaption>
+      </figure>
+      <p>
+        Designed for athletes and sneaker enthusiasts alike, the Nike Air Max 270 combines innovative features with a
+        sleek and modern design.
+      </p>
+      <figure>
+        <img src="http://localhost:3100/@assets/card-3.png" />
+        <figcaption>The Nike Air Max 270 in action</figcaption>
+      </figure>
+      <hr />
+      <h2>Features and Benefits</h2>
+      <ul>
+        <li>
+          <strong>Lightweight and Breathable:</strong> The engineered mesh upper provides excellent breathability,
+          keeping your feet cool and comfortable.
+        </li>
+        <li>
+          <strong>Max Air Cushioning:</strong> The visible Max Air unit in the heel offers responsive cushioning and
+          impact absorption.
+        </li>
+        <li>
+          <strong>Durable and Flexible:</strong> The rubber outsole with flex grooves ensures durability and flexibility
+          for natural foot movements.
+        </li>
+      </ul>
+      <hr />
+      <h3>Perfect for Any Occasion</h3>
+      <p>
+        Whether you're hitting the gym, going for a run, or simply adding a stylish touch to your everyday outfits, the
+        Nike Air Max 270 is the perfect choice.
+      </p>
+      <p>
+        With its versatile design and superior comfort, these sneakers are sure to become your go-to footwear option.
+      </p>
+      <p>Don't compromise on style or performance. Step up your sneaker game with the Nike Air Max 270.</p>
+      <hr />
+      <h4>Where to buy</h4>
+      <p>
+        Find the Nike Air Max 270 at authorized retailers or shop online on our website to get your hands on this iconic
+        pair of sneakers.
+      </p>
+      <hr />
+      <span className="prose-medium">Product Specifications</span>
+      <table>
+        <thead>
+          <tr>
+            <th>Feature</th>
+            <th>Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Upper material</td>
+            <td>Leather and mesh</td>
+          </tr>
+          <tr>
+            <td>Sole material</td>
+            <td>Rubber</td>
+          </tr>
+          <tr>
+            <td>Closure Type</td>
+            <td>Lace up</td>
+          </tr>
+          <tr>
+            <td>Available Sizes</td>
+            <td>US 6-12</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
 }
 
 // #endregion source

--- a/apps/preview/next/pages/showcases/Typography/TypographyDefault.tsx
+++ b/apps/preview/next/pages/showcases/Typography/TypographyDefault.tsx
@@ -38,13 +38,13 @@ export default function TypographyDefault() {
       <hr />
       <h3>Perfect for Any Occasion</h3>
       <p>
-        Whether you're hitting the gym, going for a run, or simply adding a stylish touch to your everyday outfits, the
+        Whether you are hitting the gym, going for a run, or simply adding a stylish touch to your everyday outfits, the
         Nike Air Max 270 is the perfect choice.
       </p>
       <p>
         With its versatile design and superior comfort, these sneakers are sure to become your go-to footwear option.
       </p>
-      <p>Don't compromise on style or performance. Step up your sneaker game with the Nike Air Max 270.</p>
+      <p>Do not compromise on style or performance. Step up your sneaker game with the Nike Air Max 270.</p>
       <hr />
       <h4>Where to buy</h4>
       <p>
@@ -52,7 +52,7 @@ export default function TypographyDefault() {
         pair of sneakers.
       </p>
       <hr />
-      <span className="prose-medium">Product Specifications</span>
+      <strong className="prose-medium">Product Specifications</strong>
       <table>
         <thead>
           <tr>

--- a/apps/preview/next/pages/showcases/Typography/TypographyDefault.tsx
+++ b/apps/preview/next/pages/showcases/Typography/TypographyDefault.tsx
@@ -1,0 +1,11 @@
+import { ShowcasePageLayout } from '../../showcases';
+
+export default function TypographyDefault() {
+  return <div>
+    <h1>Heading 1</h1>
+    <h2>Heading 2</h2>
+  </div>;
+}
+
+// #endregion source
+TypographyDefault.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/styles/global.css
+++ b/apps/preview/next/styles/global.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@300;400;500;700&family=Red+Hat+Text:ital,wght@0,400;0,500;0,700;1,300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&family=Red+Hat+Text:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/apps/preview/next/tailwind.config.js
+++ b/apps/preview/next/tailwind.config.js
@@ -12,5 +12,5 @@ module.exports = {
       },
     },
   },
-  plugins: [sfTypography],
+  plugins: [sfTypography, require('@tailwindcss/typography')],
 };

--- a/apps/preview/next/tailwind.config.js
+++ b/apps/preview/next/tailwind.config.js
@@ -1,6 +1,7 @@
 const sfTypography = require('@storefront-ui/typography');
 /** @type {import('tailwindcss').Config} */
 const { tailwindConfig } = require('@storefront-ui/tailwind-config');
+const tailwindTypography = require('@tailwindcss/typography');
 
 module.exports = {
   presets: [tailwindConfig],
@@ -12,5 +13,5 @@ module.exports = {
       },
     },
   },
-  plugins: [sfTypography, require('@tailwindcss/typography')],
+  plugins: [sfTypography, tailwindTypography],
 };

--- a/apps/preview/nuxt/assets/css/tailwind.css
+++ b/apps/preview/nuxt/assets/css/tailwind.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@300;400;500;700&family=Red+Hat+Text:ital,wght@0,400;0,500;0,700;1,300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&family=Red+Hat+Text:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/apps/preview/nuxt/package.json
+++ b/apps/preview/nuxt/package.json
@@ -21,6 +21,7 @@
     "@storefront-ui/tw-plugin-peer-next": "workspace:*",
     "@storefront-ui/typography": "workspace:*",
     "@storefront-ui/vue": "workspace:*",
+    "@tailwindcss/typography": "^0.5.9",
     "@types/lodash-es": "^4.17.6",
     "@vueuse/core": "^9.12.0",
     "autoprefixer": "^10.4.13",

--- a/apps/preview/nuxt/pages/showcases/Typography/Figure.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Figure.vue
@@ -1,8 +1,6 @@
 <template>
-  <div class="prose">
-    <figure>
-      <img src="http://localhost:3100/@assets/card-3.png" />
-      <figcaption>The Nike Air Max 270 in action</figcaption>
-    </figure>
-  </div>
+  <figure class="prose">
+    <img src="http://localhost:3100/@assets/card-3.png" />
+    <figcaption>The Nike Air Max 270 in action</figcaption>
+  </figure>
 </template>

--- a/apps/preview/nuxt/pages/showcases/Typography/Figure.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Figure.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="prose">
+    <figure>
+      <img src="http://localhost:3100/@assets/card-3.png" />
+      <figcaption>The Nike Air Max 270 in action</figcaption>
+    </figure>
+  </div>
+</template>

--- a/apps/preview/nuxt/pages/showcases/Typography/Figure.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Figure.vue
@@ -1,6 +1,6 @@
 <template>
   <figure class="prose">
-    <img src="http://localhost:3100/@assets/card-3.png" />
+    <img src="http://localhost:3100/@assets/card-3.png" alt="Example of marketing card" />
     <figcaption>The Nike Air Max 270 in action</figcaption>
   </figure>
 </template>

--- a/apps/preview/nuxt/pages/showcases/Typography/Headings.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Headings.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="prose">
+    <h1>H1</h1>
+    <h2>H2</h2>
+    <h3>H3</h3>
+    <h4>H4</h4>
+  </div>
+</template>

--- a/apps/preview/nuxt/pages/showcases/Typography/Leading.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Leading.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="prose">
+    <span class="lead">Leading text</span>
+  </div>
+</template>

--- a/apps/preview/nuxt/pages/showcases/Typography/List.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/List.vue
@@ -1,0 +1,7 @@
+<template>
+  <ul class="prose">
+    <li>List item</li>
+    <li>List item</li>
+    <li>List item</li>
+  </ul>
+</template>

--- a/apps/preview/nuxt/pages/showcases/Typography/Paragraph.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Paragraph.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="prose">
+    <p>Paragraph text</p>
+  </div>
+</template>

--- a/apps/preview/nuxt/pages/showcases/Typography/Paragraph.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Paragraph.vue
@@ -1,5 +1,3 @@
 <template>
-  <div class="prose">
-    <p>Paragraph text</p>
-  </div>
+  <p class="prose">Paragraph text</p>
 </template>

--- a/apps/preview/nuxt/pages/showcases/Typography/Quote.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Quote.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="prose">
+    <figure>
+      <blockquote>Quote Text</blockquote>
+      <figcaption>—Signature</figcaption>
+    </figure>
+  </div>
+</template>

--- a/apps/preview/nuxt/pages/showcases/Typography/Quote.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Quote.vue
@@ -1,8 +1,6 @@
 <template>
-  <div class="prose">
-    <figure>
+  <figure class="prose">
       <blockquote>Quote Text</blockquote>
       <figcaption>—Signature</figcaption>
-    </figure>
-  </div>
+  </figure>
 </template>

--- a/apps/preview/nuxt/pages/showcases/Typography/Quote.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Quote.vue
@@ -1,6 +1,6 @@
 <template>
   <figure class="prose">
-      <blockquote>Quote Text</blockquote>
-      <figcaption>—Signature</figcaption>
+    <blockquote>Quote Text</blockquote>
+    <figcaption>—Signature</figcaption>
   </figure>
 </template>

--- a/apps/preview/nuxt/pages/showcases/Typography/Table.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Table.vue
@@ -1,18 +1,22 @@
 <template>
   <div class="prose">
     <table>
-      <tr>
-        <th>Header</th>
-        <th>Header</th>
-      </tr>
-      <tr>
-        <td>Content</td>
-        <td>Content</td>
-      </tr>
-      <tr>
-        <td>Content</td>
-        <td>Content</td>
-      </tr>
+      <thead>
+        <tr>
+          <th>Header</th>
+          <th>Header</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Content</td>
+          <td>Content</td>
+        </tr>
+        <tr>
+          <td>Content</td>
+          <td>Content</td>
+        </tr>
+      </tbody> 
     </table>
   </div>
 </template>

--- a/apps/preview/nuxt/pages/showcases/Typography/Table.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Table.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="prose">
+    <table>
+      <tr>
+        <th>Header</th>
+        <th>Header</th>
+      </tr>
+      <tr>
+        <td>Content</td>
+        <td>Content</td>
+      </tr>
+      <tr>
+        <td>Content</td>
+        <td>Content</td>
+      </tr>
+    </table>
+  </div>
+</template>

--- a/apps/preview/nuxt/pages/showcases/Typography/Table.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/Table.vue
@@ -16,7 +16,7 @@
           <td>Content</td>
           <td>Content</td>
         </tr>
-      </tbody> 
+      </tbody>
     </table>
   </div>
 </template>

--- a/apps/preview/nuxt/pages/showcases/Typography/TypographyDefault.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/TypographyDefault.vue
@@ -8,7 +8,10 @@
       <blockquote>“Every step is a cushioned stride with the Air Max 270 technology.”</blockquote>
       <figcaption>—Signature</figcaption>
     </figure>
-    <p>Designed for athletes and sneaker enthusiasts alike, the Nike Air Max 270 combines innovative features with a sleek and modern design.</p>
+    <p>
+      Designed for athletes and sneaker enthusiasts alike, the Nike Air Max 270 combines innovative features with a
+      sleek and modern design.
+    </p>
     <figure>
       <img src="http://localhost:3100/@assets/card-3.png" alt="Example of marketing card" />
       <figcaption>The Nike Air Max 270 in action</figcaption>
@@ -16,18 +19,33 @@
     <hr />
     <h2>Features and Benefits</h2>
     <ul>
-      <li><strong>Lightweight and Breathable:</strong> The engineered mesh upper provides excellent breathability, keeping your feet cool and comfortable.</li>
-      <li><strong>Max Air Cushioning:</strong> The visible Max Air unit in the heel offers responsive cushioning and impact absorption.</li>
-      <li><strong>Durable and Flexible:</strong> The rubber outsole with flex grooves ensures durability and flexibility for natural foot movements.</li>
+      <li>
+        <strong>Lightweight and Breathable:</strong> The engineered mesh upper provides excellent breathability, keeping
+        your feet cool and comfortable.
+      </li>
+      <li>
+        <strong>Max Air Cushioning:</strong> The visible Max Air unit in the heel offers responsive cushioning and
+        impact absorption.
+      </li>
+      <li>
+        <strong>Durable and Flexible:</strong> The rubber outsole with flex grooves ensures durability and flexibility
+        for natural foot movements.
+      </li>
     </ul>
     <hr />
     <h3>Perfect for Any Occasion</h3>
-    <p>Whether you are hitting the gym, going for a run, or simply adding a stylish touch to your everyday outfits, the Nike Air Max 270 is the perfect choice.</p>
+    <p>
+      Whether you are hitting the gym, going for a run, or simply adding a stylish touch to your everyday outfits, the
+      Nike Air Max 270 is the perfect choice.
+    </p>
     <p>With its versatile design and superior comfort, these sneakers are sure to become your go-to footwear option.</p>
     <p>Don't compromise on style or performance. Step up your sneaker game with the Nike Air Max 270.</p>
     <hr />
     <h4>Where to buy</h4>
-    <p>Find the Nike Air Max 270 at authorized retailers or shop online on our website to get your hands on this iconic pair of sneakers.</p>
+    <p>
+      Find the Nike Air Max 270 at authorized retailers or shop online on our website to get your hands on this iconic
+      pair of sneakers.
+    </p>
     <hr />
     <strong class="prose-medium">Product Specifications</strong>
     <table>
@@ -36,8 +54,8 @@
           <th>Feature</th>
           <th>Details</th>
         </tr>
-        </thead>
-        <tbody>
+      </thead>
+      <tbody>
         <tr>
           <td>Upper material</td>
           <td>Leather and mesh</td>

--- a/apps/preview/nuxt/pages/showcases/Typography/TypographyDefault.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/TypographyDefault.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <h1 class="prose-h1">Heading 1</h1>
+    <h2>Heading 2</h2>
+  </div>
+</template>

--- a/apps/preview/nuxt/pages/showcases/Typography/TypographyDefault.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/TypographyDefault.vue
@@ -22,35 +22,39 @@
     </ul>
     <hr />
     <h3>Perfect for Any Occasion</h3>
-    <p>Whether you're hitting the gym, going for a run, or simply adding a stylish touch to your everyday outfits, the Nike Air Max 270 is the perfect choice.</p>
+    <p>Whether you are hitting the gym, going for a run, or simply adding a stylish touch to your everyday outfits, the Nike Air Max 270 is the perfect choice.</p>
     <p>With its versatile design and superior comfort, these sneakers are sure to become your go-to footwear option.</p>
     <p>Don't compromise on style or performance. Step up your sneaker game with the Nike Air Max 270.</p>
     <hr />
     <h4>Where to buy</h4>
     <p>Find the Nike Air Max 270 at authorized retailers or shop online on our website to get your hands on this iconic pair of sneakers.</p>
     <hr />
-    <span class="prose-medium">Product Specifications</span>
+    <strong class="prose-medium">Product Specifications</strong>
     <table>
-      <tr>
-        <th>Feature</th>
-        <th>Details</th>
-      </tr>
-      <tr>
-        <td>Upper material</td>
-        <td>Leather and mesh</td>
-      </tr>
-      <tr>
-        <td>Sole material</td>
-        <td>Rubber</td>
-      </tr>
-      <tr>
-        <td>Closure Type</td>
-        <td>Lace up</td>
-      </tr>
-      <tr>
-        <td>Available Sizes</td>
-        <td>US 6-12</td>
-      </tr>
+      <thead>
+        <tr>
+          <th>Feature</th>
+          <th>Details</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td>Upper material</td>
+          <td>Leather and mesh</td>
+        </tr>
+        <tr>
+          <td>Sole material</td>
+          <td>Rubber</td>
+        </tr>
+        <tr>
+          <td>Closure Type</td>
+          <td>Lace up</td>
+        </tr>
+        <tr>
+          <td>Available Sizes</td>
+          <td>US 6-12</td>
+        </tr>
+      </tbody>
     </table>
   </div>
 </template>

--- a/apps/preview/nuxt/pages/showcases/Typography/TypographyDefault.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/TypographyDefault.vue
@@ -10,7 +10,7 @@
     </figure>
     <p>Designed for athletes and sneaker enthusiasts alike, the Nike Air Max 270 combines innovative features with a sleek and modern design.</p>
     <figure>
-      <img src="http://localhost:3100/@assets/card-3.png" />
+      <img src="http://localhost:3100/@assets/card-3.png" alt="Example of marketing card" />
       <figcaption>The Nike Air Max 270 in action</figcaption>
     </figure>
     <hr />

--- a/apps/preview/nuxt/pages/showcases/Typography/TypographyDefault.vue
+++ b/apps/preview/nuxt/pages/showcases/Typography/TypographyDefault.vue
@@ -1,6 +1,56 @@
 <template>
-  <div>
-    <h1 class="prose-h1">Heading 1</h1>
-    <h2>Heading 2</h2>
+  <div class="prose">
+    <figcaption>The New Winner</figcaption>
+    <h1>Nike Air Max 270</h1>
+    <span class="lead">Experience ultimate comfort and style with the Nike Air Max 270 sneakers.</span>
+    <p>Paragraph text</p>
+    <figure>
+      <blockquote>“Every step is a cushioned stride with the Air Max 270 technology.”</blockquote>
+      <figcaption>—Signature</figcaption>
+    </figure>
+    <p>Designed for athletes and sneaker enthusiasts alike, the Nike Air Max 270 combines innovative features with a sleek and modern design.</p>
+    <figure>
+      <img src="http://localhost:3100/@assets/card-3.png" />
+      <figcaption>The Nike Air Max 270 in action</figcaption>
+    </figure>
+    <hr />
+    <h2>Features and Benefits</h2>
+    <ul>
+      <li><strong>Lightweight and Breathable:</strong> The engineered mesh upper provides excellent breathability, keeping your feet cool and comfortable.</li>
+      <li><strong>Max Air Cushioning:</strong> The visible Max Air unit in the heel offers responsive cushioning and impact absorption.</li>
+      <li><strong>Durable and Flexible:</strong> The rubber outsole with flex grooves ensures durability and flexibility for natural foot movements.</li>
+    </ul>
+    <hr />
+    <h3>Perfect for Any Occasion</h3>
+    <p>Whether you're hitting the gym, going for a run, or simply adding a stylish touch to your everyday outfits, the Nike Air Max 270 is the perfect choice.</p>
+    <p>With its versatile design and superior comfort, these sneakers are sure to become your go-to footwear option.</p>
+    <p>Don't compromise on style or performance. Step up your sneaker game with the Nike Air Max 270.</p>
+    <hr />
+    <h4>Where to buy</h4>
+    <p>Find the Nike Air Max 270 at authorized retailers or shop online on our website to get your hands on this iconic pair of sneakers.</p>
+    <hr />
+    <span class="prose-medium">Product Specifications</span>
+    <table>
+      <tr>
+        <th>Feature</th>
+        <th>Details</th>
+      </tr>
+      <tr>
+        <td>Upper material</td>
+        <td>Leather and mesh</td>
+      </tr>
+      <tr>
+        <td>Sole material</td>
+        <td>Rubber</td>
+      </tr>
+      <tr>
+        <td>Closure Type</td>
+        <td>Lace up</td>
+      </tr>
+      <tr>
+        <td>Available Sizes</td>
+        <td>US 6-12</td>
+      </tr>
+    </table>
   </div>
 </template>

--- a/apps/preview/nuxt/tailwind.config.ts
+++ b/apps/preview/nuxt/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss';
 import sfTypography from '@storefront-ui/typography';
 import { tailwindConfig } from '@storefront-ui/vue/tailwind-config';
+import tailwindTypography from '@tailwindcss/typography';
 
 export default <Config>{
   presets: [tailwindConfig],
@@ -12,5 +13,5 @@ export default <Config>{
       },
     },
   },
-  plugins: [sfTypography, require('@tailwindcss/typography')],
+  plugins: [sfTypography, tailwindTypography],
 };

--- a/apps/preview/nuxt/tailwind.config.ts
+++ b/apps/preview/nuxt/tailwind.config.ts
@@ -12,5 +12,5 @@ export default <Config>{
       },
     },
   },
-  plugins: [sfTypography],
+  plugins: [sfTypography, require('@tailwindcss/typography')],
 };

--- a/apps/test/react/package.json
+++ b/apps/test/react/package.json
@@ -36,6 +36,7 @@
     "@storefront-ui/tests-shared": "workspace:*",
     "@storefront-ui/tw-plugin-peer-next": "workspace:*",
     "@storefront-ui/typography": "workspace:*",
+    "@tailwindcss/typography": "^0.5.9",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^4.0.0-beta.0",

--- a/apps/test/react/src/index.css
+++ b/apps/test/react/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@300;400;500;700&family=Red+Hat+Text:ital,wght@0,400;0,500;0,700;1,300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&family=Red+Hat+Text:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/apps/test/react/tailwind.config.ts
+++ b/apps/test/react/tailwind.config.ts
@@ -30,5 +30,5 @@ module.exports = {
       },
     },
   },
-  plugins: [sfTypography],
+  plugins: [sfTypography, require('@tailwindcss/typography')],
 };

--- a/apps/test/react/tailwind.config.ts
+++ b/apps/test/react/tailwind.config.ts
@@ -2,6 +2,7 @@
 import { join } from 'path';
 import sfTypography from '@storefront-ui/typography';
 import { tailwindConfig } from '@storefront-ui/tailwind-config';
+import tailwindTypography from '@tailwindcss/typography';
 
 module.exports = {
   presets: [tailwindConfig],
@@ -30,5 +31,5 @@ module.exports = {
       },
     },
   },
-  plugins: [sfTypography, require('@tailwindcss/typography')],
+  plugins: [sfTypography, tailwindTypography],
 };

--- a/apps/test/vue/package.json
+++ b/apps/test/vue/package.json
@@ -36,6 +36,7 @@
     "@storefront-ui/tw-plugin-peer-next": "workspace:*",
     "@storefront-ui/typography": "workspace:*",
     "@storefront-ui/vue": "workspace:*",
+    "@tailwindcss/typography": "^0.5.9",
     "@types/node": "^18.13.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vue/tsconfig": "^0.1.3",

--- a/apps/test/vue/src/assets/global.css
+++ b/apps/test/vue/src/assets/global.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@300;400;500;700&family=Red+Hat+Text:ital,wght@0,400;0,500;0,700;1,300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&family=Red+Hat+Text:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/apps/test/vue/tailwind.config.js
+++ b/apps/test/vue/tailwind.config.js
@@ -1,6 +1,7 @@
 const sfTypography = require("@storefront-ui/typography");
 /** @type {import('tailwindcss').Config} */
 const { tailwindConfig } = require("@storefront-ui/tailwind-config");
+const tailwindTypography = require('@tailwindcss/typography');
 const { join } = require("path");
 
 module.exports = {
@@ -31,5 +32,5 @@ module.exports = {
       },
     },
   },
-  plugins: [sfTypography, require('@tailwindcss/typography') ],
+  plugins: [sfTypography, tailwindTypography ],
 };

--- a/apps/test/vue/tailwind.config.js
+++ b/apps/test/vue/tailwind.config.js
@@ -31,5 +31,5 @@ module.exports = {
       },
     },
   },
-  plugins: [sfTypography],
+  plugins: [sfTypography, require('@tailwindcss/typography') ],
 };

--- a/packages/config/tailwind/index.ts
+++ b/packages/config/tailwind/index.ts
@@ -1,4 +1,5 @@
 import { Config } from 'tailwindcss';
+import { ThemeConfig } from 'tailwindcss/types/config';
 import tailwindCssVariables from '@mertasan/tailwindcss-variables';
 import peerNextPlugin from '@storefront-ui/tw-plugin-peer-next';
 import tailwindTypography from '@tailwindcss/typography';
@@ -10,7 +11,7 @@ export const tailwindConfig: Config = {
   },
   theme: {
     extend: {
-      typography: ({ theme }) => ({
+      typography: ( { theme } : ThemeConfig ) => ({
         DEFAULT: {
           css: [
             {
@@ -22,15 +23,22 @@ export const tailwindConfig: Config = {
                 marginBottom: '20px',
               },
               '[class~="lead"]': {
+                fontWeight: theme('fontWeight.medium'),
                 fontSize: '20px',
                 lineHeight: '32px',
                 marginTop: '24px',
                 marginBottom: '24px',
+                color: theme('colors.neutral.900'),
               },
               blockquote: {
+                color: theme('colors.neutral.900'),
                 marginTop: '32px',
                 marginBottom: '32px',
                 paddingLeft: '20px',
+              },
+              'blockquote ~ figcaption ': {
+                color: theme('colors.neutral.900'),
+                fontStyle: 'italic',
               },
               h1: {
                 fontSize: '36px',
@@ -76,6 +84,7 @@ export const tailwindConfig: Config = {
                 marginBottom: '0',
               },
               figcaption: {
+                fontWeight: theme('fontStyle.italic'),
                 fontSize: '14px',
                 lineHeight: '20px',
                 marginTop: '12px',
@@ -88,6 +97,9 @@ export const tailwindConfig: Config = {
               },
               'h3 code': {
                 fontSize: '18px',
+              },
+              strong: {
+                fontWeight: theme('fontWeight.medium'),
               },
               pre: {
                 fontSize: '14px',
@@ -163,6 +175,7 @@ export const tailwindConfig: Config = {
                 lineHeight: '24px',
               },
               'thead th': {
+                fontWeight: theme('fontWeight.medium'),
                 paddingRight: '8px',
                 paddingBottom: '8px',
                 paddingLeft: '8px',

--- a/packages/config/tailwind/index.ts
+++ b/packages/config/tailwind/index.ts
@@ -1,6 +1,7 @@
 import { Config } from 'tailwindcss';
 import tailwindCssVariables from '@mertasan/tailwindcss-variables';
 import peerNextPlugin from '@storefront-ui/tw-plugin-peer-next';
+import tailwindTypography from '@tailwindcss/typography';
 
 export const tailwindConfig: Config = {
   content: [],
@@ -428,5 +429,5 @@ export const tailwindConfig: Config = {
       },
     },
   },
-  plugins: [require('@tailwindcss/typography'), tailwindCssVariables, peerNextPlugin],
+  plugins: [tailwindTypography, tailwindCssVariables, peerNextPlugin],
 };

--- a/packages/config/tailwind/index.ts
+++ b/packages/config/tailwind/index.ts
@@ -8,194 +8,194 @@ export const tailwindConfig: Config = {
     hoverOnlyWhenSupported: true,
   },
   theme: {
-    typography: ({ theme }) => ({
-      DEFAULT: {
-        css: [
-          {
-            color: theme('colors.neutral.900'),
-            fontSize: '16px',
-            fontFamily: theme('fontFamily.body'),
-            p: {
-              marginTop: '20px',
-              marginBottom: '20px',
-            },
-            '[class~="lead"]': {
-              fontSize: '20px',
-              lineHeight: '32px',
-              marginTop: '24px',
-              marginBottom: '24px',
-            },
-            blockquote: {
-              marginTop: '32px',
-              marginBottom: '32px',
-              paddingLeft: '20px',
-            },
-            h1: {
-              fontSize: '36px',
-              fontFamily: theme('fontFamily.headings'),
-              marginTop: '0',
-              marginBottom: '32px',
-              lineHeight: '40px',
-            },
-            h2: {
-              fontSize: '24px',
-              fontFamily: theme('fontFamily.headings'),
-              marginTop: '48px',
-              marginBottom: '24px',
-              lineHeight: '32px',
-            },
-            h3: {
-              fontSize: '20px',
-              fontFamily: theme('fontFamily.headings'),
-              marginTop: '32px',
-              marginBottom: '12px',
-              lineHeight: '32px',
-            },
-            h4: {
-              fontFamily: theme('fontFamily.headings'),
-              marginTop: '24px',
-              marginBottom: '8px',
-              lineHeight: '24px',
-            },
-            img: {
-              marginTop: '32px',
-              marginBottom: '32px',
-            },
-            video: {
-              marginTop: '32px',
-              marginBottom: '32px',
-            },
-            figure: {
-              marginTop: '32px',
-              marginBottom: '32px',
-            },
-            'figure > *': {
-              marginTop: '0',
-              marginBottom: '0',
-            },
-            figcaption: {
-              fontSize: '14px',
-              lineHeight: '20px',
-              marginTop: '12px',
-            },
-            code: {
-              fontSize: '14px',
-            },
-            'h2 code': {
-              fontSize: '21px',
-            },
-            'h3 code': {
-              fontSize: '18px',
-            },
-            pre: {
-              fontSize: '14px',
-              lineHeight: '24px',
-              marginTop: '24px',
-              marginBottom: '24px',
-              borderRadius: '6px',
-              paddingTop: '12px',
-              paddingRight: '16px',
-              paddingBottom: '12px',
-              paddingLeft: '16px',
-            },
-            ol: {
-              marginTop: '20px',
-              marginBottom: '20px',
-              paddingLeft: '20px',
-            },
-            ul: {
-              marginTop: '20px',
-              marginBottom: '20px',
-              paddingLeft: '26px',
-            },
-            li: {
-              marginTop: '8px',
-              marginBottom: '8px',
-            },
-            'ol > li': {
-              paddingLeft: '6px',
-            },
-            'ul > li': {
-              paddingLeft: '6px',
-            },
-            '> ul > li p': {
-              marginTop: '12px',
-              marginBottom: '12px',
-            },
-            '> ul > li > *:first-child': {
-              marginTop: '20px',
-            },
-            '> ul > li > *:last-child': {
-              marginBottom: '20px',
-            },
-            '> ol > li > *:first-child': {
-              marginTop: '20px',
-            },
-            '> ol > li > *:last-child': {
-              marginBottom: '20px',
-            },
-            'ul ul, ul ol, ol ul, ol ol': {
-              marginTop: '12px',
-              marginBottom: '12px',
-            },
-
-            hr: {
-              marginTop: '48px',
-              marginBottom: '48px',
-            },
-            'hr + *': {
-              marginTop: '0',
-            },
-            'h2 + *': {
-              marginTop: '0',
-            },
-            'h3 + *': {
-              marginTop: '0',
-            },
-            'h4 + *': {
-              marginTop: '0',
-            },
-
-            table: {
-              fontSize: '14px',
-              lineHeight: '24px',
-            },
-            'thead th': {
-              paddingRight: '8px',
-              paddingBottom: '8px',
-              paddingLeft: '8px',
-            },
-            'thead th:first-child': {
-              paddingLeft: '0',
-            },
-            'thead th:last-child': {
-              paddingRight: '0',
-            },
-            'tbody td, tfoot td': {
-              paddingTop: '8px',
-              paddingRight: '8px',
-              paddingBottom: '8px',
-              paddingLeft: '8px',
-            },
-            'tbody td:first-child, tfoot td:first-child': {
-              paddingLeft: '0',
-            },
-            'tbody td:last-child, tfoot td:last-child': {
-              paddingRight: '0',
-            },
-          },
-          {
-            '> :first-child': {
-              marginTop: '0',
-            },
-            '> :last-child': {
-              marginBottom: '0',
-            },
-          },
-        ],
-      },
-    }),
     extend: {
+      typography: ({ theme }) => ({
+        DEFAULT: {
+          css: [
+            {
+              color: theme('colors.neutral.900'),
+              fontSize: '16px',
+              fontFamily: theme('fontFamily.body'),
+              p: {
+                marginTop: '20px',
+                marginBottom: '20px',
+              },
+              '[class~="lead"]': {
+                fontSize: '20px',
+                lineHeight: '32px',
+                marginTop: '24px',
+                marginBottom: '24px',
+              },
+              blockquote: {
+                marginTop: '32px',
+                marginBottom: '32px',
+                paddingLeft: '20px',
+              },
+              h1: {
+                fontSize: '36px',
+                fontFamily: theme('fontFamily.headings'),
+                marginTop: '0',
+                marginBottom: '32px',
+                lineHeight: '40px',
+              },
+              h2: {
+                fontSize: '24px',
+                fontFamily: theme('fontFamily.headings'),
+                marginTop: '48px',
+                marginBottom: '24px',
+                lineHeight: '32px',
+              },
+              h3: {
+                fontSize: '20px',
+                fontFamily: theme('fontFamily.headings'),
+                marginTop: '32px',
+                marginBottom: '12px',
+                lineHeight: '32px',
+              },
+              h4: {
+                fontFamily: theme('fontFamily.headings'),
+                marginTop: '24px',
+                marginBottom: '8px',
+                lineHeight: '24px',
+              },
+              img: {
+                marginTop: '32px',
+                marginBottom: '32px',
+              },
+              video: {
+                marginTop: '32px',
+                marginBottom: '32px',
+              },
+              figure: {
+                marginTop: '32px',
+                marginBottom: '32px',
+              },
+              'figure > *': {
+                marginTop: '0',
+                marginBottom: '0',
+              },
+              figcaption: {
+                fontSize: '14px',
+                lineHeight: '20px',
+                marginTop: '12px',
+              },
+              code: {
+                fontSize: '14px',
+              },
+              'h2 code': {
+                fontSize: '21px',
+              },
+              'h3 code': {
+                fontSize: '18px',
+              },
+              pre: {
+                fontSize: '14px',
+                lineHeight: '24px',
+                marginTop: '24px',
+                marginBottom: '24px',
+                borderRadius: '6px',
+                paddingTop: '12px',
+                paddingRight: '16px',
+                paddingBottom: '12px',
+                paddingLeft: '16px',
+              },
+              ol: {
+                marginTop: '20px',
+                marginBottom: '20px',
+                paddingLeft: '20px',
+              },
+              ul: {
+                marginTop: '20px',
+                marginBottom: '20px',
+                paddingLeft: '26px',
+              },
+              li: {
+                marginTop: '8px',
+                marginBottom: '8px',
+              },
+              'ol > li': {
+                paddingLeft: '6px',
+              },
+              'ul > li': {
+                paddingLeft: '6px',
+              },
+              '> ul > li p': {
+                marginTop: '12px',
+                marginBottom: '12px',
+              },
+              '> ul > li > *:first-child': {
+                marginTop: '20px',
+              },
+              '> ul > li > *:last-child': {
+                marginBottom: '20px',
+              },
+              '> ol > li > *:first-child': {
+                marginTop: '20px',
+              },
+              '> ol > li > *:last-child': {
+                marginBottom: '20px',
+              },
+              'ul ul, ul ol, ol ul, ol ol': {
+                marginTop: '12px',
+                marginBottom: '12px',
+              },
+
+              hr: {
+                marginTop: '48px',
+                marginBottom: '48px',
+              },
+              'hr + *': {
+                marginTop: '0',
+              },
+              'h2 + *': {
+                marginTop: '0',
+              },
+              'h3 + *': {
+                marginTop: '0',
+              },
+              'h4 + *': {
+                marginTop: '0',
+              },
+
+              table: {
+                fontSize: '14px',
+                lineHeight: '24px',
+              },
+              'thead th': {
+                paddingRight: '8px',
+                paddingBottom: '8px',
+                paddingLeft: '8px',
+              },
+              'thead th:first-child': {
+                paddingLeft: '0',
+              },
+              'thead th:last-child': {
+                paddingRight: '0',
+              },
+              'tbody td, tfoot td': {
+                paddingTop: '8px',
+                paddingRight: '8px',
+                paddingBottom: '8px',
+                paddingLeft: '8px',
+              },
+              'tbody td:first-child, tfoot td:first-child': {
+                paddingLeft: '0',
+              },
+              'tbody td:last-child, tfoot td:last-child': {
+                paddingRight: '0',
+              },
+            },
+            {
+              '> :first-child': {
+                marginTop: '0',
+              },
+              '> :last-child': {
+                marginBottom: '0',
+              },
+            },
+          ],
+        },
+      }),
       outlineColor: ({ theme }) => ({
         DEFAULT: theme('colors.secondary.600'),
       }),

--- a/packages/config/tailwind/index.ts
+++ b/packages/config/tailwind/index.ts
@@ -11,7 +11,7 @@ export const tailwindConfig: Config = {
   },
   theme: {
     extend: {
-      typography: ( { theme } : ThemeConfig ) => ({
+      typography: ({ theme }: ThemeConfig) => ({
         DEFAULT: {
           css: [
             {
@@ -31,12 +31,14 @@ export const tailwindConfig: Config = {
                 color: theme('colors.neutral.900'),
               },
               blockquote: {
+                fontWeight: theme('fontWeight.medium'),
                 color: theme('colors.neutral.900'),
                 marginTop: '32px',
                 marginBottom: '32px',
                 paddingLeft: '20px',
               },
               'blockquote ~ figcaption ': {
+                fontWeight: theme('fontWeight.medium'),
                 color: theme('colors.neutral.900'),
                 fontStyle: 'italic',
               },

--- a/packages/config/tailwind/index.ts
+++ b/packages/config/tailwind/index.ts
@@ -8,6 +8,193 @@ export const tailwindConfig: Config = {
     hoverOnlyWhenSupported: true,
   },
   theme: {
+    typography: ({ theme }) => ({
+      DEFAULT: {
+        css: [
+          {
+            color: theme('colors.neutral.900'),
+            fontSize: '16px',
+            fontFamily: theme('fontFamily.body'),
+            p: {
+              marginTop: '20px',
+              marginBottom: '20px',
+            },
+            '[class~="lead"]': {
+              fontSize: '20px',
+              lineHeight: '32px',
+              marginTop: '24px',
+              marginBottom: '24px',
+            },
+            blockquote: {
+              marginTop: '32px',
+              marginBottom: '32px',
+              paddingLeft: '20px',
+            },
+            h1: {
+              fontSize: '36px',
+              fontFamily: theme('fontFamily.headings'),
+              marginTop: '0',
+              marginBottom: '32px',
+              lineHeight: '40px',
+            },
+            h2: {
+              fontSize: '24px',
+              fontFamily: theme('fontFamily.headings'),
+              marginTop: '48px',
+              marginBottom: '24px',
+              lineHeight: '32px',
+            },
+            h3: {
+              fontSize: '20px',
+              fontFamily: theme('fontFamily.headings'),
+              marginTop: '32px',
+              marginBottom: '12px',
+              lineHeight: '32px',
+            },
+            h4: {
+              fontFamily: theme('fontFamily.headings'),
+              marginTop: '24px',
+              marginBottom: '8px',
+              lineHeight: '24px',
+            },
+            img: {
+              marginTop: '32px',
+              marginBottom: '32px',
+            },
+            video: {
+              marginTop: '32px',
+              marginBottom: '32px',
+            },
+            figure: {
+              marginTop: '32px',
+              marginBottom: '32px',
+            },
+            'figure > *': {
+              marginTop: '0',
+              marginBottom: '0',
+            },
+            figcaption: {
+              fontSize: '14px',
+              lineHeight: '20px',
+              marginTop: '12px',
+            },
+            code: {
+              fontSize: '14px',
+            },
+            'h2 code': {
+              fontSize: '21px',
+            },
+            'h3 code': {
+              fontSize: '18px',
+            },
+            pre: {
+              fontSize: '14px',
+              lineHeight: '24px',
+              marginTop: '24px',
+              marginBottom: '24px',
+              borderRadius: '6px',
+              paddingTop: '12px',
+              paddingRight: '16px',
+              paddingBottom: '12px',
+              paddingLeft: '16px',
+            },
+            ol: {
+              marginTop: '20px',
+              marginBottom: '20px',
+              paddingLeft: '20px',
+            },
+            ul: {
+              marginTop: '20px',
+              marginBottom: '20px',
+              paddingLeft: '26px',
+            },
+            li: {
+              marginTop: '8px',
+              marginBottom: '8px',
+            },
+            'ol > li': {
+              paddingLeft: '6px',
+            },
+            'ul > li': {
+              paddingLeft: '6px',
+            },
+            '> ul > li p': {
+              marginTop: '12px',
+              marginBottom: '12px',
+            },
+            '> ul > li > *:first-child': {
+              marginTop: '20px',
+            },
+            '> ul > li > *:last-child': {
+              marginBottom: '20px',
+            },
+            '> ol > li > *:first-child': {
+              marginTop: '20px',
+            },
+            '> ol > li > *:last-child': {
+              marginBottom: '20px',
+            },
+            'ul ul, ul ol, ol ul, ol ol': {
+              marginTop: '12px',
+              marginBottom: '12px',
+            },
+
+            hr: {
+              marginTop: '48px',
+              marginBottom: '48px',
+            },
+            'hr + *': {
+              marginTop: '0',
+            },
+            'h2 + *': {
+              marginTop: '0',
+            },
+            'h3 + *': {
+              marginTop: '0',
+            },
+            'h4 + *': {
+              marginTop: '0',
+            },
+
+            table: {
+              fontSize: '14px',
+              lineHeight: '24px',
+            },
+            'thead th': {
+              paddingRight: '8px',
+              paddingBottom: '8px',
+              paddingLeft: '8px',
+            },
+            'thead th:first-child': {
+              paddingLeft: '0',
+            },
+            'thead th:last-child': {
+              paddingRight: '0',
+            },
+            'tbody td, tfoot td': {
+              paddingTop: '8px',
+              paddingRight: '8px',
+              paddingBottom: '8px',
+              paddingLeft: '8px',
+            },
+            'tbody td:first-child, tfoot td:first-child': {
+              paddingLeft: '0',
+            },
+            'tbody td:last-child, tfoot td:last-child': {
+              paddingRight: '0',
+            },
+          },
+          {
+            '> :first-child': {
+              marginTop: '0',
+            },
+            '> :last-child': {
+              marginBottom: '0',
+            },
+          },
+        ],
+      },
+    }),
     extend: {
       outlineColor: ({ theme }) => ({
         DEFAULT: theme('colors.secondary.600'),
@@ -241,5 +428,5 @@ export const tailwindConfig: Config = {
       },
     },
   },
-  plugins: [tailwindCssVariables, peerNextPlugin],
+  plugins: [require('@tailwindcss/typography'), tailwindCssVariables, peerNextPlugin],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3531,6 +3531,7 @@ __metadata:
     "@microsoft/api-documenter": ^7.21.5
     "@microsoft/api-extractor": ^7.34.4
     "@storefront-ui/tailwind-config": "workspace:^"
+    "@tailwindcss/typography": ^0.5.9
     "@vuepress/plugin-active-header-links": ^1.9.8
     "@vuepress/plugin-back-to-top": ^1.9.8
     "@vuepress/plugin-medium-zoom": ^1.9.8
@@ -3903,6 +3904,20 @@ __metadata:
   dependencies:
     defer-to-connect: ^1.0.1
   checksum: 4d9158061c5f397c57b4988cde33a163244e4f02df16364f103971957a32886beb104d6180902cbe8b38cb940e234d9f98a4e486200deca621923f62f50a06fe
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/typography@npm:^0.5.9":
+  version: 0.5.9
+  resolution: "@tailwindcss/typography@npm:0.5.9"
+  dependencies:
+    lodash.castarray: ^4.4.0
+    lodash.isplainobject: ^4.0.6
+    lodash.merge: ^4.6.2
+    postcss-selector-parser: 6.0.10
+  peerDependencies:
+    tailwindcss: "*"
+  checksum: b98e21bdd1798d7e4683499893c5c20ad43fcc8955d5d6eefbe1d30e98e9b6c28949ae8f276d39be9a66fafe843597717196bc5a0a2ac0f87ef86aa051ab9611
   languageName: node
   linkType: hard
 
@@ -16244,6 +16259,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.castarray@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "lodash.castarray@npm:4.4.0"
+  checksum: fca8c7047e0ae2738b0b2503fb00157ae0ff6d8a1b716f87ed715b22560e09de438c75b65e01a7e44ceb41c5b31dce2eb576e46db04beb9c699c498e03cbd00f
+  languageName: node
+  linkType: hard
+
 "lodash.clonedeep@npm:^4.5.0":
   version: 4.5.0
   resolution: "lodash.clonedeep@npm:4.5.0"
@@ -20172,6 +20194,16 @@ __metadata:
   dependencies:
     postcss: ^7.0.26
   checksum: b812832c06f9fc17b74b714f9c07de80fa770a1535a103b06b679f33b8e09caf60dff1e1eca489613f4ce2bb6439cd949b7d026c843aa9b45bb50f0168b75023
+  languageName: node
+  linkType: hard
+
+"postcss-selector-parser@npm:6.0.10":
+  version: 6.0.10
+  resolution: "postcss-selector-parser@npm:6.0.10"
+  dependencies:
+    cssesc: ^3.0.0
+    util-deprecate: ^1.0.2
+  checksum: 46afaa60e3d1998bd7adf6caa374baf857cc58d3ff944e29459c9a9e4680a7fe41597bd5b755fc81d7c388357e9bf67c0251d047c640a09f148e13606b8a8608
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3531,7 +3531,6 @@ __metadata:
     "@microsoft/api-documenter": ^7.21.5
     "@microsoft/api-extractor": ^7.34.4
     "@storefront-ui/tailwind-config": "workspace:^"
-    "@tailwindcss/typography": ^0.5.9
     "@vuepress/plugin-active-header-links": ^1.9.8
     "@vuepress/plugin-back-to-top": ^1.9.8
     "@vuepress/plugin-medium-zoom": ^1.9.8
@@ -3631,6 +3630,7 @@ __metadata:
     "@storefront-ui/tests-shared": "workspace:*"
     "@storefront-ui/tw-plugin-peer-next": "workspace:*"
     "@storefront-ui/typography": "workspace:*"
+    "@tailwindcss/typography": ^0.5.9
     "@types/lodash-es": ^4.17.6
     "@types/node": ^18.13.0
     "@types/react": ^18.0.28
@@ -3665,6 +3665,7 @@ __metadata:
     "@storefront-ui/tw-plugin-peer-next": "workspace:*"
     "@storefront-ui/typography": "workspace:*"
     "@storefront-ui/vue": "workspace:*"
+    "@tailwindcss/typography": ^0.5.9
     "@types/lodash-es": ^4.17.6
     "@vueuse/core": ^9.12.0
     autoprefixer: ^10.4.13
@@ -3704,6 +3705,7 @@ __metadata:
     "@storefront-ui/tests-shared": "workspace:*"
     "@storefront-ui/tw-plugin-peer-next": "workspace:*"
     "@storefront-ui/typography": "workspace:*"
+    "@tailwindcss/typography": ^0.5.9
     "@types/react": ^18.0.28
     "@types/react-dom": ^18.0.11
     "@vitejs/plugin-react": ^4.0.0-beta.0
@@ -3841,6 +3843,7 @@ __metadata:
     "@storefront-ui/tw-plugin-peer-next": "workspace:*"
     "@storefront-ui/typography": "workspace:*"
     "@storefront-ui/vue": "workspace:*"
+    "@tailwindcss/typography": ^0.5.9
     "@types/node": ^18.13.0
     "@vitejs/plugin-vue": ^4.0.0
     "@vue/tsconfig": ^0.1.3


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1239?atlOrigin=eyJpIjoiOWU5ZjVlNmE4OWYxNDJhYzlhOWYxMDY3Mzg3MGM3MWEiLCJwIjoiaiJ9

# Scope of work

- installed `tailwind/typography` plugin
- updated docs with examples of `prose` styling
- updated import of fonts with italic styles

# Screenshots of visual changes

<img width="1134" alt="Zrzut ekranu 2023-07-4 o 10 53 50" src="https://github.com/vuestorefront/storefront-ui/assets/41487496/62e8099c-922b-4288-8bc5-8861d77ed527">
<img width="1139" alt="Zrzut ekranu 2023-07-4 o 10 53 57" src="https://github.com/vuestorefront/storefront-ui/assets/41487496/57648d15-38af-4089-a36e-1201bf45eda0">
<img width="776" alt="Zrzut ekranu 2023-07-4 o 10 54 04" src="https://github.com/vuestorefront/storefront-ui/assets/41487496/e329577d-21c5-4343-95a2-cdf5e4a49eee">


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
