### PR TITLE
feat: add Tabs block

### DIFF
--- a/apps/docs/components/blocks/Tabs.md
+++ b/apps/docs/components/blocks/Tabs.md
@@ -1,0 +1,31 @@
+---
+layout: DefaultLayout
+hideBreadcrumbs: true
+description: Description
+hideToc: true
+---
+
+# Tabs
+
+The Tabs allows users to navigate between related sections of content, providing easy access to information such as product details, customer reviews, or related items. Each tab represents a distinct section, ensuring a seamless and intuitive browsing experience.
+
+Please note that if the total content within the tabs is substantial, it's important to consider potential performance impacts on page load time.
+
+## Accessibility notes
+
+Tabs blocks implement [WAI-ARIA Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).
+
+## Basic Tabs
+
+The Basic block offers essential tab functionality. This particular variant automatically activates when it receives focus, displaying its associated panel. It also provides horizontal scrolling functionality for tabs that exceed the viewport's width. This allows for seamless navigation and accessibility, ensuring that all tabs can be accessed and interacted with, even if they don't fit within the visible area. This block supports disabled tabs as well.
+
+<Showcase showcase-name="Tabs/TabsBasic" style="min-height: 350px">
+
+<!-- vue -->
+<<<../../preview/nuxt/pages/showcases/Tabs/TabsBasic.vue
+<!-- end vue -->
+<!-- react -->
+<<<../../preview/next/pages/showcases/Tabs/TabsBasic.tsx#source
+<!-- end react -->
+
+</Showcase>

--- a/apps/preview/next/pages/showcases/Tabs/TabsBasic.tsx
+++ b/apps/preview/next/pages/showcases/Tabs/TabsBasic.tsx
@@ -1,0 +1,122 @@
+import { ShowcasePageLayout } from '../../showcases';
+// #region source
+import { useRef, useState, type KeyboardEvent } from 'react';
+import classNames from 'classnames';
+
+function getPreviousIndex(current: number, elements: HTMLButtonElement[]) {
+  for (let index = current - 1; index >= 0; index -= 1) {
+    if (!elements[index].disabled) {
+      return index;
+    }
+  }
+  for (let index = elements.length - 1; index > -1; index -= 1) {
+    if (!elements[index].disabled) {
+      return index;
+    }
+  }
+  return current;
+}
+
+function getNextIndex(current: number, elements: HTMLButtonElement[]) {
+  for (let index = current + 1; index < elements.length; index += 1) {
+    if (!elements[index].disabled) {
+      return index;
+    }
+  }
+  for (let index = 0; index < elements.length; index += 1) {
+    if (!elements[index].disabled) {
+      return index;
+    }
+  }
+  return current;
+}
+
+interface Tab {
+  label: string;
+  disabled?: boolean;
+}
+
+const tabs: Tab[] = [
+  { label: 'Features' },
+  { label: 'Specifications', disabled: true },
+  { label: 'Reviews' },
+  { label: 'Support' },
+  { label: 'Delivery & Returns' },
+];
+
+export default function TabsBasic() {
+  const tablistRef = useRef<HTMLDivElement>(null);
+  const [activeTab, setActiveTab] = useState<Tab>(tabs[2]);
+  const isActive = (tab: Tab) => activeTab.label === tab.label;
+  const tabId = (label: string) => `${label}-tab`;
+  const panelId = (label: string) => `${label}-panel`;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    const elements = Array.from(tablistRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]') || []);
+    const current = elements.findIndex((el) => event.currentTarget === el);
+    const nextTab = getNextIndex(current, elements);
+    const prevTab = getPreviousIndex(current, elements);
+    const lastTab = elements.length - 1;
+
+    const goTo = (index: number) => () => {
+      event.stopPropagation();
+      event.preventDefault();
+      const goToElement = elements[index];
+      goToElement.focus();
+      goToElement.click();
+      goToElement.scrollIntoView();
+    };
+
+    const interactionsMap = new Map([
+      ['ArrowLeft', goTo(prevTab)],
+      ['ArrowRight', goTo(nextTab)],
+      ['Home', goTo(0)],
+      ['End', goTo(lastTab)],
+    ]);
+
+    const interaction = interactionsMap.get(event.key);
+    interaction?.();
+  };
+
+  return (
+    <>
+      <div
+        ref={tablistRef}
+        role="tablist"
+        aria-label="Select tab"
+        aria-orientation="horizontal"
+        className="flex gap-2 border-b border-b-neutral-200 pb-1 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+      >
+        {tabs.map((tab) => (
+          <button
+            key={tab.label}
+            type="button"
+            role="tab"
+            id={tabId(tab.label)}
+            aria-controls={panelId(tab.label)}
+            aria-selected={isActive(tab)}
+            disabled={tab.disabled}
+            tabIndex={isActive(tab) ? 0 : -1}
+            onClick={() => setActiveTab(tab)}
+            onKeyDown={handleKeyDown}
+            className={classNames(
+              'px-4 py-2 rounded-md font-medium whitespace-nowrap text-neutral-500 hover:enabled:bg-primary-100 hover:enabled:text-primary-800 active:enabled:bg-primary-200 active:enabled:text-primary-900 disabled:text-disabled-500 focus-visible:outline focus-visible:-outline-offset-2 focus-visible:shadow-[inset_0_0_0_4px_rgb(255,255,255)]',
+              { '!bg-neutral-100 !text-black': isActive(tab) },
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {tabs.map((tab) => (
+        <div key={tab.label} role="tabpanel" id={panelId(tab.label)} aria-labelledby={tabId(tab.label)}>
+          {isActive(tab) && <p className="p-4 text-neutral-500">Content for tab {tab.label}</p>}
+        </div>
+      ))}
+    </>
+  );
+}
+
+// #endregion source
+TabsBasic.getLayout = ShowcasePageLayout;

--- a/apps/preview/next/pages/showcases/Tabs/TabsBasic.tsx
+++ b/apps/preview/next/pages/showcases/Tabs/TabsBasic.tsx
@@ -46,7 +46,7 @@ const tabs: Tab[] = [
 
 export default function TabsBasic() {
   const tablistRef = useRef<HTMLDivElement>(null);
-  const [activeTab, setActiveTab] = useState<Tab>(tabs[2]);
+  const [activeTab, setActiveTab] = useState<Tab>(tabs[0]);
   const isActive = (tab: Tab) => activeTab.label === tab.label;
   const tabId = (label: string) => `${label}-tab`;
   const panelId = (label: string) => `${label}-panel`;

--- a/apps/preview/nuxt/pages/showcases/Tabs/TabsBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Tabs/TabsBasic.vue
@@ -1,0 +1,114 @@
+<template>
+  <div
+    ref="tablistRef"
+    role="tablist"
+    aria-label="Select tab"
+    aria-orientation="horizontal"
+    class="flex gap-2 border-b border-b-neutral-200 pb-1 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+  >
+    <button
+      v-for="tab in tabs"
+      :id="tabId(tab.label)"
+      :key="tab.label"
+      type="button"
+      role="tab"
+      :aria-controls="panelId(tab.label)"
+      :aria-selected="isActive(tab)"
+      :disabled="tab.disabled"
+      :tabindex="isActive(tab) ? 0 : -1"
+      :class="[
+        'px-4 py-2 rounded-md font-medium whitespace-nowrap text-neutral-500 hover:enabled:bg-primary-100 hover:enabled:text-primary-800 active:enabled:bg-primary-200 active:enabled:text-primary-900 disabled:text-disabled-500 focus-visible:outline focus-visible:-outline-offset-2 focus-visible:shadow-[inset_0_0_0_4px_rgb(255,255,255)]',
+        isActive(tab) ? '!bg-neutral-100 !text-black' : '',
+      ]"
+      @click="activeTab = tab"
+      @keydown="handleKeyDown"
+    >
+      {{ tab.label }}
+    </button>
+  </div>
+
+  <div
+    v-for="tab in tabs"
+    :id="panelId(tab.label)"
+    :key="tab.label"
+    role="tabpanel"
+    :aria-labelledby="tabId(tab.label)"
+  >
+    <p v-if="isActive(tab)" class="p-4 text-neutral-500">Content for tab: {{ tab.label }}</p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed } from 'vue';
+
+function getPreviousIndex(current: number, elements: HTMLButtonElement[]) {
+  for (let index = current - 1; index >= 0; index -= 1) {
+    if (!elements[index].disabled) {
+      return index;
+    }
+  }
+  for (let index = elements.length - 1; index > -1; index -= 1) {
+    if (!elements[index].disabled) {
+      return index;
+    }
+  }
+  return current;
+}
+
+function getNextIndex(current: number, elements: HTMLButtonElement[]) {
+  for (let index = current + 1; index < elements.length; index += 1) {
+    if (!elements[index].disabled) {
+      return index;
+    }
+  }
+  for (let index = 0; index < elements.length; index += 1) {
+    if (!elements[index].disabled) {
+      return index;
+    }
+  }
+  return current;
+}
+
+interface Tab {
+  label: string;
+  disabled?: boolean;
+}
+
+const tabs: Tab[] = [
+  { label: 'Features' },
+  { label: 'Specifications', disabled: true },
+  { label: 'Reviews' },
+  { label: 'Support' },
+  { label: 'Delivery & Returns' },
+];
+
+const tablistRef = ref<HTMLDivElement>();
+const activeTab = ref<Tab>(tabs[2]);
+const isActive = computed(() => (tab: Tab) => activeTab.value.label === tab.label);
+const tabId = (label: string) => `${label}-tab`;
+const panelId = (label: string) => `${label}-panel`;
+
+const handleKeyDown = (event: KeyboardEvent) => {
+  const elements = Array.from(tablistRef.value?.querySelectorAll<HTMLButtonElement>('[role="tab"]') || []);
+  const current = elements.findIndex((el) => event.currentTarget === el);
+  const nextTab = getNextIndex(current, elements);
+  const prevTab = getPreviousIndex(current, elements);
+  const lastTab = elements.length - 1;
+  const goTo = (index: number) => () => {
+    event.stopPropagation();
+    event.preventDefault();
+    const goToElement = elements[index];
+    goToElement.focus();
+    goToElement.click();
+    goToElement.scrollIntoView();
+  };
+  const interactionsMap = new Map([
+    ['ArrowLeft', goTo(prevTab)],
+    ['ArrowRight', goTo(nextTab)],
+    ['Home', goTo(0)],
+    ['End', goTo(lastTab)],
+  ]);
+  const interaction = interactionsMap.get(event.key);
+  interaction?.();
+};
+</script>

--- a/apps/preview/nuxt/pages/showcases/Tabs/TabsBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Tabs/TabsBasic.vue
@@ -83,7 +83,7 @@ const tabs: Tab[] = [
 ];
 
 const tablistRef = ref<HTMLDivElement>();
-const activeTab = ref<Tab>(tabs[2]);
+const activeTab = ref<Tab>(tabs[0]);
 const isActive = computed(() => (tab: Tab) => activeTab.value.label === tab.label);
 const tabId = (label: string) => `${label}-tab`;
 const panelId = (label: string) => `${label}-panel`;


### PR DESCRIPTION
# Related issue

Closes [SFUI2-1216](https://vsf.atlassian.net/browse/SFUI2-1216)

# Scope of work

This PR adds a new block page – Tabs, with one basic example.

# Screenshots of visual changes

https://github.com/vuestorefront/storefront-ui/assets/34419118/3bd253d7-7401-4024-8a79-387428ba4d24

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [ ] cypress tests created


[SFUI2-1216]: https://vsf.atlassian.net/browse/SFUI2-1216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ