### PR TITLE
chore: missing key nextjs

### DIFF
--- a/apps/preview/next/pages/showcases/Drawer/TransitionAndCloseButton.tsx
+++ b/apps/preview/next/pages/showcases/Drawer/TransitionAndCloseButton.tsx
@@ -31,7 +31,7 @@ export default function DrawerWithTransition() {
     <>
       <fieldset>
         {options.map(({ label, value }) => (
-          <label className="flex items-center my-4 cursor-pointer">
+          <label className="flex items-center my-4 cursor-pointer" key={value}>
             <SfRadio
               name="placement"
               value={value}


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

During nextjs build there is error 
<img width="814" alt="image" src="https://github.com/vuestorefront/storefront-ui/assets/2566152/cd7bef90-1580-4614-a40c-f42b05b91fea">


# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
