### PR TITLE
chore: exclude renovate update to yarn v4

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,10 @@
         "eslint-config-next"
       ],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["yarn"],
+      "allowedVersions": "<=4"
     }
   ]
 }


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

we do not want to have yarn 4 https://docs.renovatebot.com/configuration-options/#allowedversions

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
