### PR TITLE
chore: update renovate.config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": ["github>vuestorefront/.github:renovate-config"],
   "packageRules": [
     {
-      "#": "#TODO: check if eslint-config-next does not use anymore canary version (13.4.13 still uses) for eslint-plugin-react-hooks package",
       "matchPackagePatterns": [
         "eslint-config-next"
       ],


### PR DESCRIPTION
# Related issue

https://github.com/vuestorefront/storefront-ui/issues/2958

Closes #

# Scope of work

Possibly `#` breaks renovate config

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
