### PR TITLE
fix: binding on vue components [SV-222]

### DIFF
--- a/.changeset/rude-berries-beg.md
+++ b/.changeset/rude-berries-beg.md
@@ -1,0 +1,5 @@
+---
+'@storefront-ui/vue': patch
+---
+
+Fix wrong binding in components, user should overwrite data-testid

--- a/packages/sfui/frameworks/vue/components/SfChip/SfChip.vue
+++ b/packages/sfui/frameworks/vue/components/SfChip/SfChip.vue
@@ -52,14 +52,13 @@ const paddingForSize = computed(() => {
 
 <template>
   <input
-    v-bind="inputProps"
     :id="inputId"
     v-model="onSelected"
     class="absolute w-0 outline-none appearance-none peer"
     type="checkbox"
+    v-bind="inputProps"
   />
   <label
-    v-bind="$attrs"
     :for="inputId"
     :class="[
       'cursor-pointer ring-1 ring-neutral-200 ring-inset rounded-full inline-flex items-center transition duration-300 justify-center outline-offset-2 outline-secondary-600 peer-next-checked:ring-2 peer-next-checked:ring-primary-700 hover:bg-primary-100 peer-next-hover:ring-primary-200 active:bg-primary-200 peer-next-active:ring-primary-300 peer-next-disabled:cursor-not-allowed peer-next-disabled:bg-disabled-100 peer-next-disabled:opacity-50 peer-next-disabled:ring-1 peer-next-disabled:ring-disabled-200 peer-next-disabled:hover:ring-disabled-200 peer-next-checked:hover:ring-primary-700 peer-next-checked:active:ring-primary-700 peer-next-focus-visible:outline',
@@ -67,6 +66,7 @@ const paddingForSize = computed(() => {
       paddingForSize,
     ]"
     data-testid="chip"
+    v-bind="$attrs"
   >
     <slot v-if="$slots.prefix" name="prefix" />
     <slot />

--- a/packages/sfui/frameworks/vue/components/SfInput/SfInput.vue
+++ b/packages/sfui/frameworks/vue/components/SfInput/SfInput.vue
@@ -75,10 +75,10 @@ const inputValue = computed({
     <slot name="prefix" />
     <input
       v-model="inputValue"
-      v-bind="$attrs"
       class="min-w-[80px] w-full text-base outline-none appearance-none text-neutral-900 disabled:cursor-not-allowed disabled:bg-transparent read-only:bg-transparent"
       :size="1"
       data-testid="input-field"
+      v-bind="$attrs"
     />
     <slot name="suffix" />
   </component>

--- a/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
+++ b/packages/sfui/frameworks/vue/components/SfSelect/SfSelect.vue
@@ -62,7 +62,6 @@ const modelProxy = computed({
     data-testid="select"
   >
     <select
-      v-bind="$attrs"
       :required="required"
       v-model="modelProxy"
       :disabled="disabled"
@@ -80,6 +79,7 @@ const modelProxy = computed({
       @change="close"
       @click="open"
       @keydown.space="open"
+      v-bind="$attrs"
     >
       <option
         v-if="placeholder"

--- a/packages/sfui/frameworks/vue/components/SfTooltip/SfTooltip.vue
+++ b/packages/sfui/frameworks/vue/components/SfTooltip/SfTooltip.vue
@@ -30,7 +30,7 @@ const { placement, middleware, strategy } = toRefs(props);
 const { isOpen, triggerProps, tooltipProps, arrowProps } = useTooltip({ placement, middleware, strategy });
 </script>
 <template>
-  <span v-bind="triggerProps" data-testid="tooltip">
+  <span data-testid="tooltip" v-bind="triggerProps">
     <slot />
     <div
       v-if="label && isOpen"


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SV-222

# Scope of work

Some components had wrong placement of v-bind, because of that user would not be able to overwrite some initial attributes, such as `data-testid`

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
