### PR TITLE
docs: add ai-assistant

### DIFF
--- a/apps/docs/components/.vuepress/theme/layouts/EmbedLayout.vue
+++ b/apps/docs/components/.vuepress/theme/layouts/EmbedLayout.vue
@@ -1,0 +1,17 @@
+<template>
+  <Fullscreen>
+    <VsfPage class="-mt-7" />
+  </Fullscreen>
+</template>
+
+<script>
+import Fullscreen from '@theme/layouts/Fullscreen.vue';
+import VsfPage from '@theme/components/VsfPage.vue';
+export default {
+  name: 'AtomLayout',
+  components: {
+    Fullscreen,
+    VsfPage,
+  },
+};
+</script>

--- a/apps/docs/components/ai-assistant.md
+++ b/apps/docs/components/ai-assistant.md
@@ -1,0 +1,10 @@
+---
+layout: EmbedLayout
+---
+
+<div class="custom-block">
+<iframe
+  src="https://chat.fwdoperators.com/?cid=e08b598e-3781-43f8-b899-e52bfc9c06cc"
+  style="width: 100%; min-height: 90vh; border: none;"
+/>
+</div>

--- a/apps/docs/components/ai-assistant.md
+++ b/apps/docs/components/ai-assistant.md
@@ -4,7 +4,7 @@ layout: EmbedLayout
 
 <div class="custom-block">
 <iframe
-  src="https://chat.fwdoperators.com/?cid=e08b598e-3781-43f8-b899-e52bfc9c06cc"
+  src="https://chat.fwdoperators.com/?cid=3fd362f4-2a88-4d27-b2d7-d067265b0280"
   style="width: 100%; min-height: 90vh; border: none;"
 />
 </div>


### PR DESCRIPTION
# Scope of work

- Adds AI assistant page with an `iframe` embed
- Adds `EmbedLayout` to allow for header, footer, and main section without any paddings/margings

# Screenshots of visual changes

![image](https://github.com/vuestorefront/storefront-ui/assets/18535681/98cde2c6-9330-4656-84e5-14ddc095ee1f)

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
