### PR TITLE
fix: footer block semantic html structure [SFUI2-1302]

### DIFF
--- a/apps/preview/next/pages/showcases/Footer/FooterBasic.tsx
+++ b/apps/preview/next/pages/showcases/Footer/FooterBasic.tsx
@@ -170,8 +170,8 @@ export default function FooterBasic() {
     <footer className="pt-10 bg-neutral-100">
       <div className="grid justify-center grid-cols-[1fr_1fr] md:grid-cols-[repeat(4,1fr)] px-4 md:px-6 pb-10 max-w-[1536px] mx-auto">
         {categories.map(({ label, subcategories }) => (
-          <div className="grid grid-cols xs:pb-4" key={label}>
-            <div className="ml-4 text-lg font-medium leading-7 text-neutral-900 font-body">{label}</div>
+          <ul className="grid grid-cols xs:pb-4" key={label}>
+            <li className="ml-4 text-lg font-medium leading-7 text-neutral-900 font-body">{label}</li>
             {subcategories?.map(({ subcategoryLabel, link }) => (
               <SfListItem className="py-2 !bg-transparent typography-text-sm font-body" key={subcategoryLabel}>
                 <SfLink
@@ -183,7 +183,7 @@ export default function FooterBasic() {
                 </SfLink>
               </SfListItem>
             ))}
-          </div>
+          </ul>
         ))}
       </div>
       <hr />

--- a/apps/preview/nuxt/pages/showcases/Footer/FooterBasic.vue
+++ b/apps/preview/nuxt/pages/showcases/Footer/FooterBasic.vue
@@ -3,8 +3,8 @@
     <div
       class="grid justify-center grid-cols-[1fr_1fr] md:grid-cols-[repeat(4,1fr)] px-4 md:px-6 pb-10 max-w-[1536px] mx-auto"
     >
-      <div v-for="{ label, subcategories } in categories" :key="label" class="grid grid-cols xs:pb-4">
-        <div class="ml-4 text-lg font-medium leading-7 text-neutral-900 font-body">{{ label }}</div>
+      <ul v-for="{ label, subcategories } in categories" :key="label" class="grid grid-cols xs:pb-4">
+        <li class="ml-4 text-lg font-medium leading-7 text-neutral-900 font-body">{{ label }}</li>
         <SfListItem
           v-for="{ subcategoryLabel, link } in subcategories"
           :key="subcategoryLabel"
@@ -18,7 +18,7 @@
             {{ subcategoryLabel }}
           </SfLink>
         </SfListItem>
-      </div>
+      </ul>
     </div>
     <hr />
     <div class="py-10 md:flex md:mx-auto max-w-[1536px]">


### PR DESCRIPTION
# Related issue

https://vsf.atlassian.net/browse/SFUI2-1302

# Scope of work

![image](https://github.com/vuestorefront/storefront-ui/assets/2566152/714ffac1-b081-453c-9a86-47fd42bd71b6)


# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
