### PR TITLE
fix: hover on readonly and disabled

### DIFF
--- a/apps/preview/next/pages/examples/SfTextarea.tsx
+++ b/apps/preview/next/pages/examples/SfTextarea.tsx
@@ -110,9 +110,8 @@ function Example() {
           readOnly={state.get.readonly}
           onChange={onChange}
           className={classNames('w-full', {
-            '!bg-disabled-100 !ring-disabled-300 !ring-1': state.get.disabled || state.get.readonly,
-            '!text-disabled-500': state.get.disabled,
-            '!text-neutral-500': state.get.readonly,
+            '!bg-disabled-100 !ring-disabled-300 !ring-1 !text-disabled-500': state.get.disabled,
+            '!bg-disabled-100 !ring-disabled-300 !ring-1 !text-neutral-500': state.get.readonly,
           })}
         />
       </label>

--- a/apps/preview/next/pages/examples/SfTextarea.tsx
+++ b/apps/preview/next/pages/examples/SfTextarea.tsx
@@ -110,7 +110,9 @@ function Example() {
           readOnly={state.get.readonly}
           onChange={onChange}
           className={classNames('w-full', {
-            '!bg-disabled-100 !ring-disabled-300 !ring-1 !text-disabled-500': state.get.disabled || state.get.readonly,
+            '!bg-disabled-100 !ring-disabled-300 !ring-1': state.get.disabled || state.get.readonly,
+            '!text-disabled-500': state.get.disabled,
+            '!text-neutral-500': state.get.readonly,
           })}
         />
       </label>

--- a/apps/preview/next/pages/examples/SfTextarea.tsx
+++ b/apps/preview/next/pages/examples/SfTextarea.tsx
@@ -109,7 +109,9 @@ function Example() {
           disabled={state.get.disabled}
           readOnly={state.get.readonly}
           onChange={onChange}
-          className="w-full"
+          className={classNames('w-full', {
+            '!bg-disabled-100 !ring-disabled-300 !ring-1 !text-disabled-500': state.get.disabled || state.get.readonly,
+          })}
         />
       </label>
       <div className="flex justify-between">

--- a/apps/preview/nuxt/pages/examples/SfTextarea.vue
+++ b/apps/preview/nuxt/pages/examples/SfTextarea.vue
@@ -17,9 +17,8 @@
         :class="[
           'w-full',
           {
-            '!bg-disabled-100 !ring-disabled-300 !ring-1': disabled || readonly,
-            '!text-disabled-500': disabled,
-            '!text-neutral-500': readonly,
+            '!bg-disabled-100 !ring-disabled-300 !ring-1 !text-disabled-500': disabled,
+            '!bg-disabled-100 !ring-disabled-300 !ring-1 !text-neutral-500': readonly,
           },
         ]"
       />

--- a/apps/preview/nuxt/pages/examples/SfTextarea.vue
+++ b/apps/preview/nuxt/pages/examples/SfTextarea.vue
@@ -11,7 +11,16 @@
       >
         {{ label }}
       </span>
-      <SfTextarea v-bind="state" v-model="value" class="w-full" />
+      <SfTextarea
+        v-bind="state"
+        v-model="value"
+        :class="[
+          'w-full',
+          {
+            '!bg-disabled-100 !ring-disabled-300 !ring-1 !text-disabled-500': disabled || readonly,
+          },
+        ]"
+      />
     </label>
     <div class="flex justify-between">
       <div>

--- a/apps/preview/nuxt/pages/examples/SfTextarea.vue
+++ b/apps/preview/nuxt/pages/examples/SfTextarea.vue
@@ -17,7 +17,9 @@
         :class="[
           'w-full',
           {
-            '!bg-disabled-100 !ring-disabled-300 !ring-1 !text-disabled-500': disabled || readonly,
+            '!bg-disabled-100 !ring-disabled-300 !ring-1': disabled || readonly,
+            '!text-disabled-500': disabled,
+            '!text-neutral-500': readonly,
           },
         ]"
       />


### PR DESCRIPTION
# Related issue

Closes [#1296](https://vsf.atlassian.net/browse/SFUI2-1296)

# Scope of work

Added classes for `disabled` and `readonly` states in order not to show hover styles. 

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
