### PR TITLE
fix: pagination buttons are too small

### DIFF
--- a/apps/preview/next/pages/showcases/Pagination/Pagination.tsx
+++ b/apps/preview/next/pages/showcases/Pagination/Pagination.tsx
@@ -40,7 +40,7 @@ export function Showcase() {
             >
               <button
                 type="button"
-                className="px-3 sm:px-4 py-3 rounded-md text-neutral-500 md:w-12 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
+                className="min-w-[38px] px-3 sm:px-4 py-3 rounded-md text-neutral-500 md:w-12 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
                 aria-current={selectedPage === 1}
                 onClick={() => setPage(1)}
               >
@@ -70,7 +70,7 @@ export function Showcase() {
                 <div className="flex pt-1 border-t-4 border-transparent">
                   <button
                     type="button"
-                    className="px-3 sm:px-4 py-3 rounded-md text-neutral-500 md:w-12 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900 "
+                    className="min-w-[38px] px-3 sm:px-4 py-3 rounded-md text-neutral-500 md:w-12 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900 "
                     aria-current={endPage - 1 === selectedPage}
                     onClick={() => setPage(endPage - 1)}
                   >
@@ -88,7 +88,7 @@ export function Showcase() {
                 <button
                   type="button"
                   className={classNames(
-                    'px-3 sm:px-4 py-3 text-neutral-500 md:w-12 rounded-md hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900',
+                    'min-w-[38px] px-3 sm:px-4 py-3 text-neutral-500 md:w-12 rounded-md hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900',
                     { '!text-neutral-900 hover:!text-primary-800 active:!text-primary-900': selectedPage === page },
                   )}
                   aria-label={`Page ${page} of ${totalPages}`}
@@ -104,7 +104,7 @@ export function Showcase() {
                 <div className="flex pt-1 border-t-4 border-transparent">
                   <button
                     type="button"
-                    className="px-3 sm:px-4 py-3 rounded-md text-neutral-500 md:w-12 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900 "
+                    className="min-w-[38px] px-3 sm:px-4 py-3 rounded-md text-neutral-500 md:w-12 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900 "
                     aria-current={selectedPage === 1}
                     onClick={() => setPage(2)}
                   >
@@ -138,7 +138,7 @@ export function Showcase() {
             >
               <button
                 type="button"
-                className="px-3 sm:px-4 py-3 rounded-md text-neutral-500 md:w-12 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900 "
+                className="min-w-[38px] px-3 sm:px-4 py-3 rounded-md text-neutral-500 md:w-12 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900 "
                 aria-current={totalPages === selectedPage}
                 onClick={() => setPage(totalPages)}
               >

--- a/apps/preview/nuxt/pages/showcases/Pagination/Pagination.vue
+++ b/apps/preview/nuxt/pages/showcases/Pagination/Pagination.vue
@@ -23,7 +23,7 @@
         >
           <button
             type="button"
-            class="px-3 sm:px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
+            class="min-w-[38px] px-3 sm:px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
             :aria-current="selectedPage === 1"
             @click="setPage(1)"
           >
@@ -42,7 +42,7 @@
         <div class="flex pt-1 border-t-4 border-transparent">
           <button
             type="button"
-            class="px-3 sm:px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
+            class="min-w-[38px] px-3 sm:px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
             :aria-current="endPage - 1 === selectedPage"
             @click="setPage(endPage - 1)"
           >
@@ -60,7 +60,7 @@
           <button
             type="button"
             :class="[
-              'px-3 sm:px-4 py-3 md:w-12 text-neutral-500 rounded-md hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900',
+              'min-w-[38px] px-3 sm:px-4 py-3 md:w-12 text-neutral-500 rounded-md hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900',
               { '!text-neutral-900 hover:!text-primary-800 active:!text-primary-900': selectedPage === page },
             ]"
             :aria-label="`Page ${page} of ${totalPages}`"
@@ -75,7 +75,7 @@
         <div class="flex pt-1 border-t-4 border-transparent">
           <button
             type="button"
-            class="px-3 sm:px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
+            class="min-w-[38px] px-3 sm:px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
             :aria-label="`Page 2 of ${totalPages}`"
             @click="setPage(2)"
           >
@@ -99,7 +99,7 @@
         >
           <button
             type="button"
-            class="px-3 sm:px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
+            class="min-w-[38px] px-3 sm:px-4 py-3 md:w-12 rounded-md text-neutral-500 hover:bg-primary-100 hover:text-primary-800 active:bg-primary-200 active:text-primary-900"
             :aria-current="totalPages === selectedPage"
             @click="setPage(totalPages)"
           >


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes # https://vsf.atlassian.net/browse/SFUI2-1303

# Scope of work

added min width for pagination buttons (as in figma they should be not less than 38px)

<!-- describe what you did -->

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
