### PR TITLE
fix(SfSelect): disabled state attributes [SFUI2-1307]

### DIFF
--- a/.changeset/wise-bananas-build.md
+++ b/.changeset/wise-bananas-build.md
@@ -1,0 +1,6 @@
+---
+'@storefront-ui/react': patch
+'@storefront-ui/vue': patch
+---
+
+Remove redundant `selected` attribute from `SfSelect` placeholder

--- a/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
+++ b/packages/sfui/frameworks/react/components/SfSelect/SfSelect.tsx
@@ -64,7 +64,6 @@ export default function SfSelect(props: SfSelectProps) {
         {placeholder && (
           <option
             disabled
-            selected
             hidden
             value=""
             className={classNames('bg-neutral-300 text-sm', {

--- a/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
+++ b/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
@@ -84,7 +84,6 @@ const modelProxy = computed({
       <option
         v-if="placeholder"
         disabled
-        selected
         hidden
         class="text-sm bg-neutral-300"
         value=""

--- a/packages/tests/components/SfSelect/SfSelect.cy.tsx
+++ b/packages/tests/components/SfSelect/SfSelect.cy.tsx
@@ -99,7 +99,7 @@ describe('SfSelect', () => {
     it('should change value/modelValue', () => {
       initializeComponent();
 
-      page().isNotDisabled().hasSelectedOption('red');
+      page().isNotDisabled().hasSelectedOption('blue');
       cy.then(() => {
         expect(onChangeSpy).calledOnceWith();
         page().makeSnapshot();


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1307

# Scope of work

Removed redundant `selected` attribute from `SfSelect` placeholder. It caused a warning: Warning: Use the defaultValue or value props on `<select>` instead of setting selected on `<option>`

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
