### PR TITLE
fix(tailwind-config): define missing spin-slow keyframes

### DIFF
--- a/.changeset/fix-spin-slow-keyframes.md
+++ b/.changeset/fix-spin-slow-keyframes.md
@@ -1,0 +1,5 @@
+---
+'@storefront-ui/tailwind-config': patch
+---
+
+**[FIXED]** `animate-spin-slow` (used by `SfLoaderCircular`) rotates again. The Tailwind 4 theme references a `spin-slow` keyframe that was never migrated from the Tailwind 3 JS theme (where it aliased the built-in `spin`), so the loader stopped rotating. The missing `@keyframes spin-slow` is now defined.

--- a/packages/config/tailwind/config.css
+++ b/packages/config/tailwind/config.css
@@ -118,6 +118,12 @@
   --animate-line: line 1.5s ease-in infinite;
   --animate-stroke-loader-circular: stroke-loader-circular 2s ease-in-out infinite;
 
+  @keyframes spin-slow {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
   @keyframes line {
     from {
       left: -100%;


### PR DESCRIPTION
# Related issue

Internal report: [ES-2804](https://alokai.atlassian.net/browse/ES-2804) (no GitHub issue)

# Scope of work

Since the Tailwind 4 migration, `SfLoaderCircular` no longer rotates. `--animate-spin-slow: spin-slow 1.5s linear infinite` still references the `spin-slow` keyframe, but only the `line` and `stroke-loader-circular` keyframes were migrated from the TW3 JS theme — in TW3, `spin-slow` aliased Tailwind's built-in `spin` keyframes, so nothing named `spin-slow` ever existed. Tailwind 4 emits the animation with a dangling keyframe name and the spinner stays frozen (the `stroke-loader-circular` dash animation still runs, so it "pulses" without rotating).

This adds the missing `@keyframes spin-slow` definition next to the other two, keeping the theme self-contained instead of depending on Tailwind's built-in `spin` being emitted.

Verified by compiling the patched theme with `@tailwindcss/node` and building the `animate-spin-slow` candidate: before the change no `@keyframes` are emitted for it; after, `@keyframes spin-slow` is emitted and the utility resolves.

# Screenshots of visual changes

The loader spins again at its original 1.5s period — no static visual change.

# Checklist

- [x] Self code-reviewed
- [ ] Changes documented
- [ ] Semantic HTML
- [ ] SSR-friendly
- [ ] Caching friendly
- [ ] a11y for WCAG 2.0 AA
- [ ] examples created
- [ ] blocks created
- [ ] cypress tests created

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ES-2804]: https://alokai.atlassian.net/browse/ES-2804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ