### PR TITLE
fix(SfScrollable): aria label casing [SFUI2-1306]

### DIFF
--- a/.changeset/weak-terms-search.md
+++ b/.changeset/weak-terms-search.md
@@ -1,0 +1,5 @@
+---
+'@storefront-ui/react': patch
+---
+
+Fix `aria-label` casing in `SfScrollable`

--- a/packages/sfui/frameworks/react/components/SfScrollable/SfScrollable.tsx
+++ b/packages/sfui/frameworks/react/components/SfScrollable/SfScrollable.tsx
@@ -90,7 +90,7 @@ const SfScrollable = polymorphicForwardRef<typeof defaultScrollableTag, SfScroll
             size: 'lg',
             disabled: prevDisabled,
             slotPrefix: <SfIconChevronLeft />,
-            ariaLabel: buttonPrevAriaLabel,
+            "aria-label": buttonPrevAriaLabel,
             className: classNames(
               classNameButton,
               isFloating ? 'disabled:hidden' : 'disabled:!ring-disabled-300 disabled:!text-disabled-500',
@@ -112,7 +112,7 @@ const SfScrollable = polymorphicForwardRef<typeof defaultScrollableTag, SfScroll
             size: 'lg',
             disabled: nextDisabled,
             slotPrefix: <SfIconChevronRight />,
-            ariaLabel: buttonNextAriaLabel,
+            "aria-label": buttonNextAriaLabel,
             className: classNames(
               classNameButton,
               isFloating ? 'disabled:hidden' : 'disabled:!ring-disabled-300 disabled:!text-disabled-500',


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1306

# Scope of work

Changed `ariaLabel` attribute to `aria-label`.

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [x] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
