### PR TITLE
docs: update default sidebar scroll behavior

### DIFF
--- a/apps/docs/components/components/content/AppSidebarTop.vue
+++ b/apps/docs/components/components/content/AppSidebarTop.vue
@@ -11,7 +11,7 @@ function selectFramework(frameworkName: string) {
 }
 </script>
 <template>
-  <div class="relative mb-4">
+  <div class="sticky top-10  bg-white dark:bg-neutral-900 z-50 pt-4 pb-4 -mt-8">
     <SfDropdown
       v-model="isOpen"
       class="[&>div]:w-[calc(100%-32px)] [&>div]:!left-4 [&>div]:border [&>div]:rounded !w-full z-50"

--- a/apps/docs/components/content/_blocks/Banners.md
+++ b/apps/docs/components/content/_blocks/Banners.md
@@ -47,7 +47,17 @@ Four vertical displays in row on desktop.
 
 ## Hero
 
-Hero acts like a layout for your hero section. You can provide main image and any content, as well as background images for mobile and desktop devices.
+The Hero component simplifies the process of creating stunning hero sections for your website. With Hero, you have the flexibility to seamlessly integrate a main image and customize your content to suit your needs. Additionally, Hero allows adding background images tailored for both mobile and desktop devices. To ensure an optimal blend of performance and visual appeal, we recommend adhering to the following image guidelines:
+
+Desktop Background Images:
+Minimum width: 3840px
+Aspect ratio: 4:1.5
+Example size: 3840px x 1440px
+
+Mobile Background Images:
+Minimum width: 768px
+Aspect ratio: 3:4
+Example size: 768px x 1024px
 
 <Showcase showcase-name="Banners/Hero" style="min-height:620px">
 

--- a/apps/docs/components/package.json
+++ b/apps/docs/components/package.json
@@ -39,7 +39,7 @@
     "nuxt-gtag": "^0.5.7",
     "nuxt-icon": "^0.3.3",
     "nuxt-seo-kit": "^1.3.7",
-    "sf-docs-base": "^1.2.1",
+    "sf-docs-base": "^1.2.2",
     "unstorage": "^1.5.0",
     "vite-svg-loader": "^4.0.0",
     "vue": "3.4.8"

--- a/apps/preview/next/pages/showcases/Banners/Hero.tsx
+++ b/apps/preview/next/pages/showcases/Banners/Hero.tsx
@@ -5,15 +5,15 @@ import { SfButton } from '@storefront-ui/react';
 
 export default function Hero() {
   return (
-    <div className="relative min-h-[600px]">
+    <div className="relative min-h-[576px]">
       <picture>
         <source srcSet="http://localhost:3100/@assets/hero-bg.png" media="(min-width: 768px)" />
         <img
           src="http://localhost:3100/@assets/hero-bg-mobile.png"
-          className="absolute w-full h-full z-[-1] md:object-cover"
+          className="absolute w-full h-full z-[-1] object-cover"
         />
       </picture>
-      <div className="md:flex md:flex-row-reverse md:justify-center min-h-[600px] max-w-[1536px] mx-auto">
+      <div className="md:flex md:flex-row-reverse md:justify-center min-h-[576px] max-w-[1536px] mx-auto">
         <div className="flex flex-col md:basis-2/4 md:items-stretch md:overflow-hidden">
           <img
             src="http://localhost:3100/@assets/hero-headphones.png"

--- a/apps/preview/nuxt/pages/showcases/Banners/Hero.vue
+++ b/apps/preview/nuxt/pages/showcases/Banners/Hero.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="relative min-h-[600px]">
+  <div class="relative min-h-[576px]">
     <picture>
       <source srcset="http://localhost:3100/@assets/hero-bg.png" media="(min-width: 768px)" />
       <img
         src="http://localhost:3100/@assets/hero-bg-mobile.png"
-        class="absolute w-full h-full z-[-1] md:object-cover"
+        class="absolute w-full h-full z-[-1] object-cover"
         alt="hero"
       />
     </picture>
-    <div class="md:flex md:flex-row-reverse md:justify-center max-w[1536px] mx-auto md:min-h-[600px]">
+    <div class="md:flex md:flex-row-reverse md:justify-center max-w[1536px] mx-auto md:min-h-[576px]">
       <div class="flex flex-col md:basis-2/4 md:items-stretch md:overflow-hidden">
         <img
           src="http://localhost:3100/@assets/hero-headphones.png"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4422,7 +4422,7 @@ __metadata:
     nuxt-gtag: ^0.5.7
     nuxt-icon: ^0.3.3
     nuxt-seo-kit: ^1.3.7
-    sf-docs-base: ^1.2.1
+    sf-docs-base: ^1.2.2
     unstorage: ^1.5.0
     vite-svg-loader: ^4.0.0
     vue: 3.4.8
@@ -21986,9 +21986,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sf-docs-base@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "sf-docs-base@npm:1.2.1"
+"sf-docs-base@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "sf-docs-base@npm:1.2.2"
   dependencies:
     "@microsoft/api-extractor-model": ^7.26.5
     "@microsoft/tsdoc": ^0.14.2
@@ -22012,7 +22012,7 @@ __metadata:
     unstorage: ^1.5.0
     vite-svg-loader: ^4.0.0
     vue: 3.4.8
-  checksum: 8568a3c685f39317b4feee85410eaffa4519a1a57fd9f862ba7f480cd5d43e7b87db8c1635a03c65524197724990619ae5f7144ee1c19e07699a30b99d7c541e
+  checksum: ff88ea96bd4fbdc371435ed560048bff5dbf4872a7e6c15f17a69c1d3aba5cd49643d8f63fdd8c3503eaa9549516310511c5b4d2f600071f172152988323b28d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

- changes to `sf-docs-base` to adjust scroll behavior on page load
- make the `AppSidebarTop` component sticky so the framework selector is always visible

# Screenshots of visual changes

Both screenshots show the sidebar position on page load

<img width="1512" alt="image" src="https://github.com/vuestorefront/storefront-ui/assets/18535681/f902cae2-d148-4433-b118-0f86762c9a28">


<img width="1512" alt="image" src="https://github.com/vuestorefront/storefront-ui/assets/18535681/9f74b353-dd33-4f5b-87db-62e501ed2a5f">

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
