### PR TITLE
chore(ci): replace SonarCloud with Qodana

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,6 @@ concurrency:
 permissions:
   id-token: write
 
-env:
-  SONAR_TOKEN_REACT: ${{ secrets.SONAR_TOKEN_REACT }}
-  SONAR_TOKEN_VUE: ${{ secrets.SONAR_TOKEN_VUE }}
-
 jobs:
   cache:
     name: Create cache for all steps
@@ -156,14 +152,6 @@ jobs:
           CYPRESS_COVERAGE: true
       - name: Post-Cypress (generate coverage)
         run: cd apps/test/vue; yarn generate-coverage
-      - name: SonarCloud Scan
-        if: ${{ env.SONAR_TOKEN_VUE }}
-        uses: SonarSource/sonarqube-scan-action@v6
-        with:
-          projectBaseDir: packages/sfui/frameworks/vue
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_VUE }}
 
   cypress-react:
     name: Run cypress tests(React)
@@ -191,14 +179,6 @@ jobs:
           CYPRESS_COVERAGE: true
       - name: Post-Cypress (generate coverage)
         run: cd apps/test/react; yarn generate-coverage
-      - name: SonarCloud Scan
-        if: ${{ env.SONAR_TOKEN_REACT }}
-        uses: SonarSource/sonarqube-scan-action@v6
-        with:
-          projectBaseDir: packages/sfui/frameworks/react
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_REACT }}
 
   release-canary:
     name: Release Canary packages

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -1,0 +1,32 @@
+name: Qodana
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - v2
+      - v2-develop
+
+env:
+  QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+
+jobs:
+  qodana:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
+          fetch-depth: 0  # a full history is required for pull request analysis
+      - name: 'Qodana Scan'
+        if: ${{ env.QODANA_TOKEN }}
+        uses: JetBrains/qodana-action@4861e015da555e86a72b862892aba6c2b93e6891 # 2026.1.3
+        with:
+          pr-mode: false
+        env:
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+          QODANA_ENDPOINT: 'https://qodana.cloud'

--- a/packages/sfui/frameworks/react/sonar-project.properties
+++ b/packages/sfui/frameworks/react/sonar-project.properties
@@ -1,3 +1,0 @@
-sonar.projectKey=storefront-ui-react
-sonar.organization=vuestorefront
-sonar.javascript.lcov.reportPaths=./coverage/lcov.info

--- a/packages/sfui/frameworks/vue/sonar-project.properties
+++ b/packages/sfui/frameworks/vue/sonar-project.properties
@@ -1,3 +1,0 @@
-sonar.projectKey=storefront-ui-vue
-sonar.organization=vuestorefront
-sonar.javascript.lcov.reportPaths=./coverage/lcov.info

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -15,6 +15,9 @@ profile:
       enabled: true
     - inspection: NpmVulnerableApiCode
       enabled: true
+    # HardcodedPasswords and HttpUrlsUsage are the two that produce false positives -
+    # add an `ignore:` list per finding, as enterprise did for a mock .env fixture
+    # and for JSON files referencing their schemas over http://.
     - inspection: HardcodedPasswords
       enabled: true
     - inspection: HttpUrlsUsage

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,23 @@
+####################################################################################################################
+# WARNING: Do not store sensitive information in this file, as its contents will be included in the Qodana report. #
+####################################################################################################################
+
+version: "1.0"
+linter: qodana-js
+profile:
+  base:
+    name: empty
+  inspections:
+    # Security-only scope (ISO audit): dependency vulnerabilities and licences.
+    # MaliciousLibrariesLocal stays disabled - it matches declared package.json
+    # ranges instead of yarn.lock-resolved versions, producing false positives.
+    - inspection: VulnerableLibrariesLocal
+      enabled: true
+    - inspection: NpmVulnerableApiCode
+      enabled: true
+    - inspection: HardcodedPasswords
+      enabled: true
+    - inspection: HttpUrlsUsage
+      enabled: true
+include:
+  - name: CheckDependencyLicenses


### PR DESCRIPTION
## What

Replaces SonarCloud with JetBrains Qodana, mirroring the setup in the `enterprise` repo.

- Removes both `SonarCloud Scan` steps (`SonarSource/sonarqube-scan-action@v6`) from `ci.yml`, along with the now-unused workflow-level `SONAR_TOKEN_REACT` / `SONAR_TOKEN_VUE` env block.
- Deletes the two dead `sonar-project.properties` files (`packages/sfui/frameworks/{vue,react}`) that those steps consumed.
- Adds `qodana.yaml` — copied from `enterprise`, security-scoped on the `qodana-js` linter: `VulnerableLibrariesLocal`, `NpmVulnerableApiCode`, `HardcodedPasswords`, `HttpUrlsUsage`, plus `CheckDependencyLicenses`.
- Adds `.github/workflows/qodana_code_quality.yml` as a standalone workflow (JetBrains' recommended layout, and what `enterprise` does), running on `v2` / `v2-develop` and PRs.

## Before this can merge

**A Qodana Cloud project and a `QODANA_TOKEN` repository secret are needed.** `QODANA_TOKEN` is a per-project token created in the Qodana Cloud UI; this repo currently has only `SONAR_TOKEN_REACT` and `SONAR_TOKEN_VUE`.

The scan step is gated on `if: ${{ env.QODANA_TOKEN }}` — the same idiom the Sonar steps already used — so CI stays green until that secret exists, and the scan starts working the moment it's added. No coordination required between merging this and provisioning the token.

## Two things worth a decision

1. **Coverage reporting is dropped, not ported.** The Sonar steps uploaded Cypress lcov coverage for the Vue and React frameworks separately. Qodana is a static analyser and does not consume lcov, so per-framework coverage and the quality gate go away. Fine if this is Sonar decommissioning; not fine if anyone depends on those dashboards.
2. **The `Post-Cypress (generate coverage)` steps and `CYPRESS_COVERAGE: true` are left in place.** Sonar looked like their only consumer, so they may now be dead CI time — but that is a separate change and I did not want to assume nothing else reads `coverage/lcov.info`.

Note that Qodana's config here is a *security* scope, not a like-for-like replacement for Sonar's code-quality gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)