### PR TITLE
fix(preview): avoid glob import for nuxt-preview

### DIFF
--- a/apps/docs/components/nuxt.config.ts
+++ b/apps/docs/components/nuxt.config.ts
@@ -31,7 +31,11 @@ export default defineNuxtConfig({
   nitro: {
     routeRules: {
       '/figma': { redirect: 'https://www.figma.com/file/Q7Nr1NvjPdcGVhykkfDg2k/Storefront-UI-%7C-Design-Kit-v2.5-(public)?type=design&node-id=22913-91045&mode=design'}
-    }
+    },
+    prerender: {
+      crawlLinks: true,
+      failOnError: false,
+    },
   },
   vite: {
     server: {

--- a/apps/preview/next/layouts/Examples.tsx
+++ b/apps/preview/next/layouts/Examples.tsx
@@ -46,7 +46,7 @@ export default function ExampleLayout({ children }: { children: ReactElement }) 
           <ul className="sidebar-list">
             {components?.map((component) => (
               <li key={component} data-sidebar-component={component}>
-                <Link href={`/examples/${component}`} legacyBehavior>
+                <Link href={`/examples/${component}`} legacyBehavior prefetch={false}>
                   <SfListItem
                     className={classNames({ 'font-medium': router.pathname === `/examples/${component}` })}
                     selected={router.pathname === `/examples/${component}`}

--- a/apps/preview/nuxt/pages/examples.vue
+++ b/apps/preview/nuxt/pages/examples.vue
@@ -5,8 +5,13 @@
         <h2>StorefrontUI v2</h2>
         <h3>Vue components</h3>
       </header>
-      <SfButton class="sidebar-toggle" :variant="SfButtonVariant.tertiary" :size="SfButtonSize.sm"
-        :aria-label="isOpen ? 'Hide sidebar' : 'Open sidebar'" @click="isOpen = !isOpen">
+      <SfButton
+        class="sidebar-toggle"
+        :variant="SfButtonVariant.tertiary"
+        :size="SfButtonSize.sm"
+        :aria-label="isOpen ? 'Hide sidebar' : 'Open sidebar'"
+        @click="isOpen = !isOpen"
+      >
         <template #prefix>
           <SfIconChevronLeft v-if="isOpen" />
           <SfIconChevronRight v-else />
@@ -15,8 +20,12 @@
       <ul class="sidebar-list flex flex-col">
         <li v-for="component in components" :key="component">
           <NuxtLink v-slot="{ navigate }" :to="`/examples/${component}`" custom no-prefetch>
-            <SfListItem tag="span" :selected="currentRoute.path === `/examples/${component}`"
-              :class="{ 'font-medium': currentRoute.path === `/examples/${component}` }" @click="navigate">
+            <SfListItem
+              tag="span"
+              :selected="currentRoute.path === `/examples/${component}`"
+              :class="{ 'font-medium': currentRoute.path === `/examples/${component}` }"
+              @click="navigate"
+            >
               {{ component }}
             </SfListItem>
           </NuxtLink>
@@ -40,9 +49,10 @@ import { onBeforeMount } from 'vue';
 
 const { currentRoute, ...router } = useRouter();
 
-const components = router.getRoutes()
+const components = router
+  .getRoutes()
   .filter((route) => route.path.includes('examples/'))
-  .map((route) => route.path.replace('/examples/', ''))
+  .map((route) => route.path.replace('/examples/', ''));
 
 const isOpen = ref(true);
 const isNotIframe = ref(false);

--- a/apps/preview/nuxt/pages/examples.vue
+++ b/apps/preview/nuxt/pages/examples.vue
@@ -5,13 +5,8 @@
         <h2>StorefrontUI v2</h2>
         <h3>Vue components</h3>
       </header>
-      <SfButton
-        class="sidebar-toggle"
-        :variant="SfButtonVariant.tertiary"
-        :size="SfButtonSize.sm"
-        :aria-label="isOpen ? 'Hide sidebar' : 'Open sidebar'"
-        @click="isOpen = !isOpen"
-      >
+      <SfButton class="sidebar-toggle" :variant="SfButtonVariant.tertiary" :size="SfButtonSize.sm"
+        :aria-label="isOpen ? 'Hide sidebar' : 'Open sidebar'" @click="isOpen = !isOpen">
         <template #prefix>
           <SfIconChevronLeft v-if="isOpen" />
           <SfIconChevronRight v-else />
@@ -19,13 +14,9 @@
       </SfButton>
       <ul class="sidebar-list flex flex-col">
         <li v-for="component in components" :key="component">
-          <NuxtLink v-slot="{ navigate }" :to="`/examples/${component}`" custom>
-            <SfListItem
-              tag="span"
-              :selected="currentRoute.path === `/examples/${component}`"
-              :class="{ 'font-medium': currentRoute.path === `/examples/${component}` }"
-              @click="navigate"
-            >
+          <NuxtLink v-slot="{ navigate }" :to="`/examples/${component}`" custom no-prefetch>
+            <SfListItem tag="span" :selected="currentRoute.path === `/examples/${component}`"
+              :class="{ 'font-medium': currentRoute.path === `/examples/${component}` }" @click="navigate">
               {{ component }}
             </SfListItem>
           </NuxtLink>
@@ -47,12 +38,11 @@ import {
 } from '@storefront-ui/vue';
 import { onBeforeMount } from 'vue';
 
-const { currentRoute } = useRouter();
+const { currentRoute, ...router } = useRouter();
 
-const files = import.meta.glob('./examples/*.vue');
-const components = Object.keys(files)
-  .map((file) => file.match(/([\w\d_-]*)\.?[^\\\/]*$/i)[1])
-  .sort();
+const components = router.getRoutes()
+  .filter((route) => route.path.includes('examples/'))
+  .map((route) => route.path.replace('/examples/', ''))
 
 const isOpen = ref(true);
 const isNotIframe = ref(false);

--- a/apps/preview/nuxt/pages/showcases.vue
+++ b/apps/preview/nuxt/pages/showcases.vue
@@ -92,7 +92,8 @@ import { useControlsSearchParams } from '~/composables/utils/useControlsSearchPa
 const { currentRoute, ...router } = useRouter();
 
 const REST_GROUP_NAME = 'Rest';
-const paths = router.getRoutes()
+const paths = router
+  .getRoutes()
   .filter((route) => route.path.includes('showcases/'))
   .map((route) => route.path);
 const groupItemHref = (groupName, showcaseName) => {

--- a/apps/preview/nuxt/pages/showcases.vue
+++ b/apps/preview/nuxt/pages/showcases.vue
@@ -42,6 +42,7 @@
                     v-slot="{ navigate }"
                     :to="groupItemHref(groupKey, showcaseName)"
                     custom
+                    no-prefetch
                   >
                     <SfListItem
                       tag="span"
@@ -88,19 +89,19 @@ import {
 import { ref, watch, reactive, onBeforeMount } from 'vue';
 import { useControlsSearchParams } from '~/composables/utils/useControlsSearchParams';
 
-const { currentRoute } = useRouter();
+const { currentRoute, ...router } = useRouter();
 
 const REST_GROUP_NAME = 'Rest';
-const files = import.meta.glob('./showcases/**');
-const paths = Object.keys(files);
+const paths = router.getRoutes()
+  .filter((route) => route.path.includes('showcases/'))
+  .map((route) => route.path);
 const groupItemHref = (groupName, showcaseName) => {
   return `/showcases/${groupName !== REST_GROUP_NAME ? `${groupName}/` : ''}${showcaseName}`;
 };
 const groups = reactive(
   paths.reduce((prev, curr) => {
-    if (!curr.includes('.vue')) return prev;
-    const showcasePathArray = curr.replace('./showcases/', '').split('/');
-    const showcaseName = showcasePathArray[showcasePathArray.length - 1].replace('.vue', '');
+    const showcasePathArray = curr.replace('/showcases/', '').split('/');
+    const showcaseName = showcasePathArray[showcasePathArray.length - 1];
     const groupName = showcasePathArray.length === 2 ? showcasePathArray[0] : REST_GROUP_NAME;
 
     const isInUrl = currentRoute.value.href === groupItemHref(groupName, showcaseName);


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

- uses `useRouter` to generate the sidebar instead of glob imports. The glob imports where resulting in over-importing all examples or showcases. Resulting in slower iframes and rate limiting in the docs
- prerenders the docs pages.

# Screenshots of visual changes

Before (255 requests)
<img width="400" alt="Screen Shot 2024-04-10 at 14 18 23" src="https://github.com/vuestorefront/storefront-ui/assets/18535681/5e5c28d6-9ccc-4bc0-8239-99ab8f3f1588">
After (25 requests)
<img width="400" alt="Screen Shot 2024-04-10 at 14 16 34" src="https://github.com/vuestorefront/storefront-ui/assets/18535681/c356339c-3f21-474d-9bdb-bf773bbfc1bb">


# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
