### PR TITLE
chore(hero): add w-full to image

### DIFF
--- a/apps/preview/nuxt/pages/showcases/Banners/Hero.vue
+++ b/apps/preview/nuxt/pages/showcases/Banners/Hero.vue
@@ -13,7 +13,7 @@
         <img
           src="http://localhost:3100/@assets/hero-headphones.png"
           alt="Headphones"
-          class="h-full object-cover object-left"
+          class="h-full w-full object-cover object-left"
         />
       </div>
       <div class="p-4 md:p-10 md:max-w-[768px] md:flex md:flex-col md:justify-center md:items-start md:basis-2/4">


### PR DESCRIPTION
# Related issue

https://github.com/vuestorefront/unified-storefronts/pull/1237#issuecomment-2069309576

Closes #

# Scope of work

<!-- describe what you did -->
Without w-full the image behaves weirdly when the container is not 100% width

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x]  SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
