### PR TITLE
fix: proper inherit attributes

### DIFF
--- a/.changeset/cyan-carpets-collect.md
+++ b/.changeset/cyan-carpets-collect.md
@@ -1,0 +1,5 @@
+---
+'@storefront-ui/react': patch
+---
+
+fix order inherit of attributes

--- a/packages/sfui/frameworks/react/components/SfAccordionItem/SfAccordionItem.tsx
+++ b/packages/sfui/frameworks/react/components/SfAccordionItem/SfAccordionItem.tsx
@@ -12,7 +12,7 @@ const SfAccordionItem = forwardRef<HTMLDetailsElement, SfAccordionItemProps>((pr
   };
 
   return (
-    <details ref={ref} open={open} {...attributes} data-testid="accordion-item">
+    <details ref={ref} open={open} data-testid="accordion-item" {...attributes}>
       <summary
         onClick={handleClick}
         className={classNames(

--- a/packages/sfui/frameworks/react/components/SfSwitch/SfSwitch.tsx
+++ b/packages/sfui/frameworks/react/components/SfSwitch/SfSwitch.tsx
@@ -15,9 +15,9 @@ const SfSwitch = forwardRef<HTMLInputElement, SfSwitchProps>(
       )}
       type="checkbox"
       role="switch"
-      {...attributes}
       data-testid="switch"
       aria-checked={attributes?.checked}
+      {...attributes}
     />
   ),
 );

--- a/packages/sfui/frameworks/react/components/SfTextarea/SfTextarea.tsx
+++ b/packages/sfui/frameworks/react/components/SfTextarea/SfTextarea.tsx
@@ -26,8 +26,8 @@ export default forwardRef<HTMLTextAreaElement, SfTextareaProps>(
           sizeClasses[size],
           className,
         ])}
-        {...attributes}
         data-testid="textarea"
+        {...attributes}
       />
     );
   },


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

Some react components still have wrong attribute inhertiance order

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
