### PR TITLE
docs: add loading="lazy" to iframes

### DIFF
--- a/apps/docs/components/components/content/Generate.vue
+++ b/apps/docs/components/components/content/Generate.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="custom-block">
-    <iframe ref="iframeRef" :src="exampleUrl" class="generate w-full h-full border" loading="lazy"></iframe>
+    <iframe ref="iframeRef" :src="exampleUrl" class="generate w-full h-full border" loading="lazy" />
   </div>
 </template>
 

--- a/apps/docs/components/components/content/Generate.vue
+++ b/apps/docs/components/components/content/Generate.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="custom-block">
-    <iframe ref="iframeRef" :src="exampleUrl" class="generate w-full h-full border"></iframe>
+    <iframe ref="iframeRef" :src="exampleUrl" class="generate w-full h-full border" loading="lazy"></iframe>
   </div>
 </template>
 


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

To further reduce the number of unnecessary requests per page, we can add `loading="lazy"`  to our embedded iframe examples. 

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
