### PR TITLE
docs: fix scrollable & gallery snapping [ES-157]

### DIFF
--- a/apps/docs/components/content/_components/scrollable.md
+++ b/apps/docs/components/content/_components/scrollable.md
@@ -40,7 +40,7 @@ Can be setup that will be without scrollbar
 
 ### Snap
 
-`SfScrollbale` can be configured with center snap while dragging.
+`SfScrollable` can be configured with center snap while dragging.
 
 <Showcase showcase-name="Scrollable/SnapCenter" style="min-height:260px">
 
@@ -55,7 +55,7 @@ Can be setup that will be without scrollbar
 
 ### Scroll by one item
 
-By default `SfScrollable` scroll by one page of items, but can be modified that every `next` and `previous` button will change active item directly.
+Normally, the `SfScrollable` scrolls one page of items at a time, but you can change it so each time you press the `next` or `previous` button, it will switch an active item accordingly.
 
 <Showcase showcase-name="Scrollable/ScrollByOneItem" style="min-height:260px">
 

--- a/apps/preview/next/pages/showcases/Gallery/GalleryHorizontal.tsx
+++ b/apps/preview/next/pages/showcases/Gallery/GalleryHorizontal.tsx
@@ -52,7 +52,7 @@ export default function GalleryHorizontal() {
         onDragEnd={onDragged}
       >
         {images.map(({ imageSrc, alt }, index) => (
-          <div key={`${alt}-${index}`} className="flex justify-center h-full basis-full shrink-0 grow snap-center">
+          <div key={`${alt}-${index}`} className="flex justify-center h-full basis-full shrink-0 grow snap-center snap-always">
             <img
               aria-label={alt}
               aria-hidden={activeIndex !== index}

--- a/apps/preview/next/pages/showcases/Gallery/GalleryHorizontal.tsx
+++ b/apps/preview/next/pages/showcases/Gallery/GalleryHorizontal.tsx
@@ -52,7 +52,10 @@ export default function GalleryHorizontal() {
         onDragEnd={onDragged}
       >
         {images.map(({ imageSrc, alt }, index) => (
-          <div key={`${alt}-${index}`} className="flex justify-center h-full basis-full shrink-0 grow snap-center snap-always">
+          <div
+            key={`${alt}-${index}`}
+            className="flex justify-center h-full basis-full shrink-0 grow snap-center snap-always"
+          >
             <img
               aria-label={alt}
               aria-hidden={activeIndex !== index}

--- a/apps/preview/next/pages/showcases/Gallery/GalleryVertical.tsx
+++ b/apps/preview/next/pages/showcases/Gallery/GalleryVertical.tsx
@@ -111,7 +111,7 @@ export default function GalleryVertical() {
         ))}
       </SfScrollable>
       <SfScrollable
-        className="w-full h-full snap-x snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+        className="w-full h-full snap-y snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
         activeIndex={activeIndex}
         direction="vertical"
         wrapperClassName="h-full m-auto"
@@ -121,7 +121,7 @@ export default function GalleryVertical() {
         onDragEnd={onDragged}
       >
         {images.map(({ imageSrc, alt }, index) => (
-          <div key={`${alt}-${index}`} className="flex justify-center h-full basis-full shrink-0 grow snap-center">
+          <div key={`${alt}-${index}`} className="flex justify-center h-full basis-full shrink-0 grow snap-center snap-always">
             <img
               aria-label={alt}
               aria-hidden={activeIndex !== index}

--- a/apps/preview/next/pages/showcases/Gallery/GalleryVertical.tsx
+++ b/apps/preview/next/pages/showcases/Gallery/GalleryVertical.tsx
@@ -121,7 +121,10 @@ export default function GalleryVertical() {
         onDragEnd={onDragged}
       >
         {images.map(({ imageSrc, alt }, index) => (
-          <div key={`${alt}-${index}`} className="flex justify-center h-full basis-full shrink-0 grow snap-center snap-always">
+          <div
+            key={`${alt}-${index}`}
+            className="flex justify-center h-full basis-full shrink-0 grow snap-center snap-always"
+          >
             <img
               aria-label={alt}
               aria-hidden={activeIndex !== index}

--- a/apps/preview/next/pages/showcases/Scrollable/ScrollByOneItem.tsx
+++ b/apps/preview/next/pages/showcases/Scrollable/ScrollByOneItem.tsx
@@ -11,7 +11,7 @@ export default function ScrollableMoveByOne() {
   return (
     <SfScrollable
       wrapperClassName="min-w-0"
-      className="items-center w-full"
+      className="items-center w-full snap-x snap-mandatory"
       activeIndex={activeIndex}
       prevDisabled={activeIndex === 0}
       nextDisabled={activeIndex === itemsLength - 1}
@@ -29,7 +29,7 @@ export default function ScrollableMoveByOne() {
         <div
           key={i}
           className={classNames(
-            'flex items-center justify-center text-gray-500 border w-36 h-36 shrink-0 border-negative-300',
+            'flex items-center justify-center text-gray-500 border w-36 h-36 shrink-0 border-negative-300 snap-start snap-always',
             i === activeIndex ? 'border-solid bg-neutral-200' : 'border-dashed bg-neutral-100',
           )}
         >

--- a/apps/preview/nuxt/pages/showcases/Gallery/GalleryHorizontal.vue
+++ b/apps/preview/nuxt/pages/showcases/Gallery/GalleryHorizontal.vue
@@ -12,7 +12,7 @@
       <div
         v-for="({ imageSrc, alt }, index) in images"
         :key="`${alt}-${index}`"
-        class="flex justify-center h-full basis-full shrink-0 grow snap-center"
+        class="flex justify-center h-full basis-full shrink-0 grow snap-center snap-always"
       >
         <img :aria-label="alt" :aria-hidden="activeIndex !== index" class="w-auto h-full" :alt="alt" :src="imageSrc" />
       </div>

--- a/apps/preview/nuxt/pages/showcases/Gallery/GalleryVertical.vue
+++ b/apps/preview/nuxt/pages/showcases/Gallery/GalleryVertical.vue
@@ -52,7 +52,7 @@
       </template>
     </SfScrollable>
     <SfScrollable
-      class="w-full h-full snap-x snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+      class="w-full h-full snap-y snap-mandatory [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
       :active-index="activeIndex"
       direction="vertical"
       wrapper-class="h-full m-auto"
@@ -64,7 +64,7 @@
       <div
         v-for="({ imageSrc, alt }, index) in images"
         :key="`${alt}-${index}`"
-        class="flex justify-center h-full basis-full shrink-0 grow snap-center"
+        class="flex justify-center h-full basis-full shrink-0 grow snap-center snap-always"
       >
         <img
           :aria-label="alt"

--- a/apps/preview/nuxt/pages/showcases/Scrollable/ScrollByOneItem.vue
+++ b/apps/preview/nuxt/pages/showcases/Scrollable/ScrollByOneItem.vue
@@ -1,6 +1,6 @@
 <template>
   <SfScrollable
-    class="items-center w-full"
+    class="items-center w-full snap-x snap-mandatory"
     :active-index="activeIndex"
     wrapper-class="min-w-0"
     :prev-disabled="activeIndex === 0"
@@ -23,7 +23,7 @@
       v-for="(_, index) in Array.from({ length: 20 })"
       :key="index"
       :class="[
-        'flex items-center justify-center text-gray-500 border w-36 h-36 shrink-0 border-negative-300',
+        'flex items-center justify-center text-gray-500 border w-36 h-36 shrink-0 border-negative-300 snap-start snap-always',
         index === activeIndex ? 'border-solid bg-neutral-200' : 'border-dashed bg-neutral-100',
       ]"
     >


### PR DESCRIPTION
# Related issue

https://alokai.atlassian.net/browse/ES-157

# Scope of work

when scrolling snapped galleries on mobile it's really easy to scroll two items with a single swipe
now always - single swipe = single item change

# Screenshots of visual changes

<!-- if visual changes applied -->

# Checklist

- [x] Self code-reviewed
- [x] Changes documented
- [x] Semantic HTML
- [x] SSR-friendly
- [x] Caching friendly
- [x] a11y for WCAG 2.0 AA
- [x] examples created
- [x] blocks created
- [x] cypress tests created
