### PR TITLE
docs: add missing entry for browser support in nav [SFUI2-1161]

### DIFF
--- a/apps/docs/components/.vuepress/config.js
+++ b/apps/docs/components/.vuepress/config.js
@@ -62,7 +62,10 @@ const vueMenu = [
   {
     title: 'Getting Started',
     collapsable: true,
-    children: [['/vue/getting-started', 'Installation']],
+    children: [
+      ['/vue/getting-started', 'Installation'],
+      ['/vue/browser-support', 'Browser support'],
+    ],
   },
   {
     title: 'Customization',


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1161

# Scope of work

Followup PR for original implementation, missing `vue` entry in navigation results in not showing item in nav

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
