### PR TITLE
docs: add alokai docs link

### DIFF
--- a/apps/docs/components/.vuepress/config.js
+++ b/apps/docs/components/.vuepress/config.js
@@ -137,6 +137,7 @@ module.exports = {
     DOCS_EXAMPLES_VUE_PATH,
     FIGMA_URL,
     coreDocs: false,
+    storefrontUi: true,
     title: 'Storefront UI',
     repo: 'https://github.com/vuestorefront/storefront-ui',
     docsRepoPath: 'https://github.com/vuestorefront/storefront-ui/tree/v2/apps/docs/components/', // used to generate direct edit links on docs pages.

--- a/apps/docs/components/package.json
+++ b/apps/docs/components/package.json
@@ -50,7 +50,7 @@
     "sass-loader": "^13.0.0",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.2.17",
     "vue-multiselect": "^2.1.6",
-    "vuepress-theme-vsf-docs": "^1.2.19"
+    "vuepress-theme-vsf-docs": "^1.5.2"
   },
   "resolutions": {
     "webpack-hot-middleware": "2.25.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4364,7 +4364,7 @@ __metadata:
     vue-multiselect: ^2.1.6
     vuepress: ^1.9.8
     vuepress-plugin-clean-urls: ^1.1.2
-    vuepress-theme-vsf-docs: ^1.2.19
+    vuepress-theme-vsf-docs: ^1.5.2
   languageName: unknown
   linkType: soft
 
@@ -27949,9 +27949,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vuepress-theme-vsf-docs@npm:^1.2.19":
-  version: 1.3.2
-  resolution: "vuepress-theme-vsf-docs@npm:1.3.2"
+"vuepress-theme-vsf-docs@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "vuepress-theme-vsf-docs@npm:1.5.2"
   dependencies:
     "@vuepress/plugin-active-header-links": 1.9.7
     "@vuepress/plugin-nprogress": 1.9.7
@@ -27959,7 +27959,7 @@ __metadata:
     iconify-icon: ^1.0.1
     markdown-it-anchor: ^8.6.5
     vuepress-plugin-container: ^2.0.2
-  checksum: 6a934bce9e4447365ce2bbb1fb733b44de57e1eaaa231a11e78572fd90e175e1d636fd324ec113250d9351687405a9af4669b91aea9cfafca56c6450e0a89c40
+  checksum: f035beb6d6b150b9dc34e3ae1ed7b1ca50e8518d4e50b0edf813b06c200474721195093e6f0e76d13f02ca14f0cd579b04b395a8c230af176f4a39f45fd521c0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

- updates upstream vuepress theme to include alokai branding and a link to the up-to-date docs


# Screenshots of visual changes

<img width="1512" alt="image" src="https://github.com/vuestorefront/storefront-ui/assets/18535681/c8197b58-8916-4eee-afe5-0cdaf87bc624">

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
