### PR TITLE
fix(hero): backgroundImage should cover whole elements area on mobile [ES-387]

### DIFF
--- a/apps/docs/components/blocks/Banners.md
+++ b/apps/docs/components/blocks/Banners.md
@@ -49,10 +49,17 @@ Four vertical displays in row on desktop.
 
 ## Hero
 
-Hero acts like a layout for your hero section. You can add a main image and any content you want, along with background images for both mobile and desktop. To make the background images look better and load faster, it's best to use images that:
+The Hero component simplifies the process of creating stunning hero sections for your website. With Hero, you have the flexibility to seamlessly integrate a main image and customize your content to suit your needs. Additionally, Hero allows adding background images tailored for both mobile and desktop devices. To ensure an optimal blend of performance and visual appeal, we recommend adhering to the following image guidelines:
 
-- are at least 3840px wide with a 4:1.5 aspect ratio for desktop, e.g. 3840px x 1440px,
-- are at least 768px wide with a 3:4 aspect ratio for mobile, e.g. 768px x 1024px.
+Desktop Background Images:
+Minimum width: 3840px
+Aspect ratio: 4:1.5
+Example size: 3840px x 1440px
+
+Mobile Background Images:
+Minimum width: 768px
+Aspect ratio: 3:4
+Example size: 768px x 1024px
 
 <Showcase showcase-name="Banners/Hero" style="min-height:620px">
 

--- a/apps/docs/components/blocks/Banners.md
+++ b/apps/docs/components/blocks/Banners.md
@@ -49,7 +49,10 @@ Four vertical displays in row on desktop.
 
 ## Hero
 
-Hero acts like a layout for your hero section. You can provide main image and any content, as well as background images for mobile and desktop devices.
+Hero acts like a layout for your hero section. You can add a main image and any content you want, along with background images for both mobile and desktop. To make the background images look better and load faster, it's best to use images that:
+
+- are 3840px wide with a 16:9 aspect ratio for desktop,
+- are 768px wide with a 1:2 aspect ratio for mobile.
 
 <Showcase showcase-name="Banners/Hero" style="min-height:620px">
 

--- a/apps/docs/components/blocks/Banners.md
+++ b/apps/docs/components/blocks/Banners.md
@@ -51,8 +51,8 @@ Four vertical displays in row on desktop.
 
 Hero acts like a layout for your hero section. You can add a main image and any content you want, along with background images for both mobile and desktop. To make the background images look better and load faster, it's best to use images that:
 
-- are 3840px wide with a 16:9 aspect ratio for desktop,
-- are 768px wide with a 1:2 aspect ratio for mobile.
+- are at least 3840px wide with a 4:1.5 aspect ratio for desktop, e.g. 3840px x 1440px,
+- are at least 768px wide with a 3:4 aspect ratio for mobile, e.g. 768px x 1024px.
 
 <Showcase showcase-name="Banners/Hero" style="min-height:620px">
 

--- a/apps/preview/next/pages/showcases/Banners/Hero.tsx
+++ b/apps/preview/next/pages/showcases/Banners/Hero.tsx
@@ -5,7 +5,7 @@ import { SfButton } from '@storefront-ui/react';
 
 export default function Hero() {
   return (
-    <div className="relative min-h-[600px]">
+    <div className="relative min-h-[576px]">
       <picture>
         <source srcSet="http://localhost:3100/@assets/hero-bg.png" media="(min-width: 768px)" />
         <img

--- a/apps/preview/next/pages/showcases/Banners/Hero.tsx
+++ b/apps/preview/next/pages/showcases/Banners/Hero.tsx
@@ -10,7 +10,7 @@ export default function Hero() {
         <source srcSet="http://localhost:3100/@assets/hero-bg.png" media="(min-width: 768px)" />
         <img
           src="http://localhost:3100/@assets/hero-bg-mobile.png"
-          className="absolute w-full h-full z-[-1] md:object-cover"
+          className="absolute w-full h-full z-[-1] object-cover"
         />
       </picture>
       <div className="md:flex md:flex-row-reverse md:justify-center min-h-[600px] max-w-[1536px] mx-auto">

--- a/apps/preview/nuxt/pages/showcases/Banners/Hero.vue
+++ b/apps/preview/nuxt/pages/showcases/Banners/Hero.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative min-h-[600px]">
+  <div class="relative min-h-[576px]">
     <picture>
       <source srcset="http://localhost:3100/@assets/hero-bg.png" media="(min-width: 768px)" />
       <img

--- a/apps/preview/nuxt/pages/showcases/Banners/Hero.vue
+++ b/apps/preview/nuxt/pages/showcases/Banners/Hero.vue
@@ -4,7 +4,7 @@
       <source srcset="http://localhost:3100/@assets/hero-bg.png" media="(min-width: 768px)" />
       <img
         src="http://localhost:3100/@assets/hero-bg-mobile.png"
-        class="absolute w-full h-full z-[-1] md:object-cover"
+        class="absolute w-full h-full z-[-1] object-cover"
         alt="hero"
       />
     </picture>


### PR DESCRIPTION
# Related issue

https://alokai.atlassian.net/browse/ES-387

# Scope of work

<!-- describe what you did -->
current hero implementation is wrong for mobile devices - background image should try to cover whole element, but without changing it's aspect ratio

add description for best image sizes for hero background

# Screenshots of visual changes

<!-- if visual changes applied -->
Hero on mobile before:
![image](https://github.com/vuestorefront/storefront-ui/assets/10456649/bf783589-99fb-40fe-bc97-ee4511067398)

after:
![image](https://github.com/vuestorefront/storefront-ui/assets/10456649/b35723a0-432b-4ba4-8adb-1a73b501eb1f)

Description:
![image](https://github.com/vuestorefront/storefront-ui/assets/10456649/b3e3b96f-2fe0-4f3b-b783-968d1c886584)


# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
