### PR TITLE
fix: change class-name attribute in vue blocks [SFUI2-1305]

### DIFF
--- a/apps/preview/nuxt/pages/showcases/Checkbox/CheckboxLeading.vue
+++ b/apps/preview/nuxt/pages/showcases/Checkbox/CheckboxLeading.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex items-center">
-    <SfCheckbox id="checkbox" v-model="modelValue" value="value" class-name="peer" />
+    <SfCheckbox id="checkbox" v-model="modelValue" value="value" class="peer" />
     <label class="ml-3 text-base text-gray-900 cursor-pointer font-body peer-disabled:text-disabled-900" for="checkbox">
       Label
     </label>

--- a/apps/preview/nuxt/pages/showcases/Textarea/TextareaAutoresize.vue
+++ b/apps/preview/nuxt/pages/showcases/Textarea/TextareaAutoresize.vue
@@ -1,11 +1,11 @@
 <template>
   <label>
-    <span className="typography-text-sm font-medium">Description</span>
+    <span class="typography-text-sm font-medium">Description</span>
     <SfTextarea ref="textareaRef" class="w-full h-max-[500px]" />
   </label>
-  <div className="flex justify-between mt-0.5">
+  <div class="flex justify-between mt-0.5">
     <div>
-      <p className="typography-text-xs text-neutral-500">Do not include personal or financial information.</p>
+      <p class="typography-text-xs text-neutral-500">Do not include personal or financial information.</p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1305

# Scope of work

REplacing `class-name` or `className` in vue blocks

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
