### PR TITLE
fix: importing types from a local file instead of the package in SfBadge

### DIFF
--- a/.changeset/fast-pugs-warn.md
+++ b/.changeset/fast-pugs-warn.md
@@ -1,0 +1,5 @@
+---
+'@storefront-ui/react': patch
+---
+
+Import types from package in SfBadge

--- a/packages/sfui/frameworks/react/components/SfBadge/SfBadge.tsx
+++ b/packages/sfui/frameworks/react/components/SfBadge/SfBadge.tsx
@@ -1,6 +1,6 @@
 import { SfBadgePlacement } from '@storefront-ui/shared';
 import classNames from 'classnames';
-import type { SfBadgeProps } from './types';
+import type { SfBadgeProps } from '@storefront-ui/react;
 
 export default function SfBadge({
   content,

--- a/packages/sfui/frameworks/react/components/SfBadge/SfBadge.tsx
+++ b/packages/sfui/frameworks/react/components/SfBadge/SfBadge.tsx
@@ -1,6 +1,6 @@
 import { SfBadgePlacement } from '@storefront-ui/shared';
 import classNames from 'classnames';
-import type { SfBadgeProps } from '@storefront-ui/react;
+import type { SfBadgeProps } from '@storefront-ui/react';
 
 export default function SfBadge({
   content,

--- a/packages/sfui/frameworks/react/components/SfBadge/index.ts
+++ b/packages/sfui/frameworks/react/components/SfBadge/index.ts
@@ -1,3 +1,3 @@
-export { default as SfBadge } from './SfBadge';
-
 export * from './types';
+
+export { default as SfBadge } from './SfBadge';

--- a/packages/sfui/frameworks/react/components/SfRadio/index.ts
+++ b/packages/sfui/frameworks/react/components/SfRadio/index.ts
@@ -1,3 +1,3 @@
-export { default as SfRadio } from './SfRadio';
-
 export * from './types';
+
+export { default as SfRadio } from './SfRadio';

--- a/packages/sfui/frameworks/react/components/SfRatingButton/index.ts
+++ b/packages/sfui/frameworks/react/components/SfRatingButton/index.ts
@@ -1,3 +1,3 @@
-export { default as SfRatingButton } from './SfRatingButton';
-
 export * from './types';
+
+export { default as SfRatingButton } from './SfRatingButton';


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

I just changed the import statement to point to the package

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
