### PR TITLE
fix: showcase errors and warnings

### DIFF
--- a/apps/preview/next/pages/showcases/Filters/FiltersSidepanel.tsx
+++ b/apps/preview/next/pages/showcases/Filters/FiltersSidepanel.tsx
@@ -16,7 +16,7 @@ import {
   SfSelect,
   SfCheckbox,
 } from '@storefront-ui/react';
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import classNames from 'classnames';
 
 const sortOptions = [
@@ -240,9 +240,8 @@ export default function FiltersSidepanel() {
         Filter
       </h5>
       {filtersData.map((section) => (
-        <>
+        <Fragment key={section.id}>
           <SfAccordionItem
-            key={section.id}
             onToggle={handleToggle(section.id)}
             open={isAccordionItemOpen(section.id)}
             summary={
@@ -386,7 +385,7 @@ export default function FiltersSidepanel() {
                         value={value}
                         checked={price === value}
                         name="radio-price"
-                        onClick={() => setPrice(price === value ? null : value)}
+                        onChange={() => setPrice(price === value ? null : value)}
                       />
                     }
                   >
@@ -414,7 +413,7 @@ export default function FiltersSidepanel() {
                         value={value}
                         checked={rating === value}
                         name="radio-rating"
-                        onClick={() => setRating(rating === value ? null : value)}
+                        onChange={() => setRating(rating === value ? null : value)}
                       />
                     }
                   >
@@ -430,7 +429,7 @@ export default function FiltersSidepanel() {
             )}
           </SfAccordionItem>
           <hr className="my-4" />
-        </>
+        </Fragment>
       ))}
       <div className="flex justify-between">
         <SfButton variant="secondary" className="w-full mr-3" onClick={handleClearFilters}>

--- a/apps/preview/next/pages/showcases/Filters/Price.tsx
+++ b/apps/preview/next/pages/showcases/Filters/Price.tsx
@@ -45,7 +45,7 @@ export default function PriceFilter() {
                 value={value}
                 checked={price === value}
                 name="radio-price"
-                onClick={() => setPrice(price === value ? null : value)}
+                onChange={() => setPrice(price === value ? null : value)}
               />
             }
           >

--- a/apps/preview/next/pages/showcases/Filters/Rating.tsx
+++ b/apps/preview/next/pages/showcases/Filters/Rating.tsx
@@ -48,7 +48,7 @@ export default function RatingFilter() {
                 className="flex items-center"
                 checked={rating === value}
                 name="radio-rating"
-                onClick={() => setRating(rating === value ? null : value)}
+                onChange={() => setRating(rating === value ? null : value)}
               />
             }
           >

--- a/apps/preview/next/pages/showcases/Rating/RatingValues.tsx
+++ b/apps/preview/next/pages/showcases/Rating/RatingValues.tsx
@@ -7,7 +7,7 @@ export default function RatingValues() {
     <div className="flex flex-col">
       <SfRating value={0} />
       <SfRating value={3.5} />
-      <SfRating value={3.5} half-increment />
+      <SfRating value={3.5} halfIncrement />
       <SfRating value={6} max={8} />
     </div>
   );

--- a/apps/preview/nuxt/pages/showcases.vue
+++ b/apps/preview/nuxt/pages/showcases.vue
@@ -1,57 +1,64 @@
 <template>
   <div class="e-page-examples">
-    <div v-if="isNotIframe" class="sidebar" :class="!isOpen && 'sidebar-collapsed'">
-      <header class="sidebar-heading">
-        <h2>StorefrontUI v2</h2>
-        <h3>Vue Blocks</h3>
-      </header>
-      <SfButton
-        class="sidebar-toggle"
-        :variant="SfButtonVariant.tertiary"
-        :size="SfButtonSize.sm"
-        :aria-label="isOpen ? 'Hide sidebar' : 'Open sidebar'"
-        square
-        @click="isOpen = !isOpen"
-      >
-        <template #prefix>
-          <SfIconChevronLeft v-if="isOpen" />
-          <SfIconChevronRight v-else />
-        </template>
-      </SfButton>
-      <label class="sidebar-search">
-        <SfInput v-model="searchModelValue" placeholder="Search" />
-        <button type="button" class="sidebar-search__button" @click="searchModelValue = ''">
-          <SfIconCloseSm v-if="searchModelValue" class="sidebar-search__button-icon" />
-        </button>
-      </label>
-      <ul class="sidebar-list">
-        <template v-for="(groupValue, groupKey) in groups" :key="groupKey">
-          <li v-if="groupValue.visible" class="flex flex-col select-none">
-            <button
-              type="button"
-              class="text-left bg-gray-200 px-2 py-1 justify-between cursor-pointer"
-              @click="groupValue.open = !groupValue.open"
-            >
-              {{ groupKey }}<SfIconExpandMore :class="{ 'rotate-180': groupValue.open }" />
-            </button>
-            <ul v-if="groupValue.open">
-              <li v-for="showcaseName in groupValue.showcases" :key="groupKey + showcaseName">
-                <NuxtLink :key="showcaseName" v-slot="{ navigate }" :to="groupItemHref(groupKey, showcaseName)" custom>
-                  <SfListItem
-                    tag="span"
-                    :selected="currentRoute.path === groupItemHref(groupKey, showcaseName)"
-                    :class="{ 'font-medium': currentRoute.path === groupItemHref(groupKey, showcaseName) }"
-                    @click="navigate"
+    <ClientOnly>
+      <div v-if="isNotIframe" class="sidebar" :class="!isOpen && 'sidebar-collapsed'">
+        <header class="sidebar-heading">
+          <h2>StorefrontUI v2</h2>
+          <h3>Vue Blocks</h3>
+        </header>
+        <SfButton
+          class="sidebar-toggle"
+          :variant="SfButtonVariant.tertiary"
+          :size="SfButtonSize.sm"
+          :aria-label="isOpen ? 'Hide sidebar' : 'Open sidebar'"
+          square
+          @click="isOpen = !isOpen"
+        >
+          <template #prefix>
+            <SfIconChevronLeft v-if="isOpen" />
+            <SfIconChevronRight v-else />
+          </template>
+        </SfButton>
+        <label class="sidebar-search">
+          <SfInput v-model="searchModelValue" placeholder="Search" />
+          <button type="button" class="sidebar-search__button" @click="searchModelValue = ''">
+            <SfIconCloseSm v-if="searchModelValue" class="sidebar-search__button-icon" />
+          </button>
+        </label>
+        <ul class="sidebar-list">
+          <template v-for="(groupValue, groupKey) in groups" :key="groupKey">
+            <li v-if="groupValue.visible" class="flex flex-col select-none">
+              <button
+                type="button"
+                class="text-left bg-gray-200 px-2 py-1 justify-between cursor-pointer"
+                @click="groupValue.open = !groupValue.open"
+              >
+                {{ groupKey }}<SfIconExpandMore :class="{ 'rotate-180': groupValue.open }" />
+              </button>
+              <ul v-if="groupValue.open">
+                <li v-for="showcaseName in groupValue.showcases" :key="groupKey + showcaseName">
+                  <NuxtLink
+                    :key="showcaseName"
+                    v-slot="{ navigate }"
+                    :to="groupItemHref(groupKey, showcaseName)"
+                    custom
                   >
-                    {{ showcaseName }}
-                  </SfListItem>
-                </NuxtLink>
-              </li>
-            </ul>
-          </li>
-        </template>
-      </ul>
-    </div>
+                    <SfListItem
+                      tag="span"
+                      :selected="currentRoute.path === groupItemHref(groupKey, showcaseName)"
+                      :class="{ 'font-medium': currentRoute.path === groupItemHref(groupKey, showcaseName) }"
+                      @click="navigate"
+                    >
+                      {{ showcaseName }}
+                    </SfListItem>
+                  </NuxtLink>
+                </li>
+              </ul>
+            </li>
+          </template>
+        </ul>
+      </div>
+    </ClientOnly>
     <div class="e-page">
       <div
         class="e-page-component"

--- a/apps/preview/nuxt/pages/showcases/Filters/Category.vue
+++ b/apps/preview/nuxt/pages/showcases/Filters/Category.vue
@@ -8,7 +8,7 @@
     </template>
     <ul class="mt-2 mb-6">
       <li>
-        <SfListItem size="sm" as="button" type="button">
+        <SfListItem size="sm" tag="button" type="button">
           <div class="flex items-center">
             <SfIconArrowBack size="sm" class="text-neutral-500 mr-3" />Back to {{ categories[0].label }}
           </div>


### PR DESCRIPTION
# Related issue


# Scope of work

Fixing errors and warnings in showcase Nuxt and Next

Wrong attribute casing in `RatingValues.tsx`
![Screenshot 2023-10-03 at 11 37 49](https://github.com/vuestorefront/storefront-ui/assets/2566152/e9b549db-8f50-4d85-970b-dd45c9767576)

Wrong usage of `Radio` in filter showcases
![Screenshot 2023-10-03 at 10 21 18](https://github.com/vuestorefront/storefront-ui/assets/2566152/a6efaab7-ef09-481b-9402-404c5dc7df75)

Missing key on Fragment
![Screenshot 2023-10-02 at 14 26 51](https://github.com/vuestorefront/storefront-ui/assets/2566152/d6ac2e2b-ef50-41a1-a757-8745b3433c79)

Fixing hydration for Nuxt sidebar, cause by `isNotIframe` window missing on Server side 
Fixing hydration for SfListItem https://github.com/vuestorefront/storefront-ui/issues/2962

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
