### PR TITLE
chore: disable eslint-config-next rule for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>vuestorefront/.github:renovate-config"]
+  "extends": ["github>vuestorefront/.github:renovate-config"],
+  "packageRules": [
+    {
+      "#": "#TODO: check if eslint-config-next does not use anymore canary version (13.4.13 still uses) for eslint-plugin-react-hooks package",
+      "matchPackagePatterns": [
+        "eslint-config-next"
+      ],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

Because we cannot update `eslint-config-next` dependency we have to disable auto update dependency by renovate. 
Why we cannot update it? because `eslint-config-next` internally it has 
```
"eslint-plugin-react-hooks": "5.0.0-canary-7118f5dd7-20230705"
``` 
as dependency https://github.com/vercel/next.js/blob/canary/packages/eslint-config-next/package.json#L21C5-L21C67 
Which cause 2 problems
1. For your internal config we use package `eslint-plugin-react-hooks` 4.9... so those 2 packages are incompatible
2. we cant update our internal config because they use `canary` which for me is bad practice to use version that is not stable

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
