### PR TITLE
test: add local setup for docs e2e tests [SFUI2-933]

### DIFF
--- a/apps/docs/development/testing.md
+++ b/apps/docs/development/testing.md
@@ -9,10 +9,30 @@ We run every test file against 2 different framework environments:
 
 ## Running tests
 
+### Component testing of vue, react components
+
 In the root directory of this repo run `yarn test` command to spin off 2 Cypress instances in parallel.
 
 For each of Cypress instance you need to choose different browser runner (e.g Edge and Chrome). That's because of the because of [Cypress bug](https://github.com/cypress-io/cypress/issues/5613).
 In opposition to running them simultaneously, framework test suites can also be run one-by-one. To do that navigate to either `apps/preview/next` (for `React` test suite) or `apps/preview/vue` (for `Vue` test suite) and run `yarn test` command.
+
+### E2E testing of documentation
+
+In order to run whole process:
+
+1. run development Nuxtjs so it would be available through http://localhost:3001
+2. run development Nextjs so it would be available through http://localhost:3002
+3. run documentation so it would be accessible through http://localhost:8080/v2
+4. wait for all above
+5. run cypress
+
+We can simply use script:
+
+`yarn test-e2e:docs`
+
+However if we want to run every part of pipeline manually we can run:
+
+`yarn dev` in one terminal, after that `yarn dev:docs` in second terminal and lastly `yarn test-docs` in third terminal.
 
 ## How to write tests
 

--- a/apps/docs/tests/cypress.config.ts
+++ b/apps/docs/tests/cypress.config.ts
@@ -6,11 +6,10 @@ export default defineConfig({
   viewportWidth: 1920,
   defaultCommandTimeout: 20000,
   video: false,
-  
   e2e: {
     baseUrl: 'http://localhost:8080/v2',
     specPattern: '../tests/**/*.cy.{js,jsx,ts,tsx}',
     supportFile: '../tests/support/index.ts',
   },
-  chromeWebSecurity: false
+  chromeWebSecurity: false,
 });

--- a/apps/docs/tests/package.json
+++ b/apps/docs/tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@storefront-ui/docs-tests",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "docs-test": "yarn cypress open --e2e"
+  },
+  "devDependencies": {
+    "cypress": "^12.16.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "test:ci:vue": "yarn build:peer-next && turbo run test:ci:vue",
     "test:ci-pre:react": "yarn build:peer-next && turbo run test:ci-pre:react",
     "test:ci:react": "yarn build:peer-next && turbo run test:ci:react",
+    "test-docs": "yarn turbo run docs-test",
+    "test-e2e:docs": "concurrently \"yarn wait-on http://localhost:8080/v2 http://localhost:3001 http://localhost:3002 && yarn test-docs\" \"yarn dev\" \"yarn dev:docs\"",
     "clean": "rimraf ./**/node_modules && rm yarn.lock",
     "clean:total": "rimraf ./**/node_modules ./**/.cache ./**/.turbo && rm yarn.lock",
     "createVueIcons": "node createIcons framework=vue input=packages/sfui/assets/ output=packages/sfui/frameworks/vue/components/SfIcons/ absolutePathToIconBase=@storefront-ui/vue",
@@ -69,7 +71,8 @@
     "rimraf": "^5.0.0",
     "tailwindcss": "^3.1.8",
     "turbo": "latest",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "wait-on": "^7.0.1"
   },
   "engines": {
     "npm": ">=8.19.1",

--- a/turbo.json
+++ b/turbo.json
@@ -136,6 +136,10 @@
         "build:tailwind-config"
       ],
       "cache": false
+    },
+    "docs-test": {
+      "dependsOn": [],
+      "cache": false
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,6 +2535,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hapi/hoek@npm:^9.0.0":
+  version: 9.3.0
+  resolution: "@hapi/hoek@npm:9.3.0"
+  checksum: 4771c7a776242c3c022b168046af4e324d116a9d2e1d60631ee64f474c6e38d1bb07092d898bf95c7bc5d334c5582798a1456321b2e53ca817d4e7c88bc25b43
+  languageName: node
+  linkType: hard
+
+"@hapi/topo@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "@hapi/topo@npm:5.1.0"
+  dependencies:
+    "@hapi/hoek": ^9.0.0
+  checksum: 604dfd5dde76d5c334bd03f9001fce69c7ce529883acf92da96f4fe7e51221bf5e5110e964caca287a6a616ba027c071748ab636ff178ad750547fba611d6014
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.8":
   version: 0.11.8
   resolution: "@humanwhocodes/config-array@npm:0.11.8"
@@ -3657,12 +3673,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sideway/address@npm:^4.1.3":
+  version: 4.1.4
+  resolution: "@sideway/address@npm:4.1.4"
+  dependencies:
+    "@hapi/hoek": ^9.0.0
+  checksum: b9fca2a93ac2c975ba12e0a6d97853832fb1f4fb02393015e012b47fa916a75ca95102d77214b2a29a2784740df2407951af8c5dde054824c65577fd293c4cdb
+  languageName: node
+  linkType: hard
+
+"@sideway/formula@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@sideway/formula@npm:3.0.1"
+  checksum: e4beeebc9dbe2ff4ef0def15cec0165e00d1612e3d7cea0bc9ce5175c3263fc2c818b679bd558957f49400ee7be9d4e5ac90487e1625b4932e15c4aa7919c57a
+  languageName: node
+  linkType: hard
+
+"@sideway/pinpoint@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@sideway/pinpoint@npm:2.0.0"
+  checksum: 0f4491e5897fcf5bf02c46f5c359c56a314e90ba243f42f0c100437935daa2488f20482f0f77186bd6bf43345095a95d8143ecf8b1f4d876a7bc0806aba9c3d2
+  languageName: node
+  linkType: hard
+
 "@sindresorhus/is@npm:^0.14.0":
   version: 0.14.0
   resolution: "@sindresorhus/is@npm:0.14.0"
   checksum: 971e0441dd44ba3909b467219a5e242da0fc584048db5324cfb8048148fa8dcc9d44d71e3948972c4f6121d24e5da402ef191420d1266a95f713bb6d6e59c98a
   languageName: node
   linkType: hard
+
+"@storefront-ui/docs-tests@workspace:apps/docs/tests":
+  version: 0.0.0-use.local
+  resolution: "@storefront-ui/docs-tests@workspace:apps/docs/tests"
+  dependencies:
+    cypress: ^12.16.0
+  languageName: unknown
+  linkType: soft
 
 "@storefront-ui/docs@workspace:apps/docs/components":
   version: 0.0.0-use.local
@@ -3741,6 +3788,7 @@ __metadata:
     tailwindcss: ^3.1.8
     turbo: latest
     typescript: ^4.9.5
+    wait-on: ^7.0.1
   languageName: unknown
   linkType: soft
 
@@ -6600,6 +6648,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^0.27.2":
+  version: 0.27.2
+  resolution: "axios@npm:0.27.2"
+  dependencies:
+    follow-redirects: ^1.14.9
+    form-data: ^4.0.0
+  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
+  languageName: node
+  linkType: hard
+
 "axobject-query@npm:^3.1.1":
   version: 3.1.1
   resolution: "axobject-query@npm:3.1.1"
@@ -8568,7 +8626,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.6, combined-stream@npm:~1.0.6":
+"combined-stream@npm:^1.0.6, combined-stream@npm:^1.0.8, combined-stream@npm:~1.0.6":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
   dependencies:
@@ -9724,6 +9782,58 @@ __metadata:
   version: 1.0.1
   resolution: "cyclist@npm:1.0.1"
   checksum: 3cc2fdeb358599ca0ea96f5ecf2fc530ccab7ed1f8aa1a894aebfacd2009281bd7380cb9b30db02a18cdd00b3ed1d7ce81a3b11fe56e33a6a0fe4424dc592fbe
+  languageName: node
+  linkType: hard
+
+"cypress@npm:^12.16.0":
+  version: 12.16.0
+  resolution: "cypress@npm:12.16.0"
+  dependencies:
+    "@cypress/request": ^2.88.10
+    "@cypress/xvfb": ^1.2.4
+    "@types/node": ^14.14.31
+    "@types/sinonjs__fake-timers": 8.1.1
+    "@types/sizzle": ^2.3.2
+    arch: ^2.2.0
+    blob-util: ^2.0.2
+    bluebird: ^3.7.2
+    buffer: ^5.6.0
+    cachedir: ^2.3.0
+    chalk: ^4.1.0
+    check-more-types: ^2.24.0
+    cli-cursor: ^3.1.0
+    cli-table3: ~0.6.1
+    commander: ^6.2.1
+    common-tags: ^1.8.0
+    dayjs: ^1.10.4
+    debug: ^4.3.4
+    enquirer: ^2.3.6
+    eventemitter2: 6.4.7
+    execa: 4.1.0
+    executable: ^4.1.1
+    extract-zip: 2.0.1
+    figures: ^3.2.0
+    fs-extra: ^9.1.0
+    getos: ^3.2.1
+    is-ci: ^3.0.0
+    is-installed-globally: ~0.4.0
+    lazy-ass: ^1.6.0
+    listr2: ^3.8.3
+    lodash: ^4.17.21
+    log-symbols: ^4.0.0
+    minimist: ^1.2.8
+    ospath: ^1.2.2
+    pretty-bytes: ^5.6.0
+    proxy-from-env: 1.0.0
+    request-progress: ^3.0.0
+    semver: ^7.3.2
+    supports-color: ^8.1.1
+    tmp: ~0.2.1
+    untildify: ^4.0.0
+    yauzl: ^2.10.0
+  bin:
+    cypress: bin/cypress
+  checksum: 551e2ec372f56a39a22526575b39bf9c6a110e5648ac1bf1c76460dfaebc3ca57d5537e7c206316284fe796ec76fa18f0493f3e040c92bd39c3720c9136fd5e4
   languageName: node
   linkType: hard
 
@@ -12705,7 +12815,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.9":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
@@ -12771,6 +12881,17 @@ __metadata:
   version: 0.6.1
   resolution: "forever-agent@npm:0.6.1"
   checksum: 766ae6e220f5fe23676bb4c6a99387cec5b7b62ceb99e10923376e27bfea72f3c3aeec2ba5f45f3f7ba65d6616965aa7c20b15002b6860833bb6e394dea546a8
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    mime-types: ^2.1.12
+  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
   languageName: node
   linkType: hard
 
@@ -15759,6 +15880,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"joi@npm:^17.7.0":
+  version: 17.9.2
+  resolution: "joi@npm:17.9.2"
+  dependencies:
+    "@hapi/hoek": ^9.0.0
+    "@hapi/topo": ^5.0.0
+    "@sideway/address": ^4.1.3
+    "@sideway/formula": ^3.0.1
+    "@sideway/pinpoint": ^2.0.0
+  checksum: 8c3709849293411c524e5a679dba7b42598a29a663478941767b8d5b06288611dece58803c468a2c7320cc2429a3e71e3d94337fe47aefcf6c22174dbd90b601
+  languageName: node
+  linkType: hard
+
 "js-cookie@npm:^2.2.1":
   version: 2.2.1
   resolution: "js-cookie@npm:2.2.1"
@@ -17421,7 +17555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
+"minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6, minimist@npm:^1.2.7, minimist@npm:^1.2.8":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
@@ -25737,6 +25871,21 @@ __metadata:
   bin:
     vuepress: cli.js
   checksum: 59813e292363601c178c32302f2fa3453ad56338aeeb02ef54e704d4ba050ae8160ab8101ce24a2b3269917e141d722de5c3a80ae7473424fb62c09b843c18ac
+  languageName: node
+  linkType: hard
+
+"wait-on@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "wait-on@npm:7.0.1"
+  dependencies:
+    axios: ^0.27.2
+    joi: ^17.7.0
+    lodash: ^4.17.21
+    minimist: ^1.2.7
+    rxjs: ^7.8.0
+  bin:
+    wait-on: bin/wait-on
+  checksum: 1e8a17d8ee6436f71d3ab82781ce31267481fcd7bbccde49b0f8124871e6e40a1acac3401f04f775ba6203853a5813352fa131620fc139914351f3b2894d573f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-933

# Scope of work

Adding turbo workspace package `@storefront-ui/docs-tests` that can be run in pair with other processes. 
Add readme how to run cypress e2e test for docs locally without needing run everything manually

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
