### PR TITLE
docs: fix qwik background colors

### DIFF
--- a/apps/docs/components/index.md
+++ b/apps/docs/components/index.md
@@ -20,7 +20,7 @@ hideBreadcrumbs: true
         Install for React
         <iconify-icon icon="mingcute:arrow-right-fill" height="14px" class="ml-1"/>
       </RouterLink>
-      <a href="https://qwik-storefront-ui.pages.dev" target="_blank" rel="noopener" class=" px-4 py-2 rounded-lg font-medium bg-[#ac7ef4] ml-2 text-white text-opacity-80 flex items-center filter hover:brightness-110 transition-all">
+      <a href="https://qwik-storefront-ui.pages.dev" target="_blank" rel="noopener" class=" px-4 py-2 rounded-lg font-medium bg-qwik ml-2 text-white  flex items-center filter hover:brightness-110 transition-all">
         Qwik (beta)
         <iconify-icon icon="mingcute:arrow-right-fill" height="14px" class="ml-1"/>
       </a>

--- a/apps/docs/components/tailwind.config.js
+++ b/apps/docs/components/tailwind.config.js
@@ -12,6 +12,9 @@ module.exports = {
         react: {
           DEFAULT: '#61DBFB',
         },
+        qwik: {
+          DEFAULT: '#AC7EF4',
+        },
         green: {
           DEFAULT: '#00C652',
           50: '#7FFFB4',


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

Changes the Qwik background button to use a custom color since in Tailwind 2.x - JIT mode has to be enabled for arbitary values (`bg-[#whatever]`) to work. 

# Screenshots of visual changes

![image](https://github.com/vuestorefront/storefront-ui/assets/18535681/e3332df5-789b-4b4d-89e1-99e036fa2e49)

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
