### PR TITLE
fix: modal examples button focus [SFUI2-1206]

### DIFF
--- a/.changeset/thick-moose-fix.md
+++ b/.changeset/thick-moose-fix.md
@@ -1,0 +1,5 @@
+---
+'@storefront-ui/vue': patch
+---
+
+Changed initial focus to the first element in modal on vue.

--- a/apps/preview/next/pages/showcases/Modal/ModalBasic.tsx
+++ b/apps/preview/next/pages/showcases/Modal/ModalBasic.tsx
@@ -1,13 +1,16 @@
 import { ShowcasePageLayout } from '../../showcases';
 // #region source
 import { SfModal, SfButton, SfIconClose, useDisclosure } from '@storefront-ui/react';
+import { useEffect, useRef } from 'react';
 
 export default function ModalDemo() {
   const { isOpen, open, close } = useDisclosure({ initialValue: false });
+  const buttonRef = useRef(null);
 
+  useEffect(() => (isOpen ? buttonRef.current?.blur() : buttonRef.current?.focus()), [isOpen]);
   return (
     <>
-      <SfButton type="button" onClick={open}>
+      <SfButton ref={buttonRef} type="button" onClick={open}>
         To Checkout
       </SfButton>
 

--- a/apps/preview/next/pages/showcases/Modal/ModalBasic.tsx
+++ b/apps/preview/next/pages/showcases/Modal/ModalBasic.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef } from 'react';
 
 export default function ModalDemo() {
   const { isOpen, open, close } = useDisclosure({ initialValue: false });
-  const buttonRef = useRef(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => (isOpen ? buttonRef.current?.blur() : buttonRef.current?.focus()), [isOpen]);
   return (

--- a/apps/preview/next/pages/showcases/Modal/ModalTransition.tsx
+++ b/apps/preview/next/pages/showcases/Modal/ModalTransition.tsx
@@ -1,6 +1,6 @@
 import { ShowcasePageLayout } from '../../showcases';
 // #region source
-import { useId, useRef } from 'react';
+import { useEffect, useId, useRef } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import { SfModal, SfButton, SfIconClose, useDisclosure } from '@storefront-ui/react';
 
@@ -10,10 +10,12 @@ export default function ModalTransition() {
   const descriptionId = useId();
   const modalRef = useRef<HTMLElement>(null);
   const backdropRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef(null);
+  useEffect(() => (isOpen ? buttonRef.current?.blur() : buttonRef.current?.focus()), [isOpen]);
 
   return (
     <>
-      <SfButton type="button" onClick={open}>
+      <SfButton ref={buttonRef} type="button" onClick={open}>
         To Checkout
       </SfButton>
 

--- a/apps/preview/next/pages/showcases/Modal/ModalTransition.tsx
+++ b/apps/preview/next/pages/showcases/Modal/ModalTransition.tsx
@@ -10,7 +10,7 @@ export default function ModalTransition() {
   const descriptionId = useId();
   const modalRef = useRef<HTMLElement>(null);
   const backdropRef = useRef<HTMLDivElement>(null);
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   useEffect(() => (isOpen ? buttonRef.current?.blur() : buttonRef.current?.focus()), [isOpen]);
 
   return (

--- a/apps/preview/next/pages/showcases/Modal/ModalTransition.tsx
+++ b/apps/preview/next/pages/showcases/Modal/ModalTransition.tsx
@@ -10,7 +10,7 @@ export default function ModalTransition() {
   const descriptionId = useId();
   const modalRef = useRef<HTMLElement>(null);
   const backdropRef = useRef<HTMLDivElement>(null);
-  const buttonRef = useRef(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
   useEffect(() => (isOpen ? buttonRef.current?.blur() : buttonRef.current?.focus()), [isOpen]);
 
   return (

--- a/apps/preview/nuxt/pages/showcases/Modal/ModalBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Modal/ModalBasic.vue
@@ -1,5 +1,5 @@
 <template>
-  <SfButton type="button" @click="open">To Checkout</SfButton>
+  <SfButton ref="buttonRef" type="button" @click="open">To Checkout</SfButton>
 
   <SfModal
     v-model="isOpen"
@@ -29,7 +29,13 @@
 </template>
 
 <script lang="ts" setup>
+import { ref, watch } from 'vue';
 import { SfModal, SfButton, SfIconClose, useDisclosure } from '@storefront-ui/vue';
-
+import { useFocus } from '@vueuse/core';
+const buttonRef = ref();
+const { focused } = useFocus(buttonRef);
 const { isOpen, open, close } = useDisclosure({ initialValue: false });
+watch(isOpen, (open) => {
+  open ? (focused.value = false) : (focused.value = true);
+});
 </script>

--- a/apps/preview/nuxt/pages/showcases/Modal/ModalBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Modal/ModalBasic.vue
@@ -1,6 +1,5 @@
 <template>
   <SfButton ref="buttonRef" type="button" @click="open">To Checkout</SfButton>
-
   <SfModal
     v-model="isOpen"
     class="max-w-[90%] md:max-w-lg"
@@ -32,10 +31,11 @@
 import { ref, watch } from 'vue';
 import { SfModal, SfButton, SfIconClose, useDisclosure } from '@storefront-ui/vue';
 import { useFocus } from '@vueuse/core';
+
 const buttonRef = ref();
 const { focused } = useFocus(buttonRef);
-const { isOpen, open, close } = useDisclosure({ initialValue: false });
+const { isOpen, open, close } = useDisclosure();
 watch(isOpen, (open) => {
-  open ? (focused.value = false) : (focused.value = true);
+  focused.value = !open;
 });
 </script>

--- a/apps/preview/nuxt/pages/showcases/Modal/ModalTransition.vue
+++ b/apps/preview/nuxt/pages/showcases/Modal/ModalTransition.vue
@@ -1,5 +1,5 @@
 <template>
-  <SfButton type="button" @click="open">To Checkout</SfButton>
+  <SfButton ref="buttonRef" type="button" @click="open">To Checkout</SfButton>
 
   <!-- Backdrop -->
   <transition
@@ -51,7 +51,13 @@
 </template>
 
 <script lang="ts" setup>
+import { ref, watch } from 'vue';
 import { SfModal, SfButton, SfIconClose, useDisclosure } from '@storefront-ui/vue';
-
+import { useFocus } from '@vueuse/core';
+const buttonRef = ref();
+const { focused } = useFocus(buttonRef);
 const { isOpen, open, close } = useDisclosure({ initialValue: false });
+watch(isOpen, (open) => {
+  open ? (focused.value = false) : (focused.value = true);
+});
 </script>

--- a/apps/preview/nuxt/pages/showcases/Modal/ModalTransition.vue
+++ b/apps/preview/nuxt/pages/showcases/Modal/ModalTransition.vue
@@ -54,10 +54,11 @@
 import { ref, watch } from 'vue';
 import { SfModal, SfButton, SfIconClose, useDisclosure } from '@storefront-ui/vue';
 import { useFocus } from '@vueuse/core';
+
 const buttonRef = ref();
 const { focused } = useFocus(buttonRef);
-const { isOpen, open, close } = useDisclosure({ initialValue: false });
+const { isOpen, open, close } = useDisclosure();
 watch(isOpen, (open) => {
-  open ? (focused.value = false) : (focused.value = true);
+  focused.value = !open;
 });
 </script>

--- a/packages/sfui/frameworks/vue/components/SfModal/SfModal.vue
+++ b/packages/sfui/frameworks/vue/components/SfModal/SfModal.vue
@@ -41,7 +41,7 @@ const onEscKeyDown = () => {
 useTrapFocus(modalRef, {
   trapTabs: true,
   activeState: modelValue,
-  initialFocus: false,
+  initialFocus: 0,
   initialFocusContainerFallback: true,
 });
 </script>


### PR DESCRIPTION
# Related issue
Closes [#1206](https://vsf.atlassian.net/browse/SFUI2-1206)

# Scope of work

In Modal showcases - added focus on the trigger button when the modal is closed.

# Screenshots of visual changes

![modal_focus](https://github.com/vuestorefront/storefront-ui/assets/32042425/1b962a2f-5b82-4ee1-930a-e102f747e562)

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
