### PR TITLE
chore: define ts config paths

### DIFF
--- a/packages/sfui/frameworks/react/vite.config.ts
+++ b/packages/sfui/frameworks/react/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     dts({
       insertTypesEntry: true,
     }),
-    tsconfigPaths(),
+    tsconfigPaths({ root: './' }),
   ],
   build: {
     lib: {

--- a/packages/sfui/frameworks/vue/vite.config.ts
+++ b/packages/sfui/frameworks/vue/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     dts({
       insertTypesEntry: true,
     }),
-    tsconfigPaths(),
+    tsconfigPaths({ root: './' }),
   ],
   build: {
     lib: {


### PR DESCRIPTION
# Related issue

<!-- paste a link to related issue -->

Closes #

# Scope of work

Weirdly while building react package ts picks up all tsconfigs and throws error e.g for docs not existing typings (needs to run `yarn nuxt prepare`), so we need to define root for tsconfig `vite-tsconfig-paths`, once its set up no errors and package is build properly 

![image](https://github.com/vuestorefront/storefront-ui/assets/2566152/caed828e-e999-4038-b663-97778b4dbdfb)


# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [ ] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created
