### PR TITLE
chore: add a11y to vue eslint [SFUI2-1192]

### DIFF
--- a/apps/docs/components/blocks/Card.md
+++ b/apps/docs/components/blocks/Card.md
@@ -1,7 +1,7 @@
 ---
 layout: DefaultLayout
 hideBreadcrumbs: true
-description: The Card component contains content and actions that inform about a single subject. 
+description: The Card component contains content and actions that inform about a single subject.
 hideToc: true
 ---
 # Card
@@ -11,6 +11,10 @@ hideToc: true
 ## Default Card
 
 The default card view with a rectangle shaped image, a title, a description and a button for some additional actions.
+
+::: tip
+This block contain empty `anchor` element, this specific manipulation adds possibility to navigate with `tab` through whole card. With this structure we can click buttons inside or whole card itself. If root card element would be `anchor` element, we would not have possibility to click `button` inside.
+:::
 
 <Showcase showcase-name="Card/CardDefault" style="min-height: 600px">
 

--- a/apps/preview/nuxt/.eslintrc.js
+++ b/apps/preview/nuxt/.eslintrc.js
@@ -3,5 +3,7 @@ module.exports = {
   rules: {
     '@typescript-eslint/triple-slash-reference': 'off',
     'vue/multi-word-component-names': 'off',
+    // option controlComponents and defining component names does not work
+    'vuejs-accessibility/label-has-for': 'off',
   },
 };

--- a/apps/preview/nuxt/pages/showcases/Banners/Hero.vue
+++ b/apps/preview/nuxt/pages/showcases/Banners/Hero.vue
@@ -5,6 +5,7 @@
       <img
         src="http://localhost:3100/@assets/hero-bg-mobile.png"
         class="absolute w-full h-full z-[-1] md:object-cover"
+        alt="hero"
       />
     </picture>
     <div class="md:flex md:flex-row-reverse md:justify-center max-w[1536px] mx-auto md:min-h-[600px]">

--- a/apps/preview/nuxt/pages/showcases/Card/CardDefault.vue
+++ b/apps/preview/nuxt/pages/showcases/Card/CardDefault.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vuejs-accessibility/anchor-has-content -->
 <template>
   <div class="flex flex-wrap gap-4 lg:gap-6 lg:flex-nowrap">
     <div

--- a/apps/preview/nuxt/pages/showcases/Drawer/Placement.vue
+++ b/apps/preview/nuxt/pages/showcases/Drawer/Placement.vue
@@ -1,7 +1,7 @@
 <template>
   <label>
     Placement
-    <select class="p-2 mx-2 border-2 rounded border-primary-700" @change="chagePlacement">
+    <select class="p-2 mx-2 border-2 rounded border-primary-700" @blur="chagePlacement">
       <option value="top">top</option>
       <option value="right">right</option>
       <option value="bottom">bottom</option>

--- a/apps/preview/nuxt/pages/showcases/MegaMenu/MegaMenuNavigation.vue
+++ b/apps/preview/nuxt/pages/showcases/MegaMenu/MegaMenuNavigation.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vuejs-accessibility/no-static-element-interactions -->
 <template>
   <div class="w-full h-full">
     <header ref="referenceRef" class="relative">

--- a/apps/preview/nuxt/pages/showcases/ProductCard/Details.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductCard/Details.vue
@@ -46,7 +46,6 @@
               :id="inputId"
               v-model="count"
               type="number"
-              role="spinbutton"
               class="grow appearance-none mx-2 w-8 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
               :min="min"
               :max="max"

--- a/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardHorizontal.vue
+++ b/apps/preview/nuxt/pages/showcases/ProductCard/ProductCardHorizontal.vue
@@ -51,7 +51,6 @@
               :id="inputId"
               v-model="count"
               type="number"
-              role="spinbutton"
               class="appearance-none mx-2 w-8 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
               :min="min"
               :max="max"

--- a/apps/preview/nuxt/pages/showcases/QuantitySelector/OutOfStock.vue
+++ b/apps/preview/nuxt/pages/showcases/QuantitySelector/OutOfStock.vue
@@ -7,7 +7,6 @@
       <input
         :id="inputId"
         type="number"
-        role="spinbutton"
         disabled
         class="appearance-none mx-2 w-8 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
         placeholder="-"

--- a/apps/preview/nuxt/pages/showcases/QuantitySelector/QuantitySelector.vue
+++ b/apps/preview/nuxt/pages/showcases/QuantitySelector/QuantitySelector.vue
@@ -17,7 +17,6 @@
         :id="inputId"
         v-model="count"
         type="number"
-        role="spinbutton"
         class="appearance-none mx-2 w-8 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
         :min="min"
         :max="max"

--- a/apps/preview/nuxt/pages/showcases/QuantitySelector/Rounded.vue
+++ b/apps/preview/nuxt/pages/showcases/QuantitySelector/Rounded.vue
@@ -15,7 +15,6 @@
       :id="inputId"
       v-model="count"
       type="number"
-      role="spinbutton"
       class="appearance-none px-2 mx-2 w-12 text-center bg-transparent font-medium [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-inner-spin-button]:display-none [&::-webkit-inner-spin-button]:m-0 [&::-webkit-outer-spin-button]:display-none [&::-webkit-outer-spin-button]:m-0 [-moz-appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none disabled:placeholder-disabled-900 focus-visible:outline focus-visible:outline-offset focus-visible:rounded-sm"
       :min="min"
       :max="max"

--- a/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownDisabled.vue
+++ b/apps/preview/nuxt/pages/showcases/SelectDropdown/SelectDropdownDisabled.vue
@@ -16,8 +16,8 @@
           ? 'bg-disabled-100 ring-disabled-300 cursor-not-allowed'
           : 'ring-neutral-300 hover:ring-primary-700 active:ring-primary-700 active:ring-2 focus:ring-primary-700 focus:ring-2 cursor-pointer'
       "
-      :tabindex="isDisabled ? undefined : 0"
-      @keydown.space="toggle()"
+      tabindex="0"
+      @keydown.space="!isDisabled && toggle()"
       @click="!isDisabled && toggle()"
     >
       <template v-if="selectedOption">{{ selectedOption.label }}</template>

--- a/packages/config/eslint/package.json
+++ b/packages/config/eslint/package.json
@@ -21,6 +21,7 @@
     "eslint-config-prettier": "^8.6.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-cypress": "^2.12.1",
-    "eslint-plugin-vue": "^9.9.0"
+    "eslint-plugin-vue": "^9.9.0",
+    "eslint-plugin-vuejs-accessibility": "^2.1.0"
   }
 }

--- a/packages/config/eslint/vue.js
+++ b/packages/config/eslint/vue.js
@@ -17,6 +17,7 @@ module.exports = {
       "required": {
         "some": ["nesting", "id"]
       }
-    }]
+    }],
+    "vuejs-accessibility/mouse-events-have-key-events": "off"
   }
 };

--- a/packages/config/eslint/vue.js
+++ b/packages/config/eslint/vue.js
@@ -1,3 +1,22 @@
 module.exports = {
-  extends: ["@vue-storefront/eslint-config/vue3", "prettier"],
+  extends: ["@vue-storefront/eslint-config/vue3", "prettier", "plugin:vuejs-accessibility/recommended"],
+  plugins: ["vuejs-accessibility"],
+  rules: {
+    "vuejs-accessibility/form-control-has-label": [
+      'off',
+      {
+        labelComponents: [],
+        labelAttributes: [],
+        controlComponents: [],
+        assert: 'both',
+        depth: 25,
+      },
+    ],
+    // Bug https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/issues/54
+    "vuejs-accessibility/label-has-for": ["error", {
+      "required": {
+        "some": ["nesting", "id"]
+      }
+    }]
+  }
 };

--- a/packages/config/eslint/vue.js
+++ b/packages/config/eslint/vue.js
@@ -3,7 +3,7 @@ module.exports = {
   plugins: ["vuejs-accessibility"],
   rules: {
     "vuejs-accessibility/form-control-has-label": [
-      'off',
+      "off",
       {
         labelComponents: [],
         labelAttributes: [],
@@ -14,8 +14,8 @@ module.exports = {
     ],
     // Bug https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/issues/54
     "vuejs-accessibility/label-has-for": ["error", {
-      "required": {
-        "some": ["nesting", "id"]
+      required: {
+        some: ["nesting", "id"],
       }
     }],
     "vuejs-accessibility/mouse-events-have-key-events": "off"

--- a/packages/sfui/frameworks/react/components/SfSwitch/SfSwitch.tsx
+++ b/packages/sfui/frameworks/react/components/SfSwitch/SfSwitch.tsx
@@ -17,6 +17,7 @@ const SfSwitch = forwardRef<HTMLInputElement, SfSwitchProps>(
       role="switch"
       {...attributes}
       data-testid="switch"
+      aria-checked={attributes?.checked}
     />
   ),
 );

--- a/packages/sfui/frameworks/vue/components/SfAccordionItem/SfAccordionItem.vue
+++ b/packages/sfui/frameworks/vue/components/SfAccordionItem/SfAccordionItem.vue
@@ -14,6 +14,8 @@ defineEmits<{
 }>();
 </script>
 
+<!-- eslint-disable vuejs-accessibility/no-static-element-interactions -->
+<!-- eslint-disable vuejs-accessibility/click-events-have-key-events -->
 <template>
   <details :open="modelValue" data-testid="accordion-item">
     <summary

--- a/packages/sfui/frameworks/vue/components/SfRatingButton/SfRatingButton.vue
+++ b/packages/sfui/frameworks/vue/components/SfRatingButton/SfRatingButton.vue
@@ -72,6 +72,8 @@ const handleHoverOut = () => {
 };
 </script>
 
+<!-- eslint-disable vuejs-accessibility/mouse-events-have-key-events -->
+<!-- eslint-disable vuejs-accessibility/no-static-element-interactions -->
 <template>
   <div role="radiogroup" class="flex" data-testid="ratingbutton">
     <label

--- a/packages/sfui/frameworks/vue/components/SfRatingButton/SfRatingButton.vue
+++ b/packages/sfui/frameworks/vue/components/SfRatingButton/SfRatingButton.vue
@@ -72,7 +72,6 @@ const handleHoverOut = () => {
 };
 </script>
 
-<!-- eslint-disable vuejs-accessibility/mouse-events-have-key-events -->
 <!-- eslint-disable vuejs-accessibility/no-static-element-interactions -->
 <template>
   <div role="radiogroup" class="flex" data-testid="ratingbutton">

--- a/packages/sfui/frameworks/vue/components/SfSwitch/SfSwitch.vue
+++ b/packages/sfui/frameworks/vue/components/SfSwitch/SfSwitch.vue
@@ -28,6 +28,7 @@ const proxyChecked = computed({
 });
 </script>
 
+<!-- switchRef?.checked is used instead of model because model is value collection of multiple inputs, we need to have this one input check value -->
 <template>
   <input
     ref="switchRef"

--- a/packages/sfui/frameworks/vue/components/SfSwitch/SfSwitch.vue
+++ b/packages/sfui/frameworks/vue/components/SfSwitch/SfSwitch.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { InputHTMLAttributes, PropType, toRefs, computed } from 'vue';
+import { type InputHTMLAttributes, type PropType, toRefs, computed, ref } from 'vue';
 
 const props = defineProps({
   modelValue: {
@@ -21,6 +21,7 @@ const emit = defineEmits<{
   (event: 'update:modelValue', param: InputHTMLAttributes['checked']): void;
 }>();
 
+const switchRef = ref();
 const proxyChecked = computed({
   get: () => modelValue?.value,
   set: (value) => emit('update:modelValue', value),
@@ -29,6 +30,7 @@ const proxyChecked = computed({
 
 <template>
   <input
+    ref="switchRef"
     v-model="proxyChecked"
     :class="[
       `appearance-none h-5 min-w-[36px] bg-transparent border-2 border-gray-500 rounded-full relative ease-in-out duration-300 hover:border-primary-800 hover:before:checked:bg-white checked:before:left-1/2 checked:before:ml-0 checked:before:mr-0.5 disabled:before:bg-gray-500/50 hover:before:bg-primary-800 active:border-primary-800 active:before:bg-primary-800 checked:bg-none checked:bg-primary-700 checked:border-primary-700 checked:before:bg-white hover:checked:bg-primary-800 hover:checked:border-primary-800 disabled:border-gray-500/50 checked:disabled:before:bg-white checked:disabled:bg-gray-500/50 checked:disabled:border-0 before:transition-all  before:w-3.5 before:h-3.5 before:bg-gray-500 before:absolute before:top-0 before:bottom-0 before:my-auto before:rounded-full before:left-0 before:ml-0.5 before:ease-in-out before:duration-300 cursor-pointer disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-offset`,
@@ -40,5 +42,6 @@ const proxyChecked = computed({
     type="checkbox"
     role="switch"
     data-testid="switch"
+    :aria-checked="switchRef?.checked"
   />
 </template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3498,6 +3498,7 @@ __metadata:
     eslint-import-resolver-alias: ^1.1.2
     eslint-plugin-cypress: ^2.12.1
     eslint-plugin-vue: ^9.9.0
+    eslint-plugin-vuejs-accessibility: ^2.1.0
   languageName: unknown
   linkType: soft
 
@@ -6239,6 +6240,15 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 83644b56493e89a254bae05702abf3a1101b4fa4d0ca31df1c9985275a5a5bd47b3c27b7fa0b71098d41114d8ca000e6ed90cad764b306f8a503665e4d517ced
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:>=5.0.0":
+  version: 5.3.0
+  resolution: "aria-query@npm:5.3.0"
+  dependencies:
+    dequal: ^2.0.3
+  checksum: 305bd73c76756117b59aba121d08f413c7ff5e80fa1b98e217a3443fcddb9a232ee790e24e432b59ae7625aebcf4c47cb01c2cac872994f0b426f5bdfcd96ba9
   languageName: node
   linkType: hard
 
@@ -10339,6 +10349,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 8679b850e1a3d0ebbc46ee780d5df7b478c23f335887464023a631d1b9af051ad4a6595a44220f9ff8ff95a8ddccf019b5ad778a976fd7bbf77383d36f412f90
+  languageName: node
+  linkType: hard
+
 "des.js@npm:^1.0.0":
   version: 1.0.1
   resolution: "des.js@npm:1.0.1"
@@ -10786,6 +10803,13 @@ __metadata:
     minimalistic-assert: ^1.0.1
     minimalistic-crypto-utils: ^1.0.1
   checksum: d56d21fd04e97869f7ffcc92e18903b9f67f2d4637a23c860492fbbff5a3155fd9ca0184ce0c865dd6eb2487d234ce9551335c021c376cd2d3b7cb749c7d10f4
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^10.0.0":
+  version: 10.2.1
+  resolution: "emoji-regex@npm:10.2.1"
+  checksum: 1aa2d16881c56531fdfc03d0b36f5c2b6221cc4097499a5665b88b711dc3fb4d5b8804f0ca6f00c56e5dcf89bac75f0487eee85da1da77df3a33accc6ecbe426
   languageName: node
   linkType: hard
 
@@ -12011,6 +12035,19 @@ __metadata:
   peerDependencies:
     eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
   checksum: 63a7d90194fe36b605c74fcb43d0f4d41d996b0d8733b89e1979a5fe1d400ee8a6d74d9b5cc9fbdff532f1c0aec93019e93f775a1f1b693d703b97ad1b932543
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-vuejs-accessibility@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "eslint-plugin-vuejs-accessibility@npm:2.1.0"
+  dependencies:
+    aria-query: ">=5.0.0"
+    emoji-regex: ^10.0.0
+    vue-eslint-parser: ^9.0.1
+  peerDependencies:
+    eslint: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 03fab0f9ec70c297dd0c6148faec86138b025eb38cc9337adc01bc0036602f999b0be322a378822e282f8648c5f834fd2d01fc04f2b15d52f796cb0f9f4dd544
   languageName: node
   linkType: hard
 
@@ -25968,6 +26005,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vue-eslint-parser@npm:^9.0.1, vue-eslint-parser@npm:^9.1.1":
+  version: 9.3.1
+  resolution: "vue-eslint-parser@npm:9.3.1"
+  dependencies:
+    debug: ^4.3.4
+    eslint-scope: ^7.1.1
+    eslint-visitor-keys: ^3.3.0
+    espree: ^9.3.1
+    esquery: ^1.4.0
+    lodash: ^4.17.21
+    semver: ^7.3.6
+  peerDependencies:
+    eslint: ">=6.0.0"
+  checksum: 6d1476b45fcc5b456a1e5c0f33ec695cf1d392ca6113250d5e3441e6cf3b2a0ec28a9455699363641dfb7c48358f215db07856c98385a31ace9bc58196f4156e
+  languageName: node
+  linkType: hard
+
 "vue-eslint-parser@npm:^9.0.3, vue-eslint-parser@npm:^9.3.0":
   version: 9.3.0
   resolution: "vue-eslint-parser@npm:9.3.0"
@@ -25982,23 +26036,6 @@ __metadata:
   peerDependencies:
     eslint: ">=6.0.0"
   checksum: 9bdf375655c405f49a6e46e20127e42e2cb03ec63e811baf9798da7b881769653bb56aba7007d7e6584b8b22c14f0ffbdaf8fa3a902bd52ce9ff947b78e55188
-  languageName: node
-  linkType: hard
-
-"vue-eslint-parser@npm:^9.1.1":
-  version: 9.3.1
-  resolution: "vue-eslint-parser@npm:9.3.1"
-  dependencies:
-    debug: ^4.3.4
-    eslint-scope: ^7.1.1
-    eslint-visitor-keys: ^3.3.0
-    espree: ^9.3.1
-    esquery: ^1.4.0
-    lodash: ^4.17.21
-    semver: ^7.3.6
-  peerDependencies:
-    eslint: ">=6.0.0"
-  checksum: 6d1476b45fcc5b456a1e5c0f33ec695cf1d392ca6113250d5e3441e6cf3b2a0ec28a9455699363641dfb7c48358f215db07856c98385a31ace9bc58196f4156e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1192

# Scope of work

Follow-up for already done eslint company config migration ticket. React has `a11y` plugin for eslint, this PR adds this as well into `vue` eslint

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
