### PR TITLE
fix: broaden tag prop typings in all components [SFUI2-1283]

### DIFF
--- a/packages/sfui/frameworks/vue/components/SfButton/SfButton.vue
+++ b/packages/sfui/frameworks/vue/components/SfButton/SfButton.vue
@@ -10,7 +10,7 @@ export const variantClasses = {
 </script>
 
 <script lang="ts" setup>
-import { type PropType, ConcreteComponent, computed, toRefs } from 'vue';
+import { type PropType, type ConcreteComponent, computed, toRefs } from 'vue';
 import { useAttrsRef, SfButtonSize, SfButtonVariant } from '@storefront-ui/vue';
 
 const props = defineProps({

--- a/packages/sfui/frameworks/vue/components/SfDrawer/SfDrawer.vue
+++ b/packages/sfui/frameworks/vue/components/SfDrawer/SfDrawer.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { type PropType, ref, toRefs, computed } from 'vue';
+import { type PropType, type ConcreteComponent, ref, toRefs, computed } from 'vue';
 import { onClickOutside } from '@vueuse/core';
 import { SfDrawerPlacement } from '@storefront-ui/vue';
 
@@ -13,7 +13,7 @@ const props = defineProps({
     default: SfDrawerPlacement.left,
   },
   tag: {
-    type: String,
+    type: [String, Object] as PropType<string | ConcreteComponent>,
     default: 'aside',
   },
   disableClickAway: {

--- a/packages/sfui/frameworks/vue/components/SfInput/SfInput.vue
+++ b/packages/sfui/frameworks/vue/components/SfInput/SfInput.vue
@@ -10,7 +10,7 @@ const getSizeClasses = {
 </script>
 
 <script lang="ts" setup>
-import type { PropType } from 'vue';
+import type { PropType, ConcreteComponent } from 'vue';
 import { computed, ref, toRefs } from 'vue';
 import { SfInputSize, useFocusVisible } from '@storefront-ui/vue';
 
@@ -20,7 +20,7 @@ const props = defineProps({
     default: '',
   },
   wrapperTag: {
-    type: String,
+    type: [String, Object] as PropType<string | ConcreteComponent>,
     default: 'span',
   },
   size: {

--- a/packages/sfui/frameworks/vue/components/SfListItem/SfListItem.vue
+++ b/packages/sfui/frameworks/vue/components/SfListItem/SfListItem.vue
@@ -7,7 +7,7 @@ export const sizeClasses = {
 </script>
 
 <script setup lang="ts">
-import { type PropType } from 'vue';
+import { type PropType, type ConcreteComponent } from 'vue';
 import { SfListItemSize } from '@storefront-ui/vue';
 
 defineProps({
@@ -24,7 +24,7 @@ defineProps({
     default: false,
   },
   tag: {
-    type: String,
+    type: [String, Object] as PropType<string | ConcreteComponent>,
     default: undefined,
   },
 });

--- a/packages/sfui/frameworks/vue/components/SfModal/SfModal.vue
+++ b/packages/sfui/frameworks/vue/components/SfModal/SfModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, toRefs } from 'vue';
+import { ref, toRefs, type PropType, type ConcreteComponent } from 'vue';
 import { onClickOutside } from '@vueuse/core';
 import { useTrapFocus } from '@storefront-ui/vue';
 
@@ -9,7 +9,7 @@ const props = defineProps({
     default: false,
   },
   tag: {
-    type: String,
+    type: [String, Object] as PropType<string | ConcreteComponent>,
     default: '',
   },
   disableClickAway: {

--- a/packages/sfui/frameworks/vue/components/SfScrollable/SfScrollable.vue
+++ b/packages/sfui/frameworks/vue/components/SfScrollable/SfScrollable.vue
@@ -4,7 +4,7 @@ export default {
 };
 </script>
 <script lang="ts" setup>
-import { computed, toRefs, type PropType, reactive } from 'vue';
+import { computed, toRefs, type PropType, type ConcreteComponent, reactive } from 'vue';
 import {
   ClassProp,
   SfScrollableDirection,
@@ -23,7 +23,7 @@ import {
 
 const props = defineProps({
   tag: {
-    type: String,
+    type: [String, Object] as PropType<string | ConcreteComponent>,
     default: 'div',
   },
   direction: {


### PR DESCRIPTION
# Related issue

Closes https://vsf.atlassian.net/browse/SFUI2-1283

# Scope of work

add support for custom components to all of the tag props in our library

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
